### PR TITLE
Update ios sdk to 5.0.0 and android to 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Breaking changes:
 
+* iOS mapbox libraries updated to [5.0.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v5.0.0) android libraries updated to [8.0.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.0.0)
 * `StyleSheet.create` removed.  
 Mapbox styles are now just a map no need for `StyleSheet.create`.  
 `StylesSheet.identity` also removed, use expressions array instead:
@@ -48,6 +49,7 @@ Mapbox styles are now just a map no need for `StyleSheet.create`.
      />
    </MapView>
    ```
+   See [docs/Camera.md](docs/Camera.md) for more examples
 * User tracking properties moved from `MapView` to `Camera`
    ```jsx
    <MapView

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ npm install @react-native-mapbox-gl/maps --save
 * [StyleSheet](/docs/StyleSheet.md)
 * [PointAnnotation](/docs/PointAnnotation.md)
 * [Callout](/docs/Callout.md)
+* [Camera](docs/Camera.md)
+* [UserLocation](docs/UserLocation.md)
 
 ### Sources
 * [VectorSource](/docs/VectorSource.md)

--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -31,8 +31,8 @@ dependencies {
 
     // Mapbox SDK
 
-    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.6.0'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:7.3.2'
+    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.8.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:8.0.0'
 
     // Dependencies
     implementation "com.android.support:support-vector-drawable:${safeExtGet('supportLibVersion', '28.0.0')}"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/react-native-mapbox-gl/maps"
   },
   "scripts": {
-    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 4.9.0",
+    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 5.0.0",
     "fetch:style:spec": ". ./scripts/download-style-spec.sh",
     "generate": "node ./scripts/autogenerate",
     "preinstall": "npm run fetch:ios:sdk",

--- a/scripts/autogenerate.js
+++ b/scripts/autogenerate.js
@@ -17,8 +17,8 @@ if (!styleSpecJSON) {
 }
 
 const layers = [];
-const androidVersion = '7.3.2';
-const iosVersion = '4.10.0';
+const androidVersion = '8.0.0';
+const iosVersion = '5.0.0';
 
 const TMPL_PATH = path.join(__dirname, 'templates');
 


### PR DESCRIPTION
Bump ios mapbox-gl-native sdk to 5.0 and android mapbox-gl-native to 8.0. 

See https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v5.0.0 and https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.0.0