### PR TITLE
Added extraSprites prop to MapView (Reworked how images are passed to RNMBGL)

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -5,6 +5,7 @@ import android.view.View;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -161,6 +162,12 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     public void setContentInset(RCTMGLMapView mapView, ReadableArray array) {
         mapView.setReactContentInset(array);
     }
+
+    @ReactProp(name="extraSprites")
+    public void setExtraSprites(RCTMGLMapView mapView, ReadableMap extraSprites) {
+        mapView.setReactExtraSprites(extraSprites);
+    }
+
 
     //endregion
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyle.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyle.java
@@ -58,26 +58,4 @@ public class RCTMGLStyle {
 
         return new RCTMGLStyleValue(styleValueConfig);
     }
-
-    public void addImage(RCTMGLStyleValue styleValue) {
-        addImage(styleValue, null);
-    }
-
-    public ImageEntry imageEntry(RCTMGLStyleValue styleValue) {
-        return new ImageEntry(styleValue.getImageURI(), styleValue.getImageScale());
-    }
-
-    public void addImage(RCTMGLStyleValue styleValue, DownloadMapImageTask.OnAllImagesLoaded callback) {
-        if (!styleValue.shouldAddImage()) {
-            if (callback != null) {
-                callback.onAllImagesLoaded();
-            }
-            return;
-        }
-
-        String uriStr = styleValue.getImageURI();
-        Map.Entry[] images = new Map.Entry[]{ new AbstractMap.SimpleEntry(uriStr, imageEntry(styleValue)) };
-        DownloadMapImageTask task = new DownloadMapImageTask(mContext, mMap, callback);
-        task.execute(images);
-    }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
@@ -17,13 +17,11 @@ import com.mapbox.mapboxsdk.style.layers.HillshadeLayer;
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.style.light.Light;
 import com.mapbox.mapboxsdk.style.light.Position;
-import com.mapbox.rctmgl.utils.DownloadMapImageTask;
 
 import java.util.List;
 
 public class RCTMGLStyleFactory {
     public static final String VALUE_KEY = "value";
-    public static final String SHOULD_ADD_IMAGE_KEY = "shouldAddImage";
 
     public static void setFillLayerStyle(final FillLayer layer, RCTMGLStyle style) {
       List<String> styleKeys = style.getAllStyleKeys();
@@ -70,12 +68,7 @@ public class RCTMGLStyleFactory {
               RCTMGLStyleFactory.setFillTranslateAnchor(layer, styleValue);
               break;
             case "fillPattern":
-              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
-                  @Override
-                  public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.setFillPattern(layer, styleValue);
-                  }
-              });
+              RCTMGLStyleFactory.setFillPattern(layer, styleValue);
               break;
             case "fillPatternTransition":
               RCTMGLStyleFactory.setFillPatternTransition(layer, styleValue);
@@ -161,12 +154,7 @@ public class RCTMGLStyleFactory {
               RCTMGLStyleFactory.setLineDasharrayTransition(layer, styleValue);
               break;
             case "linePattern":
-              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
-                  @Override
-                  public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.setLinePattern(layer, styleValue);
-                  }
-              });
+              RCTMGLStyleFactory.setLinePattern(layer, styleValue);
               break;
             case "linePatternTransition":
               RCTMGLStyleFactory.setLinePatternTransition(layer, styleValue);
@@ -222,12 +210,7 @@ public class RCTMGLStyleFactory {
               RCTMGLStyleFactory.setIconTextFitPadding(layer, styleValue);
               break;
             case "iconImage":
-              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
-                  @Override
-                  public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.setIconImage(layer, styleValue);
-                  }
-              });
+              RCTMGLStyleFactory.setIconImage(layer, styleValue);
               break;
             case "iconRotate":
               RCTMGLStyleFactory.setIconRotate(layer, styleValue);
@@ -539,12 +522,7 @@ public class RCTMGLStyleFactory {
               RCTMGLStyleFactory.setFillExtrusionTranslateAnchor(layer, styleValue);
               break;
             case "fillExtrusionPattern":
-              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
-                  @Override
-                  public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.setFillExtrusionPattern(layer, styleValue);
-                  }
-              });
+              RCTMGLStyleFactory.setFillExtrusionPattern(layer, styleValue);
               break;
             case "fillExtrusionPatternTransition":
               RCTMGLStyleFactory.setFillExtrusionPatternTransition(layer, styleValue);
@@ -691,12 +669,7 @@ public class RCTMGLStyleFactory {
               RCTMGLStyleFactory.setBackgroundColorTransition(layer, styleValue);
               break;
             case "backgroundPattern":
-              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
-                  @Override
-                  public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.setBackgroundPattern(layer, styleValue);
-                  }
-              });
+              RCTMGLStyleFactory.setBackgroundPattern(layer, styleValue);
               break;
             case "backgroundPatternTransition":
               RCTMGLStyleFactory.setBackgroundPatternTransition(layer, styleValue);
@@ -834,7 +807,7 @@ public class RCTMGLStyleFactory {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.fillPattern(styleValue.getExpression()));
       } else {
-        layer.setProperties(PropertyFactory.fillPattern(styleValue.getImageURI()));
+        layer.setProperties(PropertyFactory.fillPattern(styleValue.getString(VALUE_KEY)));
       }
     }
 
@@ -1022,7 +995,7 @@ public class RCTMGLStyleFactory {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.linePattern(styleValue.getExpression()));
       } else {
-        layer.setProperties(PropertyFactory.linePattern(styleValue.getImageURI()));
+        layer.setProperties(PropertyFactory.linePattern(styleValue.getString(VALUE_KEY)));
       }
     }
 
@@ -1134,7 +1107,7 @@ public class RCTMGLStyleFactory {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.iconImage(styleValue.getExpression()));
       } else {
-        layer.setProperties(PropertyFactory.iconImage(styleValue.getImageURI()));
+        layer.setProperties(PropertyFactory.iconImage(styleValue.getString(VALUE_KEY)));
       }
     }
 
@@ -1838,7 +1811,7 @@ public class RCTMGLStyleFactory {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getExpression()));
       } else {
-        layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getImageURI()));
+        layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getString(VALUE_KEY)));
       }
     }
 
@@ -2106,7 +2079,7 @@ public class RCTMGLStyleFactory {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getExpression()));
       } else {
-        layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getImageURI()));
+        layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getString(VALUE_KEY)));
       }
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleValue.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleValue.java
@@ -24,10 +24,6 @@ public class RCTMGLStyleValue {
     private Expression mExpression;
     private ReadableMap mPayload;
 
-    private String imageURI = "";
-    private boolean isAddImage;
-    private Double imageScale = 1.0;
-
     public static final int InterpolationModeExponential = 100;
     public static final int InterpolationModeInterval = 101;
     public static final int InterpolationModeCategorical = 102;
@@ -36,21 +32,6 @@ public class RCTMGLStyleValue {
     public RCTMGLStyleValue(@NonNull ReadableMap config) {
         mType = config.getString("styletype");
         mPayload = config.getMap("stylevalue");
-
-        if ("image".equals(mType)) {
-            imageScale = 1.0;
-            if ("hashmap".equals(mPayload.getString("type"))) {
-                ReadableMap map = getMap();
-                imageURI = map.getMap("uri").getString("value");
-                if (map.getMap("scale") != null) {
-                    imageScale = map.getMap("scale").getDouble("value");
-                }
-            } else {
-                imageURI = mPayload.getString("value");
-            }
-            isAddImage = imageURI != null;
-            return;
-        }
 
         Dynamic dynamic = mPayload.getDynamic("value");
         if (dynamic.getType().equals(ReadableType.Array)) {
@@ -152,18 +133,6 @@ public class RCTMGLStyleValue {
 
     public boolean isExpression() {
         return isExpression;
-    }
-
-    public boolean shouldAddImage() {
-        return isAddImage;
-    }
-
-    public String getImageURI() {
-        return imageURI;
-    }
-
-    public double getImageScale() {
-        return imageScale;
     }
 
     public TransitionOptions getTransition() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/Sprite.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/Sprite.java
@@ -1,0 +1,46 @@
+package com.mapbox.rctmgl.utils;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.util.Log;
+
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+import java.lang.ref.WeakReference;
+import java.util.AbstractMap;
+import java.util.Map;
+
+public class Sprite {
+    public static final String LOG_TAG = Sprite.class.getSimpleName();
+    private String name;
+    private String url;
+
+    public Sprite(String name, String url) {
+        this.name = name;
+        this.url = url;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void load(Context context, MapboxMap map) {
+        double scale =  context.getResources().getDisplayMetrics().density;
+        ImageEntry imageEntry = new ImageEntry(url, scale);
+        Map.Entry[] images = new Map.Entry[]{ new AbstractMap.SimpleEntry<String, ImageEntry>(name, imageEntry) };
+        final WeakReference<MapboxMap> weakMap = new WeakReference<>(map);
+        DownloadMapImageTask task = new DownloadMapImageTask(context, map, new DownloadMapImageTask.OnAllImagesLoaded() {
+            @Override
+            public void onAllImagesLoaded() {
+                if (weakMap.get() != null && weakMap.get().getStyle() == null) {
+                    Log.w(LOG_TAG,"Tried to load extra sprite " + getName() +" before style loaded");
+                }
+            }
+        });
+        task.execute(images);
+    }
+}

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -10,6 +10,7 @@
 | contentInset | `union` | `none` | `false` | The distance from the edges of the map view’s frame to the edges of the map view’s logical viewport. |
 | style | `any` | `none` | `false` | Style for wrapping React Native View |
 | styleURL | `string` | `MapboxGL.StyleURL.Street` | `false` | Style URL for map |
+| extraSprites | `object` | `null` | `false` | Define extra images that can be referenced by name in the style JSON (keys are names and values are URIs or the image identifiers that RN returns when importing a static image via `import` or `require()`) | 
 | localizeLabels | `bool` | `false` | `false` | Automatically change the language of the map labels to the system’s preferred language,<br/>this is not something that can be toggled on/off |
 | zoomEnabled | `bool` | `none` | `false` | Enable/Disable zoom on the map |
 | scrollEnabled | `bool` | `true` | `false` | Enable/Disable scroll on the map |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2572,6 +2572,13 @@
         "description": "Style URL for map"
       },
       {
+        "name": "extraSprites",
+        "required": false,
+        "type": "object",
+        "default": "null",
+        "description": "Define extra images that can be referenced by name in the style JSON (keys are names and values are URIs or the image identifiers that RN returns when importing a static image via `import` or `require()`)"
+      },
+      {
         "name": "localizeLabels",
         "required": false,
         "type": "bool",

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -24,6 +24,14 @@
 
 typedef void (^FoundLayerBlock) (MGLStyleLayer* layer);
 
+@interface RCTMGLSprite : NSObject
+
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy) NSString *url;
+@property (nonatomic, strong) UIImage *image;
+
+@end
+
 @interface RCTMGLMapView : MGLMapView<RCTInvalidating>
 
 @property (nonatomic, strong) CameraUpdateQueue *cameraUpdateQueue;
@@ -33,6 +41,7 @@ typedef void (^FoundLayerBlock) (MGLStyleLayer* layer);
 @property (nonatomic, strong) NSMutableArray<RCTMGLPointAnnotation*> *pointAnnotations;
 @property (nonatomic, strong) RCTMGLLight *light;
 @property (nonatomic, copy) NSArray<NSNumber *> *reactContentInset;
+@property (nonatomic, strong, readonly) NSMutableDictionary<NSString*, RCTMGLSprite*> *extraSprites;
 
 @property (nonatomic, strong) NSMutableDictionary<NSString*, NSMutableArray<FoundLayerBlock>*> *layerWaiters;
 

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -12,6 +12,9 @@
 #import "RNMBImageUtils.h"
 #import "UIView+React.h"
 
+@implementation RCTMGLSprite
+@end
+
 @implementation RCTMGLMapView
 {
     BOOL _pendingInitialLayout;
@@ -32,6 +35,7 @@ static double const M2PI = M_PI * 2;
         _pointAnnotations = [[NSMutableArray alloc] init];
         _reactSubviews = [[NSMutableArray alloc] init];
         _layerWaiters = [[NSMutableDictionary alloc] init];
+        _extraSprites = [[NSMutableDictionary alloc] init];
     }
     return self;
 }

--- a/ios/RCTMGL/RCTMGLStyle.m
+++ b/ios/RCTMGL/RCTMGLStyle.m
@@ -53,20 +53,7 @@
     } else if ([prop isEqualToString:@"fillTranslateAnchor"]) {
       [self setFillTranslateAnchor:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"fillPattern"]) {
-      if (![styleValue shouldAddImage]) {
-        [self setFillPattern:layer withReactStyleValue:styleValue];
-      } else {
-        NSString *imageURI = [styleValue getImageURI];
-
-        [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
-          if (image != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-              [_style setImage:image forName:imageURI];
-              [self setFillPattern:layer withReactStyleValue:styleValue];
-            });
-          }
-        }];
-      }
+      [self setFillPattern:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"fillPatternTransition"]) {
       [self setFillPatternTransition:layer withReactStyleValue:styleValue];
     } else {
@@ -135,20 +122,7 @@
     } else if ([prop isEqualToString:@"lineDasharrayTransition"]) {
       [self setLineDasharrayTransition:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"linePattern"]) {
-      if (![styleValue shouldAddImage]) {
-        [self setLinePattern:layer withReactStyleValue:styleValue];
-      } else {
-        NSString *imageURI = [styleValue getImageURI];
-
-        [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
-          if (image != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-              [_style setImage:image forName:imageURI];
-              [self setLinePattern:layer withReactStyleValue:styleValue];
-            });
-          }
-        }];
-      }
+      [self setLinePattern:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"linePatternTransition"]) {
       [self setLinePatternTransition:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"lineGradient"]) {
@@ -197,20 +171,7 @@
     } else if ([prop isEqualToString:@"iconTextFitPadding"]) {
       [self setIconTextFitPadding:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"iconImage"]) {
-      if (![styleValue shouldAddImage]) {
-        [self setIconImage:layer withReactStyleValue:styleValue];
-      } else {
-        NSString *imageURI = [styleValue getImageURI];
-
-        [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
-          if (image != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-              [_style setImage:image forName:imageURI];
-              [self setIconImage:layer withReactStyleValue:styleValue];
-            });
-          }
-        }];
-      }
+      [self setIconImage:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"iconRotate"]) {
       [self setIconRotate:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"iconPadding"]) {
@@ -453,20 +414,7 @@
     } else if ([prop isEqualToString:@"fillExtrusionTranslateAnchor"]) {
       [self setFillExtrusionTranslateAnchor:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"fillExtrusionPattern"]) {
-      if (![styleValue shouldAddImage]) {
-        [self setFillExtrusionPattern:layer withReactStyleValue:styleValue];
-      } else {
-        NSString *imageURI = [styleValue getImageURI];
-
-        [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
-          if (image != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-              [_style setImage:image forName:imageURI];
-              [self setFillExtrusionPattern:layer withReactStyleValue:styleValue];
-            });
-          }
-        }];
-      }
+      [self setFillExtrusionPattern:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"fillExtrusionPatternTransition"]) {
       [self setFillExtrusionPatternTransition:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"fillExtrusionHeight"]) {
@@ -599,20 +547,7 @@
     } else if ([prop isEqualToString:@"backgroundColorTransition"]) {
       [self setBackgroundColorTransition:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"backgroundPattern"]) {
-      if (![styleValue shouldAddImage]) {
-        [self setBackgroundPattern:layer withReactStyleValue:styleValue];
-      } else {
-        NSString *imageURI = [styleValue getImageURI];
-
-        [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
-          if (image != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-              [_style setImage:image forName:imageURI];
-              [self setBackgroundPattern:layer withReactStyleValue:styleValue];
-            });
-          }
-        }];
-      }
+      [self setBackgroundPattern:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"backgroundPatternTransition"]) {
       [self setBackgroundPatternTransition:layer withReactStyleValue:styleValue];
     } else if ([prop isEqualToString:@"backgroundOpacity"]) {

--- a/ios/RCTMGL/RCTMGLStyleValue.h
+++ b/ios/RCTMGL/RCTMGLStyleValue.h
@@ -15,9 +15,6 @@
 @property (nonatomic, strong) NSDictionary *rawStyleValue;
 @property (nonatomic, readonly) NSExpression *mglStyleValue;
 
-- (BOOL)shouldAddImage;
-- (NSString *)getImageURI;
-- (double)getImageScale;
 - (MGLTransition)getTransition;
 - (NSExpression *)getSphericalPosition;
 - (BOOL)isVisible;

--- a/ios/RCTMGL/RCTMGLStyleValue.m
+++ b/ios/RCTMGL/RCTMGLStyleValue.m
@@ -8,7 +8,6 @@
 
 #import "RCTMGLStyleValue.h"
 #import "RCTMGLUtils.h"
-#import <React/RCTImageLoader.h>
 
 @implementation RCTMGLStyleValue
 {
@@ -27,8 +26,6 @@
     } else if ([_styleType isEqualToString:@"vector"] && [expressionJSON respondsToSelector:@selector(objectEnumerator)] && [[[(NSArray*)expressionJSON objectEnumerator] nextObject] isKindOfClass:[NSNumber class]]) {
         CGVector vector = [RCTMGLUtils toCGVector:(NSArray<NSNumber *> *)expressionJSON];
         return [NSExpression expressionWithMGLJSONObject:[NSValue valueWithCGVector:vector]];
-    } else if ([_styleType isEqualToString:@"image"] && [expressionJSON isKindOfClass:[NSDictionary class]]) {
-        return [NSExpression expressionForConstantValue:[self getImageURI]];
     } else if ([_styleType isEqual:@"edgeinsets"] && [expressionJSON respondsToSelector:@selector(objectEnumerator)] && [[[(NSArray*)expressionJSON objectEnumerator] nextObject] isKindOfClass:[NSNumber class]]){
         UIEdgeInsets edgeInsets = [RCTMGLUtils toUIEdgeInsets:(NSArray<NSNumber *> *)expressionJSON];
         return [NSExpression expressionWithMGLJSONObject:[NSValue valueWithUIEdgeInsets:edgeInsets]];
@@ -83,38 +80,6 @@
     }
     
     return object;
-}
-
-
-
-- (BOOL)shouldAddImage
-{
-    NSString *imageURI = [self getImageURI];
-    
-    return [imageURI containsString:@"://"];
-}
-
-- (NSString *)getImageURI
-{
-    if ([expressionJSON isKindOfClass:[NSDictionary class]]) {
-        return [expressionJSON valueForKey:@"uri"];
-    } else {
-        return (NSString *)expressionJSON;
-    }
-}
-
-- (double)getImageScale
-{
-    if ([expressionJSON isKindOfClass:[NSDictionary class]]) {
-        id scale = [expressionJSON valueForKey:@"scale"];
-        if ([scale isKindOfClass:[NSNumber class]]) {
-            return [scale doubleValue];
-        } else {
-            return 1.0;
-        }
-    } else {
-        return 1.0;
-    }
 }
 
 - (MGLTransition)getTransition

--- a/javascript/components/AbstractLayer.js
+++ b/javascript/components/AbstractLayer.js
@@ -1,7 +1,6 @@
 /* eslint react/prop-types:0  */
 import React from 'react';
 import {processColor} from 'react-native';
-import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 
 import {getFilter} from '../utils/filterUtils';
 import {getStyleType} from '../utils/styleMap';
@@ -43,8 +42,6 @@ class AbstractLayer extends React.PureComponent {
 
       if (styleType === 'color' && typeof rawStyle === 'string') {
         rawStyle = processColor(rawStyle);
-      } else if (styleType === 'image' && typeof rawStyle === 'number') {
-        rawStyle = resolveAssetSource(rawStyle) || {};
       }
 
       const bridgeValue = new BridgeValue(rawStyle);

--- a/scripts/autogenHelpers/globals.js
+++ b/scripts/autogenHelpers/globals.js
@@ -185,11 +185,7 @@ global.androidGetConfigType = function(androidType, prop) {
     case 'String[]':
       return 'styleValue.getStringArray(VALUE_KEY)';
     default:
-      if (prop && prop.image) {
-        return 'styleValue.getImageURI()';
-      } else {
-        return 'styleValue.getString(VALUE_KEY)';
-      }
+      return 'styleValue.getString(VALUE_KEY)';
   }
 };
 

--- a/scripts/templates/RCTMGLStyle.m.ejs
+++ b/scripts/templates/RCTMGLStyle.m.ejs
@@ -35,24 +35,7 @@
 
   <% for (let i = 0; i < layer.properties.length; i++) { -%>
   <%- ifOrElseIf(i) -%> ([prop isEqualToString:@"<%= layer.properties[i].name %>"]) {
-  <%_ if (layer.properties[i].image) { _%>
-      if (![styleValue shouldAddImage]) {
-        [self set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>:layer withReactStyleValue:styleValue];
-      } else {
-        NSString *imageURI = [styleValue getImageURI];
-
-        [RCTMGLUtils fetchImage:_bridge url:imageURI scale:[styleValue getImageScale] callback:^(NSError *error, UIImage *image) {
-          if (image != nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-              [_style setImage:image forName:imageURI];
-              [self set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>:layer withReactStyleValue:styleValue];
-            });
-          }
-        }];
-      }
-  <%_ } else { _%>
       [self set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>:layer withReactStyleValue:styleValue];
-  <%_ } _%>
   <%_ if (layer.properties[i].transition) { _%>
     } else if ([prop isEqualToString:@"<%= layer.properties[i].name %>Transition"]) {
       [self set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>Transition:layer withReactStyleValue:styleValue];

--- a/scripts/templates/RCTMGLStyleFactory.java.ejs
+++ b/scripts/templates/RCTMGLStyleFactory.java.ejs
@@ -20,13 +20,11 @@ import com.mapbox.mapboxsdk.style.layers.HillshadeLayer;
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.style.light.Light;
 import com.mapbox.mapboxsdk.style.light.Position;
-import com.mapbox.rctmgl.utils.DownloadMapImageTask;
 
 import java.util.List;
 
 public class RCTMGLStyleFactory {
     public static final String VALUE_KEY = "value";
-    public static final String SHOULD_ADD_IMAGE_KEY = "shouldAddImage";
 
   <%_ for (const layer of layers) { _%>
     public static void <%- setLayerMethodName(layer) -%>(final <%- getLayerType(layer, 'android') -%> layer, RCTMGLStyle style) {
@@ -42,16 +40,7 @@ public class RCTMGLStyleFactory {
         switch (styleKey) {
           <%_ for (const prop of layer.properties) { _%>
             case "<%= prop.name %>":
-              <%_ if (prop.image) { _%>
-              style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
-                  @Override
-                  public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.set<%- pascelCase(prop.name) -%>(layer, styleValue);
-                  }
-              });
-              <%_ } else { _%>
               RCTMGLStyleFactory.set<%- pascelCase(prop.name) -%>(layer, styleValue);
-              <%_ } _%>
               break;
             <%_ if (prop.transition) { _%>
             case "<%= prop.name %>Transition":


### PR DESCRIPTION
## What it Does 
This PR improves how images are registered with react-native-mapbox-gl by providing a new `extraSprites` prop on the `MapView` component and deprecating including image URLs (and ids) directly in the styles.

## The Problems it Solves 

The current allowed method of registering images with react-native-mapbox-gl is something like:

```js
import airportIcon from './icons/airportIcon.png';

const iconStyle = {
	iconImage: airportIcon
};

// render method
class MyMap extends React.Component {
	render() {
		return <MapboxGL.MapView styleURL="">
			<MapboxGL.VectorSource>
				<MapboxGL.SymbolLayer style={iconStyle}/>
			</MapboxGL.VectorSource>
		</MapboxGL.MapView>;
	}
}
```

This has a number of issues:
1. Using an image from the style's spritesheet by name is not allowed, because RNMBGL thinks strings and numbers are all URIs that need to be fetched.
2. If you want to use an expression for a prop like `iconImage` it can only reference images in the style's spritesheet because RNMBGL only loads images if `iconImage` is set to a number or string. Traversing an expression for URLs and loading them is a bad idea.
3. If you want to let the data decide what custom icon (that is not in the styles original spritesheet) to use (eg. `iconImage: ['get', 'icon']`), you can't, because RNMBGL requires the image URLs to be in the style.)

## Example of How it Works
This PR fixes all of that by decoupling image loading from the styles by adding an `extraSprites` property to the MapView.

```js
import airportIcon from './icons/airportIcon.png';

const extraSprites = {
	airport: airportIcon
}; 

const iconStyle = {
	iconImage: 'airport' // or ['get', 'icon'], or ['match', ['get', 'class'], 'aeroway', 'airport', ''], ...
};

class MyMap extends React.Component {
	render() {
		return <MapboxGL.MapView styleURL="" extraSprites={extraSprites}>
			<MapboxGL.VectorSource>
				<MapboxGL.SymbolLayer style={iconStyle}/>
			</MapboxGL.VectorSource>
		</MapboxGL.MapView>;
	}
}
```

This is a breaking change, but I think it is important enough that it would be great if it could make it into 7.0.0. Going forward with image handling for the library, I think it is best to go with something like this which is simple, less brittle, and closer to how the native SDK supports custom images.