### PR TITLE
Implement Camera defaultSettings

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
@@ -52,6 +52,7 @@ public class RCTMGLCamera extends AbstractMapFeature {
 
     private boolean hasSentFirstRegion = false;
 
+    private CameraStop mDefaultStop;
     private CameraStop mCameraStop;
     private CameraUpdateQueue mCameraUpdateQueue;
 
@@ -133,6 +134,7 @@ public class RCTMGLCamera extends AbstractMapFeature {
     public void addToMap(RCTMGLMapView mapView) {
         mMapView = mapView;
 
+        setInitialCamera();
         if (mCameraStop != null) {
             updateCamera();
         }
@@ -157,6 +159,10 @@ public class RCTMGLCamera extends AbstractMapFeature {
         }
     }
 
+    public void setDefaultStop(CameraStop stop) {
+        mDefaultStop = stop;
+    }
+
     private void updateMaxMinZoomLevel() {
         MapboxMap map = getMapboxMap();
         if (map != null) {
@@ -166,6 +172,15 @@ public class RCTMGLCamera extends AbstractMapFeature {
             if (mMaxZoomLevel >= 0.0) {
                 map.setMaxZoomPreference(mMaxZoomLevel);
             }
+        }
+    }
+
+    private void setInitialCamera() {
+        if (mDefaultStop != null) {
+            mDefaultStop.setDuration(0);
+            mDefaultStop.setMode(com.mapbox.rctmgl.components.camera.constants.CameraMode.NONE);
+            CameraUpdateItem item = mDefaultStop.toCameraUpdate(mMapView.getMapboxMap());
+            item.run();
         }
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCameraManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCameraManager.java
@@ -43,6 +43,14 @@ public class RCTMGLCameraManager extends AbstractEventEmitter<RCTMGLCamera> {
         }
     }
 
+    @ReactProp(name="defaultStop")
+    public void setDefaultStop(RCTMGLCamera camera, ReadableMap map) {
+        if (map != null) {
+            CameraStop stop = CameraStop.fromReadableMap(mContext, map, null);
+            camera.setDefaultStop(stop);
+        }
+    }
+
     @ReactProp(name="userTrackingMode")
     public void setUserTrackingMode(RCTMGLCamera camera, int userTrackingMode) {
         camera.setUserTrackingMode(userTrackingMode);

--- a/docs/Camera.md
+++ b/docs/Camera.md
@@ -6,11 +6,29 @@
 | ---- | :--: | :-----: | :------: | :----------: |
 | animationDuration | `number` | `2000` | `false` | FIX ME NO DESCRIPTION |
 | animationMode | `enum` | `'easeTo'` | `false` | FIX ME NO DESCRIPTION |
-| centerCoordinate | `arrayOf` | `none` | `false` | FIX ME NO DESCRIPTION |
-| heading | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
-| pitch | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
+| defaultSettings | `shape` | `none` | `false` | FIX ME NO DESCRIPTION |
+| &nbsp;&nbsp;centerCoordinate | `arrayOf` | `none` | `false` | Center coordinate on map [lng, lat] |
+| &nbsp;&nbsp;heading | `number` | `none` | `false` | Heading on map |
+| &nbsp;&nbsp;pitch | `number` | `none` | `false` | Pitch on map |
+| &nbsp;&nbsp;bounds | `shape` | `none` | `false` | FIX ME NO DESCRIPTION |
+| &nbsp;&nbsp;&nbsp;&nbsp;ne | `arrayOf` | `none` | `true` | northEastCoordinates - North east coordinate of bound |
+| &nbsp;&nbsp;&nbsp;&nbsp;sw | `arrayOf` | `none` | `true` | southWestCoordinates - North east coordinate of bound |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingLeft | `number` | `none` | `false` | Left camera padding for bounds |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingRight | `number` | `none` | `false` | Right camera padding for bounds |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingTop | `number` | `none` | `false` | Top camera padding for bounds |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingBottom | `number` | `none` | `false` | Bottom camera padding for bounds |
+| &nbsp;&nbsp;zoomLevel | `number` | `none` | `false` | Zoom level of the map |
+| centerCoordinate | `arrayOf` | `none` | `false` | Center coordinate on map [lng, lat] |
+| heading | `number` | `none` | `false` | Heading on map |
+| pitch | `number` | `none` | `false` | Pitch on map |
 | bounds | `shape` | `none` | `false` | FIX ME NO DESCRIPTION |
-| zoomLevel | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
+| &nbsp;&nbsp;ne | `arrayOf` | `none` | `true` | northEastCoordinates - North east coordinate of bound |
+| &nbsp;&nbsp;sw | `arrayOf` | `none` | `true` | southWestCoordinates - North east coordinate of bound |
+| &nbsp;&nbsp;paddingLeft | `number` | `none` | `false` | Left camera padding for bounds |
+| &nbsp;&nbsp;paddingRight | `number` | `none` | `false` | Right camera padding for bounds |
+| &nbsp;&nbsp;paddingTop | `number` | `none` | `false` | Top camera padding for bounds |
+| &nbsp;&nbsp;paddingBottom | `number` | `none` | `false` | Bottom camera padding for bounds |
+| zoomLevel | `number` | `none` | `false` | Zoom level of the map |
 | minZoomLevel | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | maxZoomLevel | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | followUserLocation | `bool` | `none` | `false` | FIX ME NO DESCRIPTION |

--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -10,6 +10,8 @@
 | selected | `bool` | `none` | `false` | Manually selects/deselects annotation<br/>@type {[type]} |
 | coordinate | `arrayOf` | `none` | `true` | The center point (specified as a map coordinate) of the annotation. |
 | anchor | `shape` | `{x: 0.5, y: 0.5}` | `false` | Specifies the anchor being set on a particular point of the annotation.<br/>The anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],<br/>where (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.<br/>Note this is only for custom annotations not the default pin view.<br/>Defaults to the center of the view. |
+| &nbsp;&nbsp;x | `number` | `none` | `true` | FIX ME NO DESCRIPTION |
+| &nbsp;&nbsp;y | `number` | `none` | `true` | FIX ME NO DESCRIPTION |
 | onSelected | `func` | `none` | `false` | This callback is fired once this annotation is selected. Returns a Feature as the first param. |
 | onDeselected | `func` | `none` | `false` | This callback is fired once this annotation is deselected. |
 

--- a/docs/ShapeSource.md
+++ b/docs/ShapeSource.md
@@ -16,5 +16,7 @@
 | images | `object` | `none` | `false` | Specifies the external images in key-value pairs required for the shape source.<br/>If you have an asset under Image.xcassets on iOS and the drawables directory on android<br/>you can specify an array of string names with assets as the key `{ assets: ['pin'] }`. |
 | onPress | `func` | `none` | `false` | Source press listener, gets called when a user presses one of the children layers only<br/>if that layer has a higher z-index than another source layers |
 | hitbox | `shape` | `none` | `false` | Overrides the default touch hitbox(44x44 pixels) for the source layers |
+| &nbsp;&nbsp;width | `number` | `none` | `true` | FIX ME NO DESCRIPTION |
+| &nbsp;&nbsp;height | `number` | `none` | `true` | FIX ME NO DESCRIPTION |
 
 

--- a/docs/VectorSource.md
+++ b/docs/VectorSource.md
@@ -8,5 +8,7 @@
 | url | `string` | `none` | `false` | A URL to a TileJSON configuration file describing the source’s contents and other metadata. |
 | onPress | `func` | `none` | `false` | Source press listener, gets called when a user presses one of the children layers only<br/>if that layer has a higher z-index than another source layers |
 | hitbox | `shape` | `none` | `false` | Overrides the default touch hitbox(44x44 pixels) for the source layers |
+| &nbsp;&nbsp;width | `number` | `none` | `true` | FIX ME NO DESCRIPTION |
+| &nbsp;&nbsp;height | `number` | `none` | `true` | FIX ME NO DESCRIPTION |
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,7 @@
 {
   "BackgroundLayer": {
     "description": "",
+    "displayName": "BackgroundLayer",
     "methods": [],
     "props": [
       {
@@ -153,6 +154,7 @@
   },
   "Callout": {
     "description": "Callout that displays information about a selected annotation near the annotation.",
+    "displayName": "Callout",
     "methods": [],
     "props": [
       {
@@ -205,6 +207,7 @@
   },
   "Camera": {
     "description": "",
+    "displayName": "Camera",
     "methods": [
       {
         "name": "fitBounds",
@@ -215,15 +218,27 @@
             "name": "northEastCoordinates",
             "description": "North east coordinate of bound",
             "type": {
-              "name": "Array"
-            }
+              "name": "Array",
+              "elements": [
+                {
+                  "name": "Number"
+                }
+              ]
+            },
+            "optional": false
           },
           {
             "name": "southWestCoordinates",
             "description": "South west coordinate of bound",
             "type": {
-              "name": "Array"
-            }
+              "name": "Array",
+              "elements": [
+                {
+                  "name": "Number"
+                }
+              ]
+            },
+            "optional": false
           },
           {
             "name": "padding",
@@ -262,8 +277,14 @@
             "name": "coordinates",
             "description": "Coordinates that map camera will jump too",
             "type": {
-              "name": "Array"
-            }
+              "name": "Array",
+              "elements": [
+                {
+                  "name": "Number"
+                }
+              ]
+            },
+            "optional": false
           },
           {
             "name": "animationDuration",
@@ -294,8 +315,14 @@
             "name": "coordinates",
             "description": "Coordinates that map camera will move too",
             "type": {
-              "name": "Array"
-            }
+              "name": "Array",
+              "elements": [
+                {
+                  "name": "Number"
+                }
+              ]
+            },
+            "optional": false
           },
           {
             "name": "animationDuration",
@@ -327,7 +354,8 @@
             "description": "Zoom level that the map camera will animate too",
             "type": {
               "name": "Number"
-            }
+            },
+            "optional": false
           },
           {
             "name": "animationDuration",
@@ -359,7 +387,8 @@
             "description": "Camera configuration",
             "type": {
               "name": "Object"
-            }
+            },
+            "optional": false
           }
         ],
         "returns": null,
@@ -385,30 +414,168 @@
         "description": "FIX ME NO DESCRIPTION"
       },
       {
+        "name": "defaultSettings",
+        "required": false,
+        "type": {
+          "name": "shape",
+          "value": [
+            {
+              "name": "centerCoordinate",
+              "required": false,
+              "type": "arrayOf",
+              "default": "none",
+              "description": "Center coordinate on map [lng, lat]"
+            },
+            {
+              "name": "heading",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Heading on map"
+            },
+            {
+              "name": "pitch",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Pitch on map"
+            },
+            {
+              "name": "bounds",
+              "required": false,
+              "type": {
+                "name": "shape",
+                "value": [
+                  {
+                    "name": "ne",
+                    "required": true,
+                    "type": "arrayOf",
+                    "default": "none",
+                    "description": "northEastCoordinates - North east coordinate of bound"
+                  },
+                  {
+                    "name": "sw",
+                    "required": true,
+                    "type": "arrayOf",
+                    "default": "none",
+                    "description": "southWestCoordinates - North east coordinate of bound"
+                  },
+                  {
+                    "name": "paddingLeft",
+                    "required": false,
+                    "type": "number",
+                    "default": "none",
+                    "description": "Left camera padding for bounds"
+                  },
+                  {
+                    "name": "paddingRight",
+                    "required": false,
+                    "type": "number",
+                    "default": "none",
+                    "description": "Right camera padding for bounds"
+                  },
+                  {
+                    "name": "paddingTop",
+                    "required": false,
+                    "type": "number",
+                    "default": "none",
+                    "description": "Top camera padding for bounds"
+                  },
+                  {
+                    "name": "paddingBottom",
+                    "required": false,
+                    "type": "number",
+                    "default": "none",
+                    "description": "Bottom camera padding for bounds"
+                  }
+                ]
+              },
+              "default": "none",
+              "description": "FIX ME NO DESCRIPTION"
+            },
+            {
+              "name": "zoomLevel",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Zoom level of the map"
+            }
+          ]
+        },
+        "default": "none",
+        "description": "FIX ME NO DESCRIPTION"
+      },
+      {
         "name": "centerCoordinate",
         "required": false,
         "type": "arrayOf",
         "default": "none",
-        "description": "FIX ME NO DESCRIPTION"
+        "description": "Center coordinate on map [lng, lat]"
       },
       {
         "name": "heading",
         "required": false,
         "type": "number",
         "default": "none",
-        "description": "FIX ME NO DESCRIPTION"
+        "description": "Heading on map"
       },
       {
         "name": "pitch",
         "required": false,
         "type": "number",
         "default": "none",
-        "description": "FIX ME NO DESCRIPTION"
+        "description": "Pitch on map"
       },
       {
         "name": "bounds",
         "required": false,
-        "type": "shape",
+        "type": {
+          "name": "shape",
+          "value": [
+            {
+              "name": "ne",
+              "required": true,
+              "type": "arrayOf",
+              "default": "none",
+              "description": "northEastCoordinates - North east coordinate of bound"
+            },
+            {
+              "name": "sw",
+              "required": true,
+              "type": "arrayOf",
+              "default": "none",
+              "description": "southWestCoordinates - North east coordinate of bound"
+            },
+            {
+              "name": "paddingLeft",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Left camera padding for bounds"
+            },
+            {
+              "name": "paddingRight",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Right camera padding for bounds"
+            },
+            {
+              "name": "paddingTop",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Top camera padding for bounds"
+            },
+            {
+              "name": "paddingBottom",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Bottom camera padding for bounds"
+            }
+          ]
+        },
         "default": "none",
         "description": "FIX ME NO DESCRIPTION"
       },
@@ -417,7 +584,7 @@
         "required": false,
         "type": "number",
         "default": "none",
-        "description": "FIX ME NO DESCRIPTION"
+        "description": "Zoom level of the map"
       },
       {
         "name": "minZoomLevel",
@@ -497,6 +664,7 @@
   },
   "CircleLayer": {
     "description": "CircleLayer is a style layer that renders one or more filled circles on the map.",
+    "displayName": "CircleLayer",
     "methods": [],
     "props": [
       {
@@ -829,6 +997,7 @@
   },
   "FillExtrusionLayer": {
     "description": "FillExtrusionLayer is a style layer that renders one or more 3D extruded polygons on the map.",
+    "displayName": "FillExtrusionLayer",
     "methods": [],
     "props": [
       {
@@ -1073,6 +1242,7 @@
   },
   "FillLayer": {
     "description": "FillLayer is a style layer that renders one or more filled (and optionally stroked) polygons on the map.",
+    "displayName": "FillLayer",
     "methods": [],
     "props": [
       {
@@ -1312,6 +1482,7 @@
   },
   "ImageSource": {
     "description": "ImageSource is a content source that is used for a georeferenced raster image to be shown on the map.\nThe georeferenced image scales and rotates as the user zooms and rotates the map",
+    "displayName": "ImageSource",
     "methods": [],
     "props": [
       {
@@ -1343,6 +1514,7 @@
   },
   "Light": {
     "description": "Light represents the light source for extruded geometries",
+    "displayName": "Light",
     "methods": [],
     "props": [
       {
@@ -1441,6 +1613,7 @@
   },
   "LineLayer": {
     "description": "LineLayer is a style layer that renders one or more stroked polylines on the map.",
+    "displayName": "LineLayer",
     "methods": [],
     "props": [
       {
@@ -1856,6 +2029,7 @@
   },
   "MapView": {
     "description": "MapView backed by Mapbox Native GL",
+    "displayName": "MapView",
     "methods": [
       {
         "name": "getPointInView",
@@ -1868,8 +2042,14 @@
             "name": "coordinate",
             "description": "A point expressed in the map view's coordinate system.",
             "type": {
-              "name": "Array"
-            }
+              "name": "Array",
+              "elements": [
+                {
+                  "name": "Number"
+                }
+              ]
+            },
+            "optional": false
           }
         ],
         "returns": {
@@ -1894,8 +2074,14 @@
             "name": "point",
             "description": "A point expressed in the given view’s coordinate system.",
             "type": {
-              "name": "Array"
-            }
+              "name": "Array",
+              "elements": [
+                {
+                  "name": "Number"
+                }
+              ]
+            },
+            "optional": false
           }
         ],
         "returns": {
@@ -1938,8 +2124,14 @@
             "name": "coordinate",
             "description": "A point expressed in the map view’s coordinate system.",
             "type": {
-              "name": "Array"
-            }
+              "name": "Array",
+              "elements": [
+                {
+                  "name": "Number"
+                }
+              ]
+            },
+            "optional": false
           },
           {
             "name": "filter",
@@ -1980,8 +2172,14 @@
             "name": "bbox",
             "description": "A rectangle expressed in the map view’s coordinate system.",
             "type": {
-              "name": "Array"
-            }
+              "name": "Array",
+              "elements": [
+                {
+                  "name": "Number"
+                }
+              ]
+            },
+            "optional": false
           },
           {
             "name": "filter",
@@ -2036,7 +2234,8 @@
             "description": "If true will create a temp file, otherwise it is in base64",
             "type": {
               "name": "Boolean"
-            }
+            },
+            "optional": false
           }
         ],
         "returns": {
@@ -2076,7 +2275,12 @@
         "returns": {
           "description": "Coordinates",
           "type": {
-            "name": "Array"
+            "name": "Array",
+            "elements": [
+              {
+                "name": "Number"
+              }
+            ]
           }
         },
         "description": "Returns the map's geographical centerpoint",
@@ -2327,6 +2531,7 @@
   },
   "PointAnnotation": {
     "description": "PointAnnotation represents a one-dimensional shape located at a single geographical coordinate.",
+    "displayName": "PointAnnotation",
     "methods": [],
     "props": [
       {
@@ -2367,7 +2572,25 @@
       {
         "name": "anchor",
         "required": false,
-        "type": "shape",
+        "type": {
+          "name": "shape",
+          "value": [
+            {
+              "name": "x",
+              "required": true,
+              "type": "number",
+              "default": "none",
+              "description": "FIX ME NO DESCRIPTION"
+            },
+            {
+              "name": "y",
+              "required": true,
+              "type": "number",
+              "default": "none",
+              "description": "FIX ME NO DESCRIPTION"
+            }
+          ]
+        },
         "default": "{x: 0.5, y: 0.5}",
         "description": "Specifies the anchor being set on a particular point of the annotation.\nThe anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],\nwhere (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.\nNote this is only for custom annotations not the default pin view.\nDefaults to the center of the view."
       },
@@ -2393,6 +2616,7 @@
   },
   "RasterLayer": {
     "description": "",
+    "displayName": "RasterLayer",
     "methods": [],
     "props": [
       {
@@ -2644,6 +2868,7 @@
   },
   "RasterSource": {
     "description": "RasterSource is a map content source that supplies raster image tiles to be shown on the map.\nThe location of and metadata about the tiles are defined either by an option dictionary\nor by an external file that conforms to the TileJSON specification.",
+    "displayName": "RasterSource",
     "methods": [],
     "props": [
       {
@@ -2703,6 +2928,7 @@
   },
   "ShapeSource": {
     "description": "ShapeSource is a map content source that supplies vector shapes to be shown on the map.\nThe shape may be a url or a GeoJSON object",
+    "displayName": "ShapeSource",
     "methods": [],
     "props": [
       {
@@ -2785,7 +3011,25 @@
       {
         "name": "hitbox",
         "required": false,
-        "type": "shape",
+        "type": {
+          "name": "shape",
+          "value": [
+            {
+              "name": "width",
+              "required": true,
+              "type": "number",
+              "default": "none",
+              "description": "FIX ME NO DESCRIPTION"
+            },
+            {
+              "name": "height",
+              "required": true,
+              "type": "number",
+              "default": "none",
+              "description": "FIX ME NO DESCRIPTION"
+            }
+          ]
+        },
         "default": "none",
         "description": "Overrides the default touch hitbox(44x44 pixels) for the source layers"
       }
@@ -2797,6 +3041,7 @@
   },
   "SymbolLayer": {
     "description": "SymbolLayer is a style layer that renders icon and text labels at points or along lines on the map.",
+    "displayName": "SymbolLayer",
     "methods": [],
     "props": [
       {
@@ -4126,6 +4371,7 @@
   },
   "UserLocation": {
     "description": "",
+    "displayName": "UserLocation",
     "methods": [
       {
         "name": "setLocationManager",
@@ -4149,7 +4395,9 @@
       {
         "name": "userIconLayers",
         "docblock": null,
-        "modifiers": [],
+        "modifiers": [
+          "get"
+        ],
         "params": [],
         "returns": null
       }
@@ -4202,6 +4450,7 @@
   },
   "VectorSource": {
     "description": "VectorSource is a map content source that supplies tiled vector data in Mapbox Vector Tile format to be shown on the map.\nThe location of and metadata about the tiles are defined either by an option dictionary or by an external file that conforms to the TileJSON specification.",
+    "displayName": "VectorSource",
     "methods": [],
     "props": [
       {
@@ -4228,7 +4477,25 @@
       {
         "name": "hitbox",
         "required": false,
-        "type": "shape",
+        "type": {
+          "name": "shape",
+          "value": [
+            {
+              "name": "width",
+              "required": true,
+              "type": "number",
+              "default": "none",
+              "description": "FIX ME NO DESCRIPTION"
+            },
+            {
+              "name": "height",
+              "required": true,
+              "type": "number",
+              "default": "none",
+              "description": "FIX ME NO DESCRIPTION"
+            }
+          ]
+        },
         "default": "none",
         "description": "Overrides the default touch hitbox(44x44 pixels) for the source layers"
       }
@@ -4240,6 +4507,7 @@
   },
   "Annotation": {
     "description": "",
+    "displayName": "Annotation",
     "methods": [
       {
         "name": "onPress",
@@ -4251,7 +4519,9 @@
       {
         "name": "symbolStyle",
         "docblock": null,
-        "modifiers": [],
+        "modifiers": [
+          "get"
+        ],
         "params": [],
         "returns": null
       }

--- a/example/src/examples/SetUserTrackingModes.js
+++ b/example/src/examples/SetUserTrackingModes.js
@@ -86,6 +86,10 @@ class SetUserTrackingModes extends React.Component {
           <MapboxGL.UserLocation visible={this.state.showUserLocation} />
 
           <MapboxGL.Camera
+            defaultSettings={{
+              centerCoordinate: [-111.8678, 40.2866],
+              zoomLevel: 16,
+            }}
             followUserLocation={
               this.state.userSelectedUserTrackingMode !== 'none'
             }

--- a/ios/RCTMGL/RCTMGLCamera.h
+++ b/ios/RCTMGL/RCTMGLCamera.h
@@ -13,6 +13,7 @@
 @interface RCTMGLCamera : UIView
 
 @property (nonatomic, strong) NSDictionary<NSString *, id> *stop;
+@property (nonatomic, strong) NSDictionary<NSString *, id> *defaultStop;
 @property (nonatomic, strong) RCTMGLMapView *map;
 
 @property (nonatomic, copy) NSNumber *animationDuration;

--- a/ios/RCTMGL/RCTMGLCamera.m
+++ b/ios/RCTMGL/RCTMGLCamera.m
@@ -14,6 +14,7 @@
 #import "RCTMGLLocationManager.h"
 #import "RCTMGLEvent.h"
 #import "RCTMGLEventTypes.h"
+#import "CameraMode.h"
 
 @implementation RCTMGLCamera
 {
@@ -45,6 +46,11 @@
     [self _updateMinMaxZoomLevel];
 }
 
+- (void)setDefaultStop:(NSDictionary<NSString *,id> *)stop
+{
+    _defaultStop = stop;
+}
+
 - (void)setStop:(NSDictionary<NSString *,id> *)stop
 {
     _stop = stop;
@@ -60,6 +66,7 @@
     _map = map;
     _map.reactCamera = self;
 
+    [self _setInitialCamera];
     [self _updateMinMaxZoomLevel];
     [self _updateCamera];
 }
@@ -110,6 +117,20 @@
     
     [cameraUpdateQueue enqueue:[CameraStop fromDictionary:_stop]];
     [cameraUpdateQueue execute:_map];
+}
+
+- (void)_setInitialCamera
+{
+    if (! _defaultStop) {
+        return;
+    }
+
+    CameraStop* stop = [CameraStop fromDictionary:_defaultStop];
+    stop.duration = 0;
+    stop.mode = [NSNumber numberWithInt:RCT_MAPBOX_CAMERA_MODE_NONE];
+    CameraUpdateItem *item = [[CameraUpdateItem alloc] init];
+    item.cameraStop = stop;
+    [item execute:_map withCompletionHandler:^{ }];
 }
 
 - (void)_updateCamera

--- a/ios/RCTMGL/RCTMGLCameraManager.m
+++ b/ios/RCTMGL/RCTMGLCameraManager.m
@@ -33,6 +33,8 @@ RCT_EXPORT_VIEW_PROPERTY(minZoomLevel, NSNumber)
 
 RCT_EXPORT_VIEW_PROPERTY(onUserTrackingModeChange, RCTBubblingEventBlock)
 
+RCT_EXPORT_VIEW_PROPERTY(defaultStop, NSDictionary)
+
 #pragma Methods
 
 - (BOOL)requiresMainQueueSetup

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -12,22 +12,62 @@ const MapboxGL = NativeModules.MGLModule;
 
 export const NATIVE_MODULE_NAME = 'RCTMGLCamera';
 
-class Camera extends NativeBridgeComponent {
-  static ViewSettingsPropTypes = {
-    centerCoordinate: PropTypes.arrayOf(PropTypes.number),
-    heading: PropTypes.number,
-    pitch: PropTypes.number,
-    bounds: PropTypes.shape({
-      ne: PropTypes.arrayOf(PropTypes.number).isRequired,
-      sw: PropTypes.arrayOf(PropTypes.number).isRequired,
-      paddingLeft: PropTypes.number,
-      paddingRight: PropTypes.number,
-      paddingTop: PropTypes.number,
-      paddingBottom: PropTypes.number,
-    }),
-    zoomLevel: PropTypes.number,
-  };
+const SettingsPropTypes = {
+  /**
+   * Center coordinate on map [lng, lat]
+   */
+  centerCoordinate: PropTypes.arrayOf(PropTypes.number),
 
+  /**
+   * Heading on map
+   */
+  heading: PropTypes.number,
+
+  /**
+   * Pitch on map
+   */
+  pitch: PropTypes.number,
+
+
+  bounds: PropTypes.shape({
+    /**
+     * northEastCoordinates - North east coordinate of bound
+     */
+    ne: PropTypes.arrayOf(PropTypes.number).isRequired,
+
+    /**
+     * southWestCoordinates - North east coordinate of bound
+     */
+    sw: PropTypes.arrayOf(PropTypes.number).isRequired,
+
+    /**
+     * Left camera padding for bounds
+     */
+    paddingLeft: PropTypes.number,
+
+    /**
+     * Right camera padding for bounds
+     */
+    paddingRight: PropTypes.number,
+
+    /**
+     * Top camera padding for bounds
+     */
+    paddingTop: PropTypes.number,
+
+    /**
+     * Bottom camera padding for bounds
+     */
+    paddingBottom: PropTypes.number,
+  }),
+
+  /**
+   * Zoom level of the map
+   */
+  zoomLevel: PropTypes.number,
+};
+
+class Camera extends NativeBridgeComponent {
   static propTypes = {
     ...viewPropTypes,
 
@@ -36,10 +76,10 @@ class Camera extends NativeBridgeComponent {
     animationMode: PropTypes.oneOf(['flyTo', 'easeTo', 'moveTo']),
 
     // default - view settings
-    defaultViewSettings: PropTypes.shape(Camera.ViewSettingsPropTypes),
+    defaultSettings: PropTypes.shape(SettingsPropTypes),
 
     // normal - view settings
-    ...Camera.ViewSettingsPropTypes,
+    ...SettingsPropTypes,
 
     minZoomLevel: PropTypes.number,
     maxZoomLevel: PropTypes.number,
@@ -350,22 +390,22 @@ class Camera extends NativeBridgeComponent {
     this.refs.camera.setNativeProps({stop: cameraConfig});
   }
 
-  _createDefaultViewCamera() {
-    if (this.defaultViewCamera) {
-      return this.defaultViewCamera;
+  _createDefaultCamera() {
+    if (this.defaultCamera) {
+      return this.defaultCamera;
     }
-    if (!this.props.defaultViewSettings) {
+    if (!this.props.defaultSettings) {
       return null;
     }
 
-    this.defaultViewCamera = this._createStopConfig(
+    this.defaultCamera = this._createStopConfig(
       {
-        ...this.props.defaultViewSettings,
+        ...this.props.defaultSettings,
         animationMode: Camera.Mode.Move,
       },
       false,
     );
-    return this.defaultViewCamera;
+    return this.defaultCamera;
   }
 
   _createStopConfig(config = {}, ignoreFollowUserLocation = false) {
@@ -480,7 +520,7 @@ class Camera extends NativeBridgeComponent {
         stop={this._createStopConfig(props)}
         maxZoomLevel={this.props.maxZoomLevel}
         minZoomLevel={this.props.minZoomLevel}
-        defaultStop={this._createDefaultViewCamera()}
+        defaultStop={this._createDefaultCamera()}
         {...callbacks}
       />
     );

--- a/package.json
+++ b/package.json
@@ -44,11 +44,6 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-config-prettier": "^4.1.0",
-    "eslint-plugin-flowtype": "^3.4.2",
-    "eslint-plugin-fp": "^2.3.0",
-    "eslint-plugin-react-native": "^3.6.0",
     "@babel/core": "7.0.0",
     "@babel/plugin-proposal-class-properties": "7.4.4",
     "@babel/plugin-transform-exponentiation-operator": "7.2.0",
@@ -61,10 +56,16 @@
     "ejs": "^2.5.7",
     "ejs-lint": "^0.3.0",
     "eslint": "^5.3.0",
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-config-prettier": "^4.1.0",
     "eslint-config-strict-react": "9.0.2",
+    "eslint-plugin-flowtype": "^3.4.2",
+    "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "2.17.3",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "7.13.0",
+    "eslint-plugin-react-native": "^3.6.0",
+    "flow-bin": "^0.95.1",
     "husky": "^0.14.3",
     "jest": "24.8.0",
     "jest-cli": "^24.8.0",
@@ -73,10 +74,9 @@
     "node-dir": "0.1.17",
     "prettier": "^1.11.1",
     "react": "16.8.6",
-    "react-docgen": "2.18.0",
+    "react-docgen": "^5.0.0-beta.1",
     "react-native": "0.59.0",
-    "react-test-renderer": "16.8.3",
-    "flow-bin": "^0.95.1"
+    "react-test-renderer": "16.8.3"
   },
   "jest": {
     "preset": "react-native",

--- a/scripts/autogenHelpers/DocJSONBuilder.js
+++ b/scripts/autogenHelpers/DocJSONBuilder.js
@@ -89,11 +89,23 @@ class DocJSONBuilder {
       }
     }
 
-    // props
-    component.props = Object.keys(component.props).map((propName) => {
-      const propMeta = component.props[propName];
+    function mapNestedProp(propMeta) {
+      let result = {
+        type: {
+          name: propMeta.name,
+          value: propMeta.value,
+        },
+        description: propMeta.description,
+        required: propMeta.required,
+      };
+      if (propMeta.value) {
+        result.type.value = propMeta.value;
+      }
+      return result;
+    }
 
-      return {
+    function mapProp(propMeta, propName) {
+      var result =  {
         name: propName || 'FIX ME NO NAME',
         required: propMeta.required || false,
         type: (propMeta.type && propMeta.type.name) || 'FIX ME UNKNOWN TYPE',
@@ -102,6 +114,20 @@ class DocJSONBuilder {
           : propMeta.defaultValue.value.replace(/\n/g, ''),
         description: propMeta.description || 'FIX ME NO DESCRIPTION',
       };
+      if (propMeta.type && (propMeta.type.name === "shape") && propMeta.type.value) {
+        var type = propMeta.type.value;
+        var value =
+          Object.keys(type).map(propName => (mapProp(mapNestedProp(type[propName]), propName)));
+        result.type = { name: "shape", value };
+      }
+      return result;
+    }
+
+    // props
+    component.props = Object.keys(component.props).map((propName) => {
+      const propMeta = component.props[propName];
+
+      return mapProp(propMeta, propName);
     });
 
     // methods

--- a/scripts/autogenHelpers/globals.js
+++ b/scripts/autogenHelpers/globals.js
@@ -358,15 +358,26 @@ global.methodMarkdownTableRow = function(method) {
     .join('\n');
 };
 
-global.propMarkdownTableRows = function(component) {
-  return component.props
+function _propMarkdownTableRows(props, prefix = "") {
+  return props
     .map((prop) => {
-      return `| ${prop.name} | \`${prop.type}\` | \`${prop.default}\` | \`${
+      let type = prop.type;
+      if (typeof(type) === "object") {
+        type = type.name;
+      }
+      let result =  `| ${prefix}${prop.name} | \`${type}\` | \`${prop.default}\` | \`${
         prop.required
       }\` | ${replaceNewLine(prop.description)} |`;
+      if (type == "shape") {
+        result = `${result}\n${_propMarkdownTableRows(prop.type.value, `&nbsp;&nbsp;${prefix}`)}`
+      }
+      return result;
     })
     .join('\n');
 };
+global.propMarkdownTableRows = function (component) {
+  return _propMarkdownTableRows(component.props, "");
+}
 
 global.getMarkdownMethodSignature = function(method) {
   const params = method.params


### PR DESCRIPTION
`Camera` has `centerCoordinate` bounds `bounds`, `zoomLevel` for moving `Camera` around in a `MapView`. Ideally those would affect the current state of camera. 

In a lot of cases we'd just want to define where the map camera should be initially and later we'd follow user's location, or just let the user change camera, by pinch-zoom etc.

Right now we can set initial camera position by setting `centerCoordinate` and `zoomLevel` for example and specify `animationDuration={0}`. This however does not work if we set `followUserLocation`.

This proposal would add a new `defaultSettings` like this:
```js
<MapView>
  <Camera
      defaultSettings={{
        centerCoordinate: [-111.8678, 40.2866],
        zoomLevel: 16,
      }}
      followUserLocation
      followUserMode="normal"
   />
</MapView>
```

If we use an analogy of `Camera` is like a `TextInput` component, then `bounds`,`centerCoordinate` etc would be like for `value` for `TextInput`. 
For that analogy `Camera` new `defaultSettings` would be same as `defaultValue`  in `TextInput`.


I'm a bit unsure if it's simplifies usage or just makes it more complex. Alertnative would be allowing `centerCoordinate` et all to work even if `followUserLocation` is set.

Fixes: #55


