### PR TITLE
Inhibits state updates when MapView is unmounted

### DIFF
--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -225,6 +225,7 @@ class MapView extends NativeBridgeComponent {
     regionDidChangeDebounceTime: 500,
   };
 
+  _mounted = false;
   constructor(props) {
     super(props);
 
@@ -257,7 +258,12 @@ class MapView extends NativeBridgeComponent {
   }
 
   componentDidMount() {
+    this._mounted = true;
     this._setHandledMapChangedEvents(this.props);
+  }
+
+  componentWillUnmount() {
+    this._mounted = false;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -666,6 +672,8 @@ class MapView extends NativeBridgeComponent {
     if (isFunction(this.props.onRegionWillChange)) {
       this.props.onRegionWillChange(payload);
     }
+    if (!this._mounted) return;
+    
     this.setState({isUserInteraction: payload.properties.isUserInteraction});
   }
 
@@ -673,6 +681,8 @@ class MapView extends NativeBridgeComponent {
     if (isFunction(this.props.onRegionDidChange)) {
       this.props.onRegionDidChange(payload);
     }
+    if (!this._mounted) return;
+    
     this.setState({region: payload});
   }
 
@@ -745,6 +755,8 @@ class MapView extends NativeBridgeComponent {
   }
 
   _onLayout(e) {
+    if (!this._mounted) return;
+    
     this.setState({
       isReady: true,
       width: e.nativeEvent.layout.width,

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -225,7 +225,6 @@ class MapView extends NativeBridgeComponent {
     regionDidChangeDebounceTime: 500,
   };
 
-  _mounted = false;
   constructor(props) {
     super(props);
 
@@ -258,12 +257,12 @@ class MapView extends NativeBridgeComponent {
   }
 
   componentDidMount() {
-    this._mounted = true;
     this._setHandledMapChangedEvents(this.props);
   }
 
   componentWillUnmount() {
-    this._mounted = false;
+    this._onDebouncedRegionWillChange.cancel();
+    this._onDebouncedRegionDidChange.cancel();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -672,8 +671,6 @@ class MapView extends NativeBridgeComponent {
     if (isFunction(this.props.onRegionWillChange)) {
       this.props.onRegionWillChange(payload);
     }
-    if (!this._mounted) return;
-    
     this.setState({isUserInteraction: payload.properties.isUserInteraction});
   }
 
@@ -681,8 +678,6 @@ class MapView extends NativeBridgeComponent {
     if (isFunction(this.props.onRegionDidChange)) {
       this.props.onRegionDidChange(payload);
     }
-    if (!this._mounted) return;
-    
     this.setState({region: payload});
   }
 
@@ -755,8 +750,6 @@ class MapView extends NativeBridgeComponent {
   }
 
   _onLayout(e) {
-    if (!this._mounted) return;
-    
     this.setState({
       isReady: true,
       width: e.nativeEvent.layout.width,


### PR DESCRIPTION
I've recently seen a few warnings regarding MapView trying to update its state while being unmounted. I found three places where this warning could originate from;

https://github.com/react-native-mapbox-gl/maps/blob/9e3310ae56ad6872437d3a82ee1e5f9fd2bedc90/javascript/components/MapView.js#L669 https://github.com/react-native-mapbox-gl/maps/blob/9e3310ae56ad6872437d3a82ee1e5f9fd2bedc90/javascript/components/MapView.js#L676 https://github.com/react-native-mapbox-gl/maps/blob/9e3310ae56ad6872437d3a82ee1e5f9fd2bedc90/javascript/components/MapView.js#L748-L752

I have previously used a variable in my own projects which I can query when setting state. This will allow me to cancel or inhibit `setState` when the component is unmounted. What do you think about this solution?