### PR TITLE
Fix for SymbolLayer Filter Being Removed When Runtime Styling (iOS)

### DIFF
--- a/ios/RCTMGL/RCTMGLLayer.h
+++ b/ios/RCTMGL/RCTMGLLayer.h
@@ -22,7 +22,7 @@
 @property (nonatomic, strong) MGLStyle *style;
 @property (nonatomic, weak) RCTMGLMapView* map;
 @property (nonatomic, strong) NSDictionary *reactStyle;
-@property (nonatomic, strong) NSArray<NSDictionary<NSString *, id> *> *filter;
+@property (nonatomic, strong) NSArray *filter;
 
 @property (nonatomic, copy) NSString *id;
 @property (nonatomic, copy) NSString *sourceID;

--- a/ios/RCTMGL/RCTMGLLayer.m
+++ b/ios/RCTMGL/RCTMGLLayer.m
@@ -72,14 +72,15 @@
     }
 }
 
-- (void)setFilter:(NSArray<NSDictionary<NSString *,id> *> *)filter
+- (void)setFilter:(NSArray *)filter
 {
     _filter = filter;
     
     if (_styleLayer != nil) {
         NSPredicate *predicate = [self buildFilters];
-        
-        [self updateFilter:predicate];
+        if (predicate) {
+            [self updateFilter:predicate];
+        }
     }
 }
 
@@ -222,7 +223,7 @@
 
 - (NSPredicate*)buildFilters
 {
-    return [FilterParser parse:_filter];
+    return _filter ? [FilterParser parse:_filter] : nil;
 }
 
 - (BOOL)_hasInitialized

--- a/ios/RCTMGL/RCTMGLSymbolLayer.m
+++ b/ios/RCTMGL/RCTMGLSymbolLayer.m
@@ -94,7 +94,9 @@
 - (void)addedToMap
 {
     NSPredicate *filter = [self buildFilters];
-    [self updateFilter:filter];
+    if (filter != nil) {
+        [self updateFilter:filter];
+    }
     
     if (_snapshot == YES) {
         UIImage *image = [self _createViewSnapshot];


### PR DESCRIPTION
Currently on iOS, If the root style has a layer, and you are modifying the style of the layer by adding a child of the MapView with the same layer id, the layer's filter gets cleared. This happens because there is a missing `_filter == nil` check in RCTMGLSymbolLayer.m. The other layer types have this check in place.

Also in the PR I fixed a few invalid argument types (filters can now be any expression) and added a few more null checks.