### PR TITLE
[WIP] Enable HeatmapLayer Support

### DIFF
--- a/__tests__/interface.test.js
+++ b/__tests__/interface.test.js
@@ -23,6 +23,7 @@ describe('Public Interface', () => {
       'FillLayer',
       'FillExtrusionLayer',
       'CircleLayer',
+      'HeatmapLayer',
       'LineLayer',
       'SymbolLayer',
       'BackgroundLayer',

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/RCTMGLPackage.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/RCTMGLPackage.java
@@ -19,6 +19,7 @@ import com.mapbox.rctmgl.components.styles.layers.RCTMGLBackgroundLayerManager;
 import com.mapbox.rctmgl.components.styles.layers.RCTMGLCircleLayerManager;
 import com.mapbox.rctmgl.components.styles.layers.RCTMGLFillExtrusionLayerManager;
 import com.mapbox.rctmgl.components.styles.layers.RCTMGLFillLayerManager;
+import com.mapbox.rctmgl.components.styles.layers.RCTMGLHeatmapLayerManager;
 import com.mapbox.rctmgl.components.styles.layers.RCTMGLLineLayerManager;
 import com.mapbox.rctmgl.components.styles.layers.RCTMGLRasterLayerManager;
 import com.mapbox.rctmgl.components.styles.layers.RCTMGLSymbolLayerManager;
@@ -76,6 +77,7 @@ public class RCTMGLPackage implements ReactPackage {
         // layers
         managers.add(new RCTMGLFillLayerManager());
         managers.add(new RCTMGLFillExtrusionLayerManager());
+        managers.add(new RCTMGLHeatmapLayerManager());
         managers.add(new RCTMGLLineLayerManager());
         managers.add(new RCTMGLCircleLayerManager());
         managers.add(new RCTMGLSymbolLayerManager());

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
@@ -7,6 +7,7 @@ import com.mapbox.mapboxsdk.style.layers.BackgroundLayer;
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
+import com.mapbox.mapboxsdk.style.layers.HeatmapLayer;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLHeatmapLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLHeatmapLayer.java
@@ -1,0 +1,55 @@
+package com.mapbox.rctmgl.components.styles.layers;
+
+import android.content.Context;
+
+import com.mapbox.mapboxsdk.style.expressions.Expression;
+import com.mapbox.mapboxsdk.style.layers.HeatmapLayer;
+import com.mapbox.rctmgl.components.mapview.RCTMGLMapView;
+import com.mapbox.rctmgl.components.styles.RCTMGLStyle;
+import com.mapbox.rctmgl.components.styles.RCTMGLStyleFactory;
+
+/**
+ * Created by dhee9000 on 6/8/2019
+ */
+
+public class RCTMGLHeatmapLayer extends RCTLayer<HeatmapLayer> {
+    private String mSourceLayerID;
+
+    public RCTMGLHeatmapLayer(Context context){
+        super(context);
+    }
+
+    @Override
+    protected void updateFilter(Expression expression) {
+        mLayer.setFilter(expression);
+    }
+
+    @Override
+    public void addToMap(RCTMGLMapView mapView) {
+        super.addToMap(mapView);
+    }
+
+    @Override
+    public HeatmapLayer makeLayer() {
+        HeatmapLayer layer = new HeatmapLayer(mID, mSourceID);
+
+        if (mSourceLayerID != null) {
+            layer.setSourceLayer(mSourceLayerID);
+        }
+
+        return layer;
+    }
+
+    @Override
+    public void addStyles() {
+        RCTMGLStyleFactory.setHeatmapLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+    }
+
+    public void setSourceLayerID(String sourceLayerID) {
+        mSourceLayerID = sourceLayerID;
+
+        if (mLayer != null) {
+            mLayer.setSourceLayer(sourceLayerID);
+        }
+    }
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLHeatmapLayerManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLHeatmapLayerManager.java
@@ -1,0 +1,77 @@
+package com.mapbox.rctmgl.components.styles.layers;
+
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.ArrayList;
+
+/**
+ * Created by dhee9000 on 6/8/2019
+ */
+
+public class RCTMGLHeatmapLayerManager extends ViewGroupManager<RCTMGLHeatmapLayer>{
+    public static final String REACT_Class = RCTMGLHeatmapLayer.class.getSimpleName();
+
+    @Override
+    public String getName() {
+        return REACT_Class;
+    }
+
+    @Override
+    protected RCTMGLHeatmapLayer createViewInstance(ThemedReactContext reactContext) {
+        return new RCTMGLHeatmapLayer(reactContext);
+    }
+
+    @ReactProp(name="id")
+    public void setId(RCTMGLHeatmapLayer layer, String id) {
+        layer.setID(id);
+    }
+
+    @ReactProp(name="sourceID")
+    public void setSourceID(RCTMGLHeatmapLayer layer, String sourceID) {
+        layer.setSourceID(sourceID);
+    }
+
+    @ReactProp(name="aboveLayerID")
+    public void setAboveLayerID(RCTMGLHeatmapLayer layer, String aboveLayerID) {
+        layer.setAboveLayerID(aboveLayerID);
+    }
+
+    @ReactProp(name="belowLayerID")
+    public void setBelowLayerID(RCTMGLHeatmapLayer layer, String belowLayerID) {
+        layer.setBelowLayerID(belowLayerID);
+    }
+
+    @ReactProp(name="layerIndex")
+    public void setLayerIndex(RCTMGLHeatmapLayer layer, int layerIndex){
+        layer.setLayerIndex(layerIndex);
+    }
+
+    @ReactProp(name="minZoomLevel")
+    public void setMinZoomLevel(RCTMGLHeatmapLayer layer, double minZoomLevel) {
+        layer.setMinZoomLevel(minZoomLevel);
+    }
+
+    @ReactProp(name="maxZoomLevel")
+    public void setMaxZoomLevel(RCTMGLHeatmapLayer layer, double maxZoomLevel) {
+        layer.setMaxZoomLevel(maxZoomLevel);
+    }
+
+    @ReactProp(name="reactStyle")
+    public void setReactStyle(RCTMGLHeatmapLayer layer, ReadableMap style) {
+        layer.setReactStyle(style);
+    }
+
+    @ReactProp(name="sourceLayerID")
+    public void setSourceLayerId(RCTMGLHeatmapLayer layer, String sourceLayerID) {
+        layer.setSourceLayerID(sourceLayerID);
+    }
+
+    @ReactProp(name="filter")
+    public void setFilter(RCTMGLHeatmapLayer layer, ReadableArray filterList) {
+        layer.setFilter(filterList);
+    }
+}

--- a/docs/HeatmapLayer.md
+++ b/docs/HeatmapLayer.md
@@ -1,0 +1,148 @@
+## <MapboxGL.HeatmapLayer />
+### HeatmapLayer renders a heatmap of provided GeoJSON data based on the provided style.
+
+### props
+| Prop | Type | Default | Required | Description |
+| ---- | :--: | :-----: | :------: | :----------: |
+| id | `string` | `none` | `false` | A string that uniquely identifies the source in the style to which it is added. |
+| sourceID | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | The source from which to obtain the data to style.<br/>If the source has not yet been added to the current style, the behavior is undefined. |
+| sourceLayerID | `string` | `none` | `false` | Identifier of the layer within the source identified by the sourceID property<br/>from which the receiver obtains the data to style. |
+| aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |
+| belowLayerID | `string` | `none` | `false` | Inserts a layer below belowLayerID |
+| layerIndex | `number` | `none` | `false` | Inserts a layer at a specified index |
+| filter | `array` | `none` | `false` | Filter only the features in the source layer that satisfy a condition that you define |
+| minZoomLevel | `number` | `none` | `false` | The minimum zoom level at which the layer gets parsed and appears. |
+| maxZoomLevel | `number` | `none` | `false` | The maximum zoom level at which the layer gets parsed and appears. |
+| style | `union` | `none` | `false` | Customizable style attributes |
+
+
+### styles
+
+* <a href="#name">visibility</a><br/>
+* <a href="#name-1">heatmapColor</a><br/>
+* <a href="#name-2">heatmapIntensity</a><br/>
+* <a href="#name-3">heatmapOpacity</a><br/>
+* <a href="#name-4">heatmapRadius</a><br/>
+* <a href="#name-5">heatmapWeight</a><br/>
+
+
+___
+
+#### Name
+`visibility`
+
+#### Description
+Whether this layer is displayed.
+
+#### Type
+`enum`
+#### Default Value
+`visible`
+
+#### Supported Values
+**visible** - The layer is shown.<br />
+**none** - The layer is not shown.<br />
+
+
+
+___
+
+#### Name
+`heatmapColor`
+
+#### Description
+The color of the heatmap.
+
+#### Type
+`enum`
+#### Default Value
+`visible`
+
+#### Supported Values
+**visible** - The layer is shown.<br />
+**none** - The layer is not shown.<br />
+
+
+
+___
+
+#### Name
+`heatmapIntensity`
+
+#### Description
+The intensity of the heatmap. This is a multiplier on top of heatmapWeight.
+
+#### Type
+`number`
+#### Default Value
+`1`
+
+
+#### Expression
+
+Parameters: `zoom, feature, feature-state`
+
+___
+
+#### Name
+`heatmapOpacity`
+
+#### Description
+Adjusts opacity of the heatmap layer.
+
+#### Type
+`number`
+#### Default Value
+`1`
+
+
+#### Expression
+
+Parameters: `zoom, feature, feature-state`
+
+___
+
+#### Name
+`heatmapRadius`
+
+#### Description
+Adjusts the heatmap radius based on parameters.
+
+#### Type
+`number`
+#### Default Value
+`1`
+
+#### Minimum
+`0`
+
+#### Expression
+
+Parameters: `zoom, feature, feature-state`
+
+___
+
+#### Name
+`heatmapWeight`
+
+#### Description
+Sets the weight of the heatmap based on parameters.
+
+#### Type
+`number`
+#### Default Value
+`1`
+
+#### Minimum
+`0`
+
+
+#### Maximum
+`1`
+
+#### Expression
+
+Parameters: `zoom, feature, feature-state`
+
+___
+

--- a/ios/RCTMGL/RCTMGLHeatmapLayer.h
+++ b/ios/RCTMGL/RCTMGLHeatmapLayer.h
@@ -1,0 +1,14 @@
+//
+//  RCTMGLHeatmapLayer.h
+//  RCTMGL
+//
+//  Created by Dheeraj Yalamanchili on 6/8/19.
+//
+
+#import "RCTMGLLayer.h"
+
+@interface RCTMGLHeatmapLayer : RCTMGLLayer
+
+@property (nonatomic, copy) NSString *sourceLayerID;
+
+@end

--- a/ios/RCTMGL/RCTMGLHeatmapLayer.m
+++ b/ios/RCTMGL/RCTMGLHeatmapLayer.m
@@ -1,0 +1,49 @@
+//
+//  RCTMGLHeatmapLayer.m
+//  RCTMGL
+//
+//  Created by Dheeraj Yalamanchili on 6/8/2019
+
+#import "RCTMGLHeatmapLayer.h"
+#import "RCTMGLStyle.h"
+
+@implementation RCTMGLHeatmapLayer
+
+- (void)updateFilter:(NSPredicate *)predicate
+{
+    ((MGLHeatmapStyleLayer *) self.styleLayer).predicate = predicate;
+}
+
+- (void)setSourceLayerID:(NSString *)sourceLayerID
+{
+    _sourceLayerID = sourceLayerID;
+    
+    if (self.styleLayer != nil) {
+        ((MGLHeatmapStyleLayer*) self.styleLayer).sourceLayerIdentifier = _sourceLayerID;
+    }
+}
+
+- (void)addedToMap
+{
+    NSPredicate *filter = [self buildFilters];
+    if (filter != nil) {
+        [self updateFilter:filter];
+    }
+}
+
+- (MGLHeatmapStyleLayer*)makeLayer:(MGLStyle*)style
+{
+    MGLSource *source = [style sourceWithIdentifier:self.sourceID];
+    MGLHeatmapStyleLayer *layer = [[MGLHeatmapStyleLayer alloc] initWithIdentifier:self.id source:source];
+    layer.sourceLayerIdentifier = _sourceLayerID;
+    return layer;
+}
+
+- (void)addStyles
+{
+    RCTMGLStyle *style = [[RCTMGLStyle alloc] initWithMGLStyle:self.style];
+    style.bridge = self.bridge;
+    [style heatmapLayer:(MGLHeatmapStyleLayer *) withReactStyle:self.reactStyle];
+}
+
+@end

--- a/ios/RCTMGL/RCTMGLHeatmapLayer.m
+++ b/ios/RCTMGL/RCTMGLHeatmapLayer.m
@@ -43,7 +43,7 @@
 {
     RCTMGLStyle *style = [[RCTMGLStyle alloc] initWithMGLStyle:self.style];
     style.bridge = self.bridge;
-    [style heatmapLayer:(MGLHeatmapStyleLayer *) withReactStyle:self.reactStyle];
+    [style heatmapLayer:(MGLHeatmapStyleLayer *)self.styleLayer withReactStyle:self.reactStyle];
 }
 
 @end

--- a/ios/RCTMGL/RCTMGLHeatmapLayerManager.h
+++ b/ios/RCTMGL/RCTMGLHeatmapLayerManager.h
@@ -1,12 +1,12 @@
 //
 //  RCTMGLHeatmapLayerManager.h
-//  Pods
+//  RCTMGL
 //
 //  Created by Dheeraj Yalamanchili on 6/8/19.
 //
 
-#ifndef RCTMGLHeatmapLayerManager_h
-#define RCTMGLHeatmapLayerManager_h
+#import "ViewManager.h"
 
+@interface RCTMGLHeatmapLayerManager : ViewManager
 
-#endif /* RCTMGLHeatmapLayerManager_h */
+@end

--- a/ios/RCTMGL/RCTMGLHeatmapLayerManager.h
+++ b/ios/RCTMGL/RCTMGLHeatmapLayerManager.h
@@ -1,0 +1,12 @@
+//
+//  RCTMGLHeatmapLayerManager.h
+//  Pods
+//
+//  Created by Dheeraj Yalamanchili on 6/8/19.
+//
+
+#ifndef RCTMGLHeatmapLayerManager_h
+#define RCTMGLHeatmapLayerManager_h
+
+
+#endif /* RCTMGLHeatmapLayerManager_h */

--- a/ios/RCTMGL/RCTMGLHeatmapLayerManager.m
+++ b/ios/RCTMGL/RCTMGLHeatmapLayerManager.m
@@ -1,0 +1,38 @@
+//
+//  RCTMGLHeatmapLayerManager.m
+//  RCTMGL
+//
+//  Created by Dheeraj Yalamanchili on 6/8/19.
+//
+
+#import "RCTMGLHeatmapLayerManager.h"
+#import "RCTMGLHeatmapLayer.h"
+
+@implementation RCTMGLHeatmapLayerManager
+
+RCT_EXPORT_MODULE()
+
+// Heatmap layer props
+RCT_EXPORT_VIEW_PROPERTY(sourceLayerID, NSString);
+
+// standard layer props
+RCT_EXPORT_VIEW_PROPERTY(id, NSString);
+RCT_EXPORT_VIEW_PROPERTY(sourceID, NSString);
+RCT_EXPORT_VIEW_PROPERTY(filter, NSArray);
+
+RCT_EXPORT_VIEW_PROPERTY(aboveLayerID, NSString);
+RCT_EXPORT_VIEW_PROPERTY(belowLayerID, NSString);
+RCT_EXPORT_VIEW_PROPERTY(layerIndex, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(reactStyle, NSDictionary);
+
+RCT_EXPORT_VIEW_PROPERTY(maxZoomLevel, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(minZoomLevel, NSNumber);
+
+- (UIView*)view
+{
+    RCTMGLHeatmapLayer *layer = [RCTMGLHeatmapLayer new];
+    layer.bridge = self.bridge;
+    return layer;
+}
+
+@end

--- a/javascript/components/HeatmapLayer.js
+++ b/javascript/components/HeatmapLayer.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {NativeModules, requireNativeComponent} from 'react-native';
+
+import {viewPropTypes} from '../utils';
+import {HeatmapLayerStyleProp} from '../utils/styleMap';
+
+import AbstractLayer from './AbstractLayer';
+
+const MapboxGL = NativeModules.MGLModule;
+
+export const NATIVE_MODULE_NAME = 'RCTMGLHeatmapLayer';
+
+/**
+ * HeatmapLayer is a style layer that renders one or more filled circles on the map.
+ */
+class HeatmapLayer extends AbstractLayer {
+  static propTypes = {
+    ...viewPropTypes,
+
+    /**
+     * A string that uniquely identifies the source in the style to which it is added.
+     */
+    id: PropTypes.string,
+
+    /**
+     * The source from which to obtain the data to style.
+     * If the source has not yet been added to the current style, the behavior is undefined.
+     */
+    sourceID: PropTypes.string,
+
+    /**
+     * Identifier of the layer within the source identified by the sourceID property
+     * from which the receiver obtains the data to style.
+     */
+    sourceLayerID: PropTypes.string,
+
+    /**
+     * Inserts a layer above aboveLayerID.
+     */
+    aboveLayerID: PropTypes.string,
+
+    /**
+     * Inserts a layer below belowLayerID
+     */
+    belowLayerID: PropTypes.string,
+
+    /**
+     * Inserts a layer at a specified index
+     */
+    layerIndex: PropTypes.number,
+
+    /**
+     *  Filter only the features in the source layer that satisfy a condition that you define
+     */
+    filter: PropTypes.array,
+
+    /**
+     * The minimum zoom level at which the layer gets parsed and appears.
+     */
+    minZoomLevel: PropTypes.number,
+
+    /**
+     * The maximum zoom level at which the layer gets parsed and appears.
+     */
+    maxZoomLevel: PropTypes.number,
+
+    /**
+     * Customizable style attributes
+     */
+    style: PropTypes.oneOfType([
+      HeatmapLayerStyleProp,
+      PropTypes.arrayOf(HeatmapLayerStyleProp),
+    ]),
+  };
+
+  static defaultProps = {
+    sourceID: MapboxGL.StyleSource.DefaultSourceID,
+  };
+
+  render() {
+    const props = {
+      ...this.baseProps,
+      sourceLayerID: this.props.sourceLayerID,
+    };
+    return <RCTMGLHeatmapLayer ref="nativeLayer" {...props} />;
+  }
+}
+
+const RCTMGLHeatmapLayer = requireNativeComponent(
+  NATIVE_MODULE_NAME,
+  HeatmapLayer,
+  {
+    nativeOnly: {reactStyle: true},
+  },
+);
+
+export default HeatmapLayer;

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -19,6 +19,7 @@ import ImageSource from './components/ImageSource';
 // Layers
 import FillLayer from './components/FillLayer';
 import FillExtrusionLayer from './components/FillExtrusionLayer';
+import HeatmapLayer from './components/HeatmapLayer';
 import LineLayer from './components/LineLayer';
 import CircleLayer from './components/CircleLayer';
 import SymbolLayer from './components/SymbolLayer';
@@ -82,6 +83,7 @@ MapboxGL.ImageSource = ImageSource;
 // layers
 MapboxGL.FillLayer = FillLayer;
 MapboxGL.FillExtrusionLayer = FillExtrusionLayer;
+MapboxGL.HeatmapLayer = HeatmapLayer;
 MapboxGL.LineLayer = LineLayer;
 MapboxGL.CircleLayer = CircleLayer;
 MapboxGL.SymbolLayer = SymbolLayer;


### PR DESCRIPTION
Related to issue: @react-native-mapbox-gl/maps#115

Adds support for HeatmapLayer in Style Layers for Android and iOS.

- On Android, Heatmap Layer appears to be working, at least for the examples provided for the native Mapbox SDK
  - RCTMGLHeatmapLayer.java created based on RCTMGLCircleLayer
  - RCTMGLHeatmapLayerManager.java based on RCTMGLCircleLayerManager
  - Styles were already present under RCTMGLStyle.java
  - Added to RCTMGLHeatmapLayerManager to RCTMGLPackage so that it works in React Native

- On iOS, the project does not run, possibly missing changes higher up in the library.
  - RCTMLGHeatmapLayer.m and .h created based on RCTMGLCircleLayer.m and h
  - RCTMGLHeatmapLayerManager.m and .h created based on RCTMGLCircleLayerManager.m and h

TODO:
Test style properties and expressions for HeatmapLayer
Add example to example project
Complete documentation of available properties