### PR TITLE
Added support for bounds with flight/ease camera animations

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/CameraUpdateItem.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/CameraUpdateItem.java
@@ -3,6 +3,7 @@ package com.mapbox.rctmgl.components.camera;
 import android.support.annotation.NonNull;
 
 import com.mapbox.mapboxsdk.camera.CameraUpdate;
+import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.rctmgl.components.camera.constants.CameraMode;
 
@@ -63,12 +64,20 @@ public class CameraUpdateItem implements RunnableFuture<Void> {
             return;
         }
 
-        if (mCameraMode == CameraMode.FLIGHT && mDuration > 0) {
-            map.animateCamera(mCameraUpdate, mDuration, callback);
-        } else if (mCameraMode == CameraMode.EASE) {
-            map.easeCamera(mCameraUpdate, mDuration, callback);
-        } else {
+        // animateCamera / easeCamera only allows positive duration
+        if (mDuration == 0 || mCameraMode == CameraMode.NONE) {
             map.moveCamera(mCameraUpdate, callback);
+            return;
+        }
+
+        // On iOS a duration of -1 means default or dynamic duration (based on flight-path length)
+        // On Android we can fallback to Mapbox's default duration as there is no such API
+        int duration = mDuration < 0 ? MapboxConstants.ANIMATION_DURATION : mDuration;
+
+        if (mCameraMode == CameraMode.FLIGHT) {
+            map.animateCamera(mCameraUpdate, duration, callback);
+        } else if (mCameraMode == CameraMode.EASE) {
+            map.easeCamera(mCameraUpdate, duration, callback);
         }
     }
 

--- a/ios/RCTMGL/CameraStop.h
+++ b/ios/RCTMGL/CameraStop.h
@@ -14,15 +14,12 @@
 @property (nonatomic, strong) NSNumber *pitch;
 @property (nonatomic, strong) NSNumber *heading;
 @property (nonatomic, strong) NSNumber *zoom;
-@property (nonatomic, strong) NSNumber *boundsPaddingLeft;
-@property (nonatomic, strong) NSNumber *boundsPaddingRight;
-@property (nonatomic, strong) NSNumber *boundsPaddingTop;
-@property (nonatomic, strong) NSNumber *boundsPaddingBottom;
 @property (nonatomic, strong) NSNumber *mode;
 @property (nonatomic, assign) NSTimeInterval duration;
 
 @property (nonatomic, assign) CLLocationCoordinate2D coordinate;
 @property (nonatomic, assign) MGLCoordinateBounds bounds;
+@property (nonatomic, assign) UIEdgeInsets boundsPadding;
 
 + (CameraStop*)fromDictionary:(NSDictionary*)args;
 

--- a/ios/RCTMGL/CameraStop.m
+++ b/ios/RCTMGL/CameraStop.m
@@ -53,21 +53,11 @@
     if (args[@"bounds"]) {
         stop.bounds = [RCTMGLUtils fromFeatureCollection:args[@"bounds"]];
         
-        if (args[@"boundsPaddingLeft"]) {
-            stop.boundsPaddingLeft = args[@"boundsPaddingLeft"];
-        }
-        
-        if (args[@"boundsPaddingRight"]) {
-            stop.boundsPaddingRight = args[@"boundsPaddingRight"];
-        }
-        
-        if (args[@"boundsPaddingTop"]) {
-            stop.boundsPaddingTop = args[@"boundsPaddingTop"];
-        }
-        
-        if (args[@"boundsPaddingBottom"]) {
-            stop.boundsPaddingBottom = args[@"boundsPaddingBottom"];
-        }
+        CGFloat paddingTop = args[@"boundsPaddingTop"] ? [args[@"boundsPaddingTop"] floatValue] : 0.0;
+        CGFloat paddingRight = args[@"boundsPaddingRight"] ? [args[@"boundsPaddingRight"] floatValue] : 0.0;
+        CGFloat paddingBottom = args[@"boundsPaddingBottom"] ? [args[@"boundsPaddingBottom"] floatValue] : 0.0;
+        CGFloat paddingLeft = args[@"boundsPaddingLeft"] ? [args[@"boundsPaddingLeft"] floatValue] : 0.0;
+        stop.boundsPadding = UIEdgeInsetsMake(paddingTop, paddingLeft, paddingBottom, paddingRight);
     }
     
     NSTimeInterval duration = 2.0;

--- a/ios/RCTMGL/CameraUpdateItem.m
+++ b/ios/RCTMGL/CameraUpdateItem.m
@@ -13,12 +13,12 @@
 
 - (void)execute:(RCTMGLMapView *)mapView withCompletionHandler:(void (^)(void))completionHandler
 {
-    if ([self _areBoundsValid:_cameraStop.bounds]) {
-        [self _fitBoundsCamera:mapView withCompletionHandler:completionHandler];
-    } else if (_cameraStop.mode == [NSNumber numberWithInt:RCT_MAPBOX_CAMERA_MODE_FLIGHT]) {
+    if (_cameraStop.mode == [NSNumber numberWithInt:RCT_MAPBOX_CAMERA_MODE_FLIGHT]) {
         [self _flyToCamera:mapView withCompletionHandler:completionHandler];
     } else if (_cameraStop.mode == [NSNumber numberWithInt:RCT_MAPBOX_CAMERA_MODE_EASE]) {
         [self _moveCamera:mapView animated:YES withCompletionHandler:completionHandler];
+    } else if ([self _areBoundsValid:_cameraStop.bounds]) {
+        [self _fitBoundsCamera:mapView withCompletionHandler:completionHandler];
     } else {
         [self _moveCamera:mapView animated:NO withCompletionHandler:completionHandler];
     }
@@ -47,11 +47,6 @@
 - (void)_fitBoundsCamera:(RCTMGLMapView*)mapView withCompletionHandler:(void (^)(void))completionHandler
 {
     MGLCoordinateBounds bounds = _cameraStop.bounds;
-    CGFloat paddingTop = [_cameraStop.boundsPaddingTop floatValue];
-    CGFloat paddingRight = [_cameraStop.boundsPaddingRight floatValue];
-    CGFloat paddingBottom = [_cameraStop.boundsPaddingBottom floatValue];
-    CGFloat paddingLeft = [_cameraStop.boundsPaddingLeft floatValue];
-    
     CLLocationCoordinate2D coordinates[] = {
         { bounds.ne.latitude, bounds.sw.longitude },
         bounds.sw,
@@ -61,7 +56,7 @@
 
     [mapView setVisibleCoordinates:coordinates
              count:4
-             edgePadding:UIEdgeInsetsMake(paddingTop, paddingLeft, paddingBottom, paddingRight)
+             edgePadding:_cameraStop.boundsPadding
              direction:mapView.direction
              duration:_cameraStop.duration
              animationTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut]
@@ -94,6 +89,10 @@
     
     if ([self _isCoordValid:_cameraStop.coordinate]) {
         nextCamera.centerCoordinate = _cameraStop.coordinate;
+    } else if ([self _areBoundsValid:_cameraStop.bounds]) {
+        MGLMapCamera *boundsCamera = [mapView camera:_cameraStop fittingCoordinateBounds:_cameraStop.bounds edgePadding: _cameraStop.boundsPadding];
+        nextCamera.centerCoordinate = boundsCamera.centerCoordinate;
+        nextCamera.altitude = boundsCamera.altitude;
     }
     
     if (_cameraStop.zoom != nil) {


### PR DESCRIPTION
This PR adds support for using `bounds` when updating camera with `Flight` or `Ease` animation mode.

Fixes:
- iOS: Always used `Move` when `bounds` was provided, regardless of `animationMode`
- Android: Always  used `Flight` when bounds was provided, regardless of `animationMode`
- Android: Wasn't able to handle negative animationDuration. On iOS this adds [specific behavior](https://docs.mapbox.com/ios/api/maps/5.1.0/Classes/MGLMapView.html#/c:objc(cs)MGLMapView(im)flyToCamera:withDuration:completionHandler:) to flight mode camera updates.
- Android: In the process of testing the two animation modes with `bounds` I also found that Android behaved incorrectly when combing the update with `pitch` and `bearing`. In order for Android to correctly use `bounds` + `pitch` / `bearing` I updated the way we determine target camera position by using [`getCameraForLatLngBounds`](https://docs.mapbox.com/android/api/map-sdk/8.1.0/com/mapbox/mapboxsdk/maps/MapboxMap.html#getCameraForLatLngBounds-com.mapbox.mapboxsdk.geometry.LatLngBounds-int:A-double-double-) that takes into account `pitch` + `heading`. For iOS this wasn't needed as it already animated as expected.