### PR TITLE
Improved stability of offline manager

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -199,6 +199,9 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
                     return;
                 }
 
+                // stop download before deleting (https://github.com/mapbox/mapbox-gl-native/issues/12382#issuecomment-431055103)
+                region.setDownloadState(INACTIVE_REGION_DOWNLOAD_STATE);
+
                 region.delete(new OfflineRegion.OfflineRegionDeleteCallback() {
                     @Override
                     public void onDelete() {


### PR DESCRIPTION
When deleting offline packs you can run into some hard crashes if you try to delete an offline pack that has already been deleted or that is still downloading. Obscure crashes can also happen when sending progress events for offline packs that are in an invalid state.

This PR puts more checks in place so that these cases are handled more gracefully. We have been using these checks in production and have seen an increase in stability.