### PR TITLE
iOS: fix asset image scale

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyle.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyle.java
@@ -1,13 +1,13 @@
 package com.mapbox.rctmgl.components.styles;
 
 import android.content.Context;
-import android.net.Uri;
 import android.support.annotation.NonNull;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.rctmgl.utils.DownloadMapImageTask;
+import com.mapbox.rctmgl.utils.ImageEntry;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -63,6 +63,10 @@ public class RCTMGLStyle {
         addImage(styleValue, null);
     }
 
+    public ImageEntry imageEntry(RCTMGLStyleValue styleValue) {
+        return new ImageEntry(styleValue.getImageURI(), styleValue.getImageScale());
+    }
+
     public void addImage(RCTMGLStyleValue styleValue, DownloadMapImageTask.OnAllImagesLoaded callback) {
         if (!styleValue.shouldAddImage()) {
             if (callback != null) {
@@ -72,7 +76,7 @@ public class RCTMGLStyle {
         }
 
         String uriStr = styleValue.getImageURI();
-        Map.Entry[] images = new Map.Entry[]{ new AbstractMap.SimpleEntry(uriStr, uriStr) };
+        Map.Entry[] images = new Map.Entry[]{ new AbstractMap.SimpleEntry(uriStr, imageEntry(styleValue)) };
         DownloadMapImageTask task = new DownloadMapImageTask(mContext, mMap, callback);
         task.execute(images);
     }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
@@ -1134,7 +1134,7 @@ public class RCTMGLStyleFactory {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.iconImage(styleValue.getExpression()));
       } else {
-        layer.setProperties(PropertyFactory.iconImage(styleValue.getString(VALUE_KEY)));
+        layer.setProperties(PropertyFactory.iconImage(styleValue.getImageURI()));
       }
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleValue.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleValue.java
@@ -26,6 +26,7 @@ public class RCTMGLStyleValue {
 
     private String imageURI = "";
     private boolean isAddImage;
+    private Double imageScale = 1.0;
 
     public static final int InterpolationModeExponential = 100;
     public static final int InterpolationModeInterval = 101;
@@ -37,7 +38,16 @@ public class RCTMGLStyleValue {
         mPayload = config.getMap("stylevalue");
 
         if ("image".equals(mType)) {
-            imageURI = mPayload.getString("value");
+            imageScale = 1.0;
+            if ("hashmap".equals(mPayload.getString("type"))) {
+                ReadableMap map = getMap();
+                imageURI = map.getMap("uri").getString("value");
+                if (map.getMap("scale") != null) {
+                    imageScale = map.getMap("scale").getDouble("value");
+                }
+            } else {
+                imageURI = mPayload.getString("value");
+            }
             isAddImage = imageURI != null && imageURI.contains("://");
             return;
         }
@@ -115,7 +125,7 @@ public class RCTMGLStyleValue {
         return stringArr;
     }
 
-    public ReadableMap getMap(String key) {
+    public ReadableMap getMap() {
         if ("hashmap".equals(mPayload.getString("type"))) {
             ReadableArray keyValues = mPayload.getArray("value");
             WritableNativeMap result = new WritableNativeMap();
@@ -132,6 +142,10 @@ public class RCTMGLStyleValue {
         return null;
     }
 
+    public ReadableMap getMap(String _key) {
+        return getMap();
+    }
+
     public Expression getExpression() {
         return mExpression;
     }
@@ -146,6 +160,10 @@ public class RCTMGLStyleValue {
 
     public String getImageURI() {
         return imageURI;
+    }
+
+    public double getImageScale() {
+        return imageScale;
     }
 
     public TransitionOptions getTransition() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/ConvertUtils.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/ConvertUtils.java
@@ -96,11 +96,13 @@ public class ConvertUtils {
 
         if (type.equals(ExpressionParser.TYPE_MAP)) {
             JsonObject result = new JsonObject();
-            ReadableMap mapValue = map.getMap("value");
-            ReadableMapKeySetIterator it = mapValue.keySetIterator();
-            while (it.hasNextKey()) {
-                String key = it.nextKey();
-                result.add(key, typedToJsonElement(mapValue.getMap(key)));
+
+            ReadableArray keyValues = map.getArray("value");
+            for (int i = 0; i < keyValues.size(); i++) {
+                ReadableArray keyValue = keyValues.getArray(i);
+                String key = keyValue.getMap(0).getString("value");
+
+                result.add(key, typedToJsonElement(keyValue.getMap(1)));
             }
             return result;
         }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/ImageEntry.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/ImageEntry.java
@@ -1,0 +1,11 @@
+package com.mapbox.rctmgl.utils;
+
+public class ImageEntry {
+    public String uri;
+    public double scale = 1.0;
+
+    public ImageEntry(String _uri, double _scale) {
+        uri = _uri;
+        scale = _scale;
+    }
+}

--- a/ios/RCTMGL/RCTMGLImageQueue.h
+++ b/ios/RCTMGL/RCTMGLImageQueue.h
@@ -14,6 +14,6 @@
 + (instancetype)sharedInstance;
 
 - (void)cancelAllOperations;
-- (void)addImage:(NSString *)imageURL bridge:(RCTBridge *)bridge completionHandler:(RCTImageLoaderCompletionBlock)handler;
+- (void)addImage:(NSString *)imageURL scale:(double)scale bridge:(RCTBridge *)bridge completionHandler:(RCTImageLoaderCompletionBlock)handler;
 
 @end

--- a/ios/RCTMGL/RCTMGLImageQueue.m
+++ b/ios/RCTMGL/RCTMGLImageQueue.m
@@ -44,12 +44,13 @@
     [imageQueue cancelAllOperations];
 }
 
-- (void)addImage:(NSString *)imageURL bridge:(RCTBridge *)bridge completionHandler:(RCTImageLoaderCompletionBlock)handler
+- (void)addImage:(NSString *)imageURL scale:(double)scale bridge:(RCTBridge *)bridge completionHandler:(RCTImageLoaderCompletionBlock)handler
 {
     RCTMGLImageQueueOperation *operation = [[RCTMGLImageQueueOperation alloc] init];
     operation.bridge = bridge;
     operation.urlRequest = [RCTConvert NSURLRequest:imageURL];
     operation.completionHandler = handler;
+    operation.scale = scale;
     [imageQueue addOperation:operation];
 }
 

--- a/ios/RCTMGL/RCTMGLImageQueueOperation.h
+++ b/ios/RCTMGL/RCTMGLImageQueueOperation.h
@@ -12,5 +12,6 @@
 @property (nonatomic, weak) RCTBridge *bridge;
 @property (nonatomic, copy) RCTImageLoaderCompletionBlock completionHandler;
 @property (nonatomic, copy) NSURLRequest *urlRequest;
+@property (nonatomic)       double scale;
 
 @end

--- a/ios/RCTMGL/RCTMGLImageQueueOperation.m
+++ b/ios/RCTMGL/RCTMGLImageQueueOperation.m
@@ -23,7 +23,7 @@
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         cancellationBlock = [weakSelf.bridge.imageLoader loadImageWithURLRequest:weakSelf.urlRequest
                                                                             size:CGSizeZero
-                                                                           scale:UIScreen.mainScreen.scale
+                                                                           scale:self.scale
                                                                          clipped:YES
                                                                       resizeMode:RCTResizeModeStretch
                                                                    progressBlock:nil

--- a/ios/RCTMGL/RCTMGLLayer.m
+++ b/ios/RCTMGL/RCTMGLLayer.m
@@ -213,7 +213,7 @@
     if (url == nil) {
         return;
     }
-    [RCTMGLUtils fetchImage:_bridge url:url callback:^(NSError *error, UIImage *image) {
+    [RCTMGLUtils fetchImage:_bridge url:url scale:1.0 callback:^(NSError *error, UIImage *image) {
         if (image != nil) {
             [_style setImage:image forName:url];
         }

--- a/ios/RCTMGL/RCTMGLStyle.m
+++ b/ios/RCTMGL/RCTMGLStyle.m
@@ -58,7 +58,7 @@
       } else {
         NSString *imageURI = [styleValue getImageURI];
 
-        [RCTMGLUtils fetchImage:_bridge url:imageURI callback:^(NSError *error, UIImage *image) {
+          [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
             dispatch_async(dispatch_get_main_queue(), ^{
               [_style setImage:image forName:imageURI];
@@ -140,7 +140,7 @@
       } else {
         NSString *imageURI = [styleValue getImageURI];
 
-        [RCTMGLUtils fetchImage:_bridge url:imageURI callback:^(NSError *error, UIImage *image) {
+          [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
             dispatch_async(dispatch_get_main_queue(), ^{
               [_style setImage:image forName:imageURI];
@@ -202,7 +202,7 @@
       } else {
         NSString *imageURI = [styleValue getImageURI];
 
-        [RCTMGLUtils fetchImage:_bridge url:imageURI callback:^(NSError *error, UIImage *image) {
+        [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
             dispatch_async(dispatch_get_main_queue(), ^{
               [_style setImage:image forName:imageURI];
@@ -458,7 +458,7 @@
       } else {
         NSString *imageURI = [styleValue getImageURI];
 
-        [RCTMGLUtils fetchImage:_bridge url:imageURI callback:^(NSError *error, UIImage *image) {
+          [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
             dispatch_async(dispatch_get_main_queue(), ^{
               [_style setImage:image forName:imageURI];
@@ -604,7 +604,7 @@
       } else {
         NSString *imageURI = [styleValue getImageURI];
 
-        [RCTMGLUtils fetchImage:_bridge url:imageURI callback:^(NSError *error, UIImage *image) {
+          [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
           if (image != nil) {
             dispatch_async(dispatch_get_main_queue(), ^{
               [_style setImage:image forName:imageURI];

--- a/ios/RCTMGL/RCTMGLStyleValue.h
+++ b/ios/RCTMGL/RCTMGLStyleValue.h
@@ -17,6 +17,7 @@
 
 - (BOOL)shouldAddImage;
 - (NSString *)getImageURI;
+- (double)getImageScale;
 - (MGLTransition)getTransition;
 - (NSExpression *)getSphericalPosition;
 - (BOOL)isVisible;

--- a/ios/RCTMGL/RCTMGLStyleValue.m
+++ b/ios/RCTMGL/RCTMGLStyleValue.m
@@ -27,6 +27,8 @@
     } else if ([_styleType isEqualToString:@"vector"] && [expressionJSON respondsToSelector:@selector(objectEnumerator)] && [[[(NSArray*)expressionJSON objectEnumerator] nextObject] isKindOfClass:[NSNumber class]]) {
         CGVector vector = [RCTMGLUtils toCGVector:(NSArray<NSNumber *> *)expressionJSON];
         return [NSExpression expressionWithMGLJSONObject:[NSValue valueWithCGVector:vector]];
+    } else if ([_styleType isEqualToString:@"image"] && [expressionJSON isKindOfClass:[NSDictionary class]]) {
+        return [NSExpression expressionForConstantValue:[self getImageURI]];
     } else if ([_styleType isEqual:@"edgeinsets"] && [expressionJSON isKindOfClass:[NSNumber class]]){
         UIEdgeInsets edgeInsets = [RCTMGLUtils toUIEdgeInsets:(NSArray<NSNumber *> *)expressionJSON];
         return [NSExpression expressionWithMGLJSONObject:[NSValue valueWithUIEdgeInsets:edgeInsets]];
@@ -76,15 +78,36 @@
     return object;
 }
 
+
+
 - (BOOL)shouldAddImage
 {
-    NSString *imageURI = (NSString *)expressionJSON;
+    NSString *imageURI = [self getImageURI];
+    
     return [imageURI containsString:@"://"];
 }
 
 - (NSString *)getImageURI
 {
-    return (NSString *)expressionJSON;
+    if ([expressionJSON isKindOfClass:[NSDictionary class]]) {
+        return [expressionJSON valueForKey:@"uri"];
+    } else {
+        return (NSString *)expressionJSON;
+    }
+}
+
+- (double)getImageScale
+{
+    if ([expressionJSON isKindOfClass:[NSDictionary class]]) {
+        id scale = [expressionJSON valueForKey:@"scale"];
+        if ([scale isKindOfClass:[NSNumber class]]) {
+            return [scale doubleValue];
+        } else {
+            return 1.0;
+        }
+    } else {
+        return 1.0;
+    }
 }
 
 - (MGLTransition)getTransition

--- a/ios/RCTMGL/RCTMGLUtils.h
+++ b/ios/RCTMGL/RCTMGLUtils.h
@@ -22,7 +22,7 @@
 + (NSTimeInterval)fromMS:(NSNumber*)number;
 + (NSNumber*)clamp:(NSNumber*)value min:(NSNumber*)min max:(NSNumber*)max;
 + (UIColor*)toColor:(id)value;
-+ (void)fetchImage:(RCTBridge*)bridge url:(NSString*)url callback:(RCTImageLoaderCompletionBlock)callback;
++ (void)fetchImage:(RCTBridge*)bridge url:(NSString*)url scale:(double)scale callback:(RCTImageLoaderCompletionBlock)callback;
 + (void)fetchImages:(RCTBridge *)bridge style:(MGLStyle *)style objects:(NSDictionary<NSString *, NSString *>*)objects callback:(void (^)())callback;
 + (CGVector)toCGVector:(NSArray<NSNumber*>*)arr;
 + (UIEdgeInsets)toUIEdgeInsets:(NSArray<NSNumber *> *)arr;

--- a/ios/RCTMGL/RCTMGLUtils.m
+++ b/ios/RCTMGL/RCTMGLUtils.m
@@ -88,9 +88,9 @@ static double const MS_TO_S = 0.001;
     return CGVectorMake([arr[0] floatValue], [arr[1] floatValue]);
 }
 
-+ (void)fetchImage:(RCTBridge*)bridge url:(NSString *)url callback:(RCTImageLoaderCompletionBlock)callback
++ (void)fetchImage:(RCTBridge*)bridge url:(NSString *)url scale:(double)scale callback:(RCTImageLoaderCompletionBlock)callback
 {
-    [RCTMGLImageQueue.sharedInstance addImage:url bridge:bridge completionHandler:callback];
+    [RCTMGLImageQueue.sharedInstance addImage:url scale:scale bridge:bridge completionHandler:callback];
 }
 
 + (void)fetchImages:(RCTBridge *)bridge style:(MGLStyle *)style objects:(NSDictionary<NSString *, NSString *>*)objects callback:(void (^)())callback
@@ -121,7 +121,7 @@ static double const MS_TO_S = 0.001;
         UIImage *foundImage = [style imageForName:imageName];
         
         if (foundImage == nil) {
-            [RCTMGLImageQueue.sharedInstance addImage:objects[imageName] bridge:bridge completionHandler:^(NSError *error, UIImage *image) {
+            [RCTMGLImageQueue.sharedInstance addImage:objects[imageName] scale:1.0 bridge:bridge completionHandler:^(NSError *error, UIImage *image) {
               if (!image) {
                 RCTLogWarn(@"Failed to fetch image: %@ error:%@", imageName, error);
               }

--- a/javascript/components/AbstractLayer.js
+++ b/javascript/components/AbstractLayer.js
@@ -44,8 +44,7 @@ class AbstractLayer extends React.PureComponent {
       if (styleType === 'color' && typeof rawStyle === 'string') {
         rawStyle = processColor(rawStyle);
       } else if (styleType === 'image' && typeof rawStyle === 'number') {
-        const asset = resolveAssetSource(rawStyle) || {};
-        rawStyle = asset.uri || rawStyle;
+        rawStyle = resolveAssetSource(rawStyle) || {};
       }
 
       const bridgeValue = new BridgeValue(rawStyle);


### PR DESCRIPTION
Fixes: #68 

Use imageScale from react native vs trying to figure out.

Before #1206 mapbox worked for static images without `@2x` and `@3x` suffixes.
#1206 fixed that for the case the image had same resolution as the device (so `@3x` on 3x device).

This PR should work for normal and scaled images (`@2x`...)

https://github.com/nitaliano/react-native-mapbox-gl/pull/1206