### PR TITLE
Fixed setTelemetryEnabled argument type (should be literal not pointer)

### DIFF
--- a/ios/RCTMGL/MGLModule.m
+++ b/ios/RCTMGL/MGLModule.m
@@ -253,7 +253,7 @@ RCT_EXPORT_METHOD(getAccessToken:(RCTPromiseResolveBlock)resolve rejecter:(RCTPr
     reject(@"missing_access_token", @"No access token has been set", nil);
 }
 
-RCT_EXPORT_METHOD(setTelemetryEnabled:(BOOL *)telemetryEnabled)
+RCT_EXPORT_METHOD(setTelemetryEnabled:(BOOL)telemetryEnabled)
 {
     [[NSUserDefaults standardUserDefaults] setBool:telemetryEnabled
                                             forKey:@"MGLMapboxMetricsEnabled"];


### PR DESCRIPTION
The argument type for setTelemetryEnabled on iOS should be a `BOOL` instead of a `BOOL *`. It worked as it was because ultimately both bools and pointers are just integers which can either be 0 or non-zero, but this is more clear at least. 