### PR TITLE
Fixed crash on android if RasterSource.tileSize is null

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLRasterSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLRasterSource.java
@@ -28,7 +28,8 @@ public class RCTMGLRasterSource extends RCTSource<RasterSource> {
 
     @Override
     public RasterSource makeSource() {
-        return new RasterSource(mID, buildTileset(), mTileSize == null ? 256 : mTileSize);
+        if (mTileSize == null) return new RasterSource(mID, buildTileset());
+        return new RasterSource(mID, buildTileset(), mTileSize);
     }
 
     public void setURL(String url) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLRasterSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLRasterSource.java
@@ -28,7 +28,7 @@ public class RCTMGLRasterSource extends RCTSource<RasterSource> {
 
     @Override
     public RasterSource makeSource() {
-        return new RasterSource(mID, buildTileset(), mTileSize);
+        return new RasterSource(mID, buildTileset(), mTileSize == null ? 256 : mTileSize);
     }
 
     public void setURL(String url) {


### PR DESCRIPTION
`tileSize` is an optional property for react-native-mapbox-gl, but android apps will crash if it is not set.

How it happens: 
1. `mTileSize` (java.lang.Integer) is null
2. in `makeSource()` it gets implicitly casted to a native int when constructing the new RasterSource
3. this implicit cast calls java.lang.Integer.intValue on a null pointer