### PR TITLE
Fix Android sometimes missing callbacks

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/AbstractEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/AbstractEvent.java
@@ -8,11 +8,13 @@ import javax.annotation.Nullable;
 
 public class AbstractEvent extends Event<AbstractEvent> {
     private String mEventName;
+    private final boolean mCanCoalesce;
     private WritableMap mEvent;
 
-    public AbstractEvent(int viewId, String eventName, @Nullable WritableMap event) {
+    public AbstractEvent(int viewId, String eventName, boolean canCoalesce, @Nullable WritableMap event) {
         super(viewId);
         mEventName = eventName;
+        mCanCoalesce = canCoalesce;
         mEvent = event;
     }
 
@@ -24,5 +26,10 @@ public class AbstractEvent extends Event<AbstractEvent> {
     @Override
     public void dispatch(RCTEventEmitter rctEventEmitter) {
         rctEventEmitter.receiveEvent(getViewTag(), getEventName(), mEvent);
+    }
+
+    @Override
+    public boolean canCoalesce() {
+        return mCanCoalesce;
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/AbstractEventEmitter.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/AbstractEventEmitter.java
@@ -43,7 +43,7 @@ abstract public class AbstractEventEmitter<T extends ViewGroup> extends ViewGrou
         }
 
         mRateLimitedEvents.put(eventCacheKey, System.currentTimeMillis());
-        mEventDispatcher.dispatchEvent(new AbstractEvent(event.getID(), event.getKey(), event.toJSON()));
+        mEventDispatcher.dispatchEvent(new AbstractEvent(event.getID(), event.getKey(), event.canCoalesce(), event.toJSON()));
     }
 
     @Override

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
@@ -17,9 +17,6 @@ import com.mapbox.mapboxsdk.location.LocationComponent;
 import com.mapbox.mapboxsdk.location.LocationComponentOptions;
 import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 // import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
-import com.mapbox.mapboxsdk.style.layers.Layer;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.rctmgl.components.AbstractMapFeature;
 import com.mapbox.rctmgl.components.mapview.RCTMGLMapView;
 import com.mapbox.rctmgl.events.IEvent;
@@ -27,7 +24,6 @@ import com.mapbox.rctmgl.events.MapUserTrackingModeEvent;
 import com.mapbox.rctmgl.events.MapChangeEvent;
 import com.mapbox.rctmgl.location.LocationManager;
 import com.mapbox.rctmgl.location.UserLocation;
-import com.mapbox.rctmgl.location.UserLocationLayerConstants;
 import com.mapbox.rctmgl.location.UserLocationVerticalAlignment;
 import com.mapbox.rctmgl.location.UserTrackingMode;
 import com.mapbox.rctmgl.location.UserTrackingState;
@@ -250,7 +246,7 @@ public class RCTMGLCamera extends AbstractMapFeature {
         if(location == null){
             return;
         }
-        IEvent event = new MapChangeEvent(this, makeLocationChangePayload(location), EventTypes.USER_LOCATION_UPDATED);
+        IEvent event = new MapChangeEvent(this, EventTypes.USER_LOCATION_UPDATED, makeLocationChangePayload(location));
         mManager.handleEvent(event);
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -16,43 +16,31 @@ import android.view.MotionEvent;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
-import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.plugins.markerview.MarkerView;
 import com.mapbox.mapboxsdk.plugins.markerview.MarkerViewManager;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdate;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.geometry.VisibleRegion;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.UiSettings;
-import com.mapbox.mapboxsdk.plugins.localization.LocalizationPlugin;
 // import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.Layer;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.rctmgl.components.AbstractMapFeature;
 import com.mapbox.rctmgl.components.annotation.RCTMGLCallout;
 import com.mapbox.rctmgl.components.annotation.RCTMGLCalloutAdapter;
 import com.mapbox.rctmgl.components.annotation.RCTMGLPointAnnotation;
-import com.mapbox.rctmgl.components.annotation.RCTMGLPointAnnotationAdapter;
-import com.mapbox.rctmgl.components.camera.CameraStop;
-import com.mapbox.rctmgl.components.camera.CameraUpdateQueue;
 import com.mapbox.rctmgl.components.camera.RCTMGLCamera;
 import com.mapbox.rctmgl.components.mapview.helpers.CameraChangeTracker;
 import com.mapbox.rctmgl.components.styles.light.RCTMGLLight;
@@ -62,27 +50,15 @@ import com.mapbox.rctmgl.events.AndroidCallbackEvent;
 import com.mapbox.rctmgl.events.IEvent;
 import com.mapbox.rctmgl.events.MapChangeEvent;
 import com.mapbox.rctmgl.events.MapClickEvent;
-import com.mapbox.rctmgl.events.MapUserTrackingModeEvent;
-import com.mapbox.rctmgl.events.constants.EventKeys;
 import com.mapbox.rctmgl.events.constants.EventTypes;
-import com.mapbox.rctmgl.location.LocationManager;
-import com.mapbox.rctmgl.location.UserLocation;
-import com.mapbox.rctmgl.location.UserLocationLayerConstants;
-import com.mapbox.rctmgl.location.UserLocationVerticalAlignment;
-import com.mapbox.rctmgl.location.UserTrackingState;
 import com.mapbox.rctmgl.utils.BitmapUtils;
 import com.mapbox.rctmgl.utils.GeoJSONUtils;
 import com.mapbox.rctmgl.utils.GeoViewport;
-import com.mapbox.rctmgl.utils.SimpleEventCallback;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Locale;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -809,51 +785,46 @@ public class RCTMGLMapView extends MapView implements
 
     //region Methods
     public void queryRenderedFeaturesAtPoint(String callbackID, PointF point, Expression filter, List<String> layerIDs) {
-        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
         List<Feature> features = mMap.queryRenderedFeatures(point, filter, layerIDs.toArray(new String[layerIDs.size()]));
 
         WritableMap payload = new WritableNativeMap();
         payload.putString("data", FeatureCollection.fromFeatures(features).toJson());
-        event.setPayload(payload);
 
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
         mManager.handleEvent(event);
     }
 
     public void getZoom(String callbackID) {
-        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
         CameraPosition position = mMap.getCameraPosition();
 
         WritableMap payload = new WritableNativeMap();
         payload.putDouble("zoom", position.zoom);
-        event.setPayload(payload);
 
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
         mManager.handleEvent(event);
     }
 
     public void queryRenderedFeaturesInRect(String callbackID, RectF rect, Expression filter, List<String> layerIDs) {
-        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
         List<Feature> features = mMap.queryRenderedFeatures(rect, filter, layerIDs.toArray(new String[layerIDs.size()]));
 
         WritableMap payload = new WritableNativeMap();
         payload.putString("data", FeatureCollection.fromFeatures(features).toJson());
-        event.setPayload(payload);
 
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
         mManager.handleEvent(event);
     }
 
     public void getVisibleBounds(String callbackID) {
-        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
         VisibleRegion region = mMap.getProjection().getVisibleRegion();
 
         WritableMap payload = new WritableNativeMap();
         payload.putArray("visibleBounds", GeoJSONUtils.fromLatLngBounds(region.latLngBounds));
-        event.setPayload(payload);
 
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
         mManager.handleEvent(event);
     }
 
     public void getPointInView(String callbackID, LatLng mapCoordinate) {
-        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
 
         PointF pointInView = mMap.getProjection().toScreenLocation(mapCoordinate);
         WritableMap payload = new WritableNativeMap();
@@ -862,13 +833,12 @@ public class RCTMGLMapView extends MapView implements
         array.pushDouble(pointInView.x);
         array.pushDouble(pointInView.y);
         payload.putArray("pointInView", array);
-        event.setPayload(payload);
 
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
         mManager.handleEvent(event);
     }
 
     public void getCoordinateFromView(String callbackID, PointF pointInView) {
-        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
 
         LatLng mapCoordinate = mMap.getProjection().fromScreenLocation(pointInView);
         WritableMap payload = new WritableNativeMap();
@@ -877,13 +847,12 @@ public class RCTMGLMapView extends MapView implements
         array.pushDouble(mapCoordinate.getLongitude());
         array.pushDouble(mapCoordinate.getLatitude());
         payload.putArray("coordinateFromView", array);
-        event.setPayload(payload);
 
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
         mManager.handleEvent(event);
     }
 
     public void takeSnap(final String callbackID, final boolean writeToDisk) {
-        final AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
 
         if (mMap == null) {
             throw new Error("takeSnap should only be called after the map has rendered");
@@ -895,14 +864,14 @@ public class RCTMGLMapView extends MapView implements
                 WritableMap payload = new WritableNativeMap();
                 String uri = writeToDisk ? BitmapUtils.createTempFile(mContext, snapshot) : BitmapUtils.createBase64(snapshot);
                 payload.putString("uri", uri);
-                event.setPayload(payload);
+
+                AndroidCallbackEvent event = new AndroidCallbackEvent(RCTMGLMapView.this, callbackID, payload);
                 mManager.handleEvent(event);
             }
         });
     }
 
     public void getCenter(String callbackID) {
-        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, EventKeys.MAP_ANDROID_CALLBACK);
         LatLng center = mMap.getCameraPosition().target;
 
         WritableArray array = new WritableNativeArray();
@@ -910,8 +879,8 @@ public class RCTMGLMapView extends MapView implements
         array.pushDouble(center.getLatitude());
         WritableMap payload = new WritableNativeMap();
         payload.putArray("center", array);
-        event.setPayload(payload);
 
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
         mManager.handleEvent(event);
     }
 
@@ -1039,7 +1008,7 @@ public class RCTMGLMapView extends MapView implements
     }
 
     public void sendRegionChangeEvent(boolean isAnimated) {
-        IEvent event = new MapChangeEvent(this, makeRegionPayload(new Boolean(isAnimated)), EventTypes.REGION_DID_CHANGE);
+        IEvent event = new MapChangeEvent(this, EventTypes.REGION_DID_CHANGE, makeRegionPayload(new Boolean(isAnimated)));
         mManager.handleEvent(event);
         mCameraChangeTracker.setReason(CameraChangeTracker.EMPTY);
     }
@@ -1149,7 +1118,7 @@ public class RCTMGLMapView extends MapView implements
             case EventTypes.REGION_WILL_CHANGE:
             case EventTypes.REGION_DID_CHANGE:
             case EventTypes.REGION_IS_CHANGING:
-                event = new MapChangeEvent(this, makeRegionPayload(null), eventType);
+                event = new MapChangeEvent(this, eventType, makeRegionPayload(null));
                 break;
             default:
                 event = new MapChangeEvent(this, eventType);
@@ -1170,7 +1139,7 @@ public class RCTMGLMapView extends MapView implements
         if(location == null){
             return;
         }
-        IEvent event = new MapChangeEvent(this, makeLocationChangePayload(location), EventTypes.USER_LOCATION_UPDATED);
+        IEvent event = new MapChangeEvent(this, EventTypes.USER_LOCATION_UPDATED, makeLocationChangePayload(location));
         mManager.handleEvent(event);
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/AbstractEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/AbstractEvent.java
@@ -57,4 +57,10 @@ abstract public class AbstractEvent implements IEvent {
         map.putMap("payload", payloadClone);
         return map;
     }
+
+    @Override
+    public boolean canCoalesce() {
+        // default behavior of com.facebook.react.uimanager.events.Event
+        return true;
+    }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/AndroidCallbackEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/AndroidCallbackEvent.java
@@ -32,4 +32,10 @@ public class AndroidCallbackEvent extends AbstractEvent {
     public WritableMap getPayload() {
         return mPayload;
     }
+
+    @Override
+    public boolean canCoalesce() {
+        // never coalesce callbacks into a single event
+        return false;
+    }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/AndroidCallbackEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/AndroidCallbackEvent.java
@@ -11,21 +11,16 @@ import com.mapbox.rctmgl.events.constants.EventKeys;
  */
 
 public class AndroidCallbackEvent extends AbstractEvent {
-    private String mKey;
-    private WritableMap mPayload;
+    private final WritableMap mPayload;
 
-    public AndroidCallbackEvent(View view, String callbackID, String key) {
+    public AndroidCallbackEvent(View view, String callbackID, WritableMap payload) {
         super(view, callbackID);
-        mKey = key;
-    }
-
-    public void setPayload(WritableMap payload) {
         mPayload = payload;
     }
 
     @Override
     public String getKey() {
-        return mKey;
+        return EventKeys.MAP_ANDROID_CALLBACK;
     }
 
     @Override
@@ -35,7 +30,9 @@ public class AndroidCallbackEvent extends AbstractEvent {
 
     @Override
     public boolean canCoalesce() {
-        // never coalesce callbacks into a single event
+        // Make sure EventDispatcher never merges EventKeys.MAP_ANDROID_CALLBACK events.
+        // These events are couples to unique callbacks references (promises) on the JS side which
+        // each expect response with their corresponding callbackID
         return false;
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/IEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/IEvent.java
@@ -12,6 +12,7 @@ public interface IEvent {
     String getType();
     long getTimestamp();
     boolean equals(IEvent event);
+    boolean canCoalesce();
     WritableMap getPayload();
     WritableMap toJSON();
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/LocationEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/LocationEvent.java
@@ -89,4 +89,9 @@ public class LocationEvent implements IEvent {
         map.putMap("payload", getPayload());
         return map;
     }
+
+    @Override
+    public boolean canCoalesce() {
+        return true;
+    }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/MapChangeEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/MapChangeEvent.java
@@ -15,10 +15,10 @@ public class MapChangeEvent extends AbstractEvent {
     private WritableMap mPayload;
 
     public MapChangeEvent(View view, String eventType) {
-        this(view, Arguments.createMap(), eventType);
+        this(view, eventType, Arguments.createMap());
     }
 
-    public MapChangeEvent(View view, WritableMap payload, String eventType) {
+    public MapChangeEvent(View view, String eventType, WritableMap payload) {
         super(view, eventType);
         mPayload = payload;
     }
@@ -34,5 +34,14 @@ public class MapChangeEvent extends AbstractEvent {
         WritableMap payloadClone = Arguments.createMap();
         payloadClone.merge(mPayload);
         return payloadClone;
+    }
+
+    @Override
+    public boolean canCoalesce() {
+        // Make sure EventDispatcher never merges EventKeys.MAP_ONCHANGE events.
+        // This event name is used to emit events with different
+        // com.mapbox.rctmgl.events.constants.EventTypes which are dispatched separately on
+        // the JS side
+        return false;
     }
 }

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -6,8 +6,6 @@ import locationManager from '../modules/location/locationManager';
 import {isNumber, toJSONString, viewPropTypes, existenceChange} from '../utils';
 import * as geoUtils from '../utils/geoUtils';
 
-import NativeBridgeComponent from './NativeBridgeComponent';
-
 const MapboxGL = NativeModules.MGLModule;
 
 export const NATIVE_MODULE_NAME = 'RCTMGLCamera';
@@ -67,7 +65,7 @@ const SettingsPropTypes = {
   zoomLevel: PropTypes.number,
 };
 
-class Camera extends NativeBridgeComponent {
+class Camera extends React.Component {
   static propTypes = {
     ...viewPropTypes,
 

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -28,6 +28,8 @@ export const NATIVE_MODULE_NAME = 'RCTMGLMapView';
 
 export const ANDROID_TEXTURE_NATIVE_MODULE_NAME = 'RCTMGLAndroidTextureMapView';
 
+let callbackIncrement = 0;
+
 const styles = StyleSheet.create({
   matchParent: {flex: 1},
 });
@@ -479,7 +481,8 @@ class MapView extends NativeBridgeComponent {
 
     if (isAndroid()) {
       return new Promise(resolve => {
-        const callbackID = `${Date.now()}`;
+        callbackIncrement++;
+        const callbackID = `${methodName}_${callbackIncrement}`;
         this._addAddAndroidCallback(callbackID, resolve);
         args.unshift(callbackID);
         runNativeCommand(NATIVE_MODULE_NAME, methodName, this._nativeRef, args);


### PR DESCRIPTION
I noticed that callbacks on Android don't always work. Here's some example code:

```js
const time = Date.now();
let hasResult = false;
const zoom1 = this._map.getZoom();
const zoom2 = this._map.getZoom();
const zoom3 = this._map.getZoom();
console.log(`Request Zoom: ${time}`);
Promise.all([zoom1, zoom2, zoom3]).then(values => {
  hasResult = true;
  console.log(`Received Zoom: ${time}`);
  this.setState({zoom: values[0]});
});
setTimeout(() => {
  if (!hasResult) {
    console.log(`Request Zoom: ${time} timed-out`);
  }
}, 1000);
```

In which I added the following in `_runNativeCommand` inside `MapView.js` for debugging purposes.
```
console.log(``${methodName}: ${callbackID}`)
```


This is the output:

```js
getZoom: 1561558978423
getZoom: 1561558978424
getZoom: 1561558978424
Request Zoom: 1561558978423
Request Zoom: 1561558978423 timed-out
```
_Note it's timing sensitive so this might only occur in faster environments_

Two issues:

- `callbackID` is not unique enough. It only uses `Date.now()` with the chance the callback method gets overridden in `_callbackMap` within the same millisecond.

- Callbacks are dispatched via [EventDispatcher](https://github.com/react-native-mapbox-gl/maps/blob/master/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/AbstractEventEmitter.java#L46) which by default [merges](https://github.com/facebook/react-native/blob/1151c096dab17e5d9a6ac05b61aacecd4305f3db/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java#L59-L75) events with the same `eventName (string)`, `viewId (int)`, and `coalescingKey (int)`

In case of callbacks such as `getZoom` / `getCenter` etc these values are:

- `eventName` = `rct.mapbox.map.androidcallback`

- `viewId` = `mapView.getID()`

- `coalescingKey` = 0


Which is fine for most events but for callbacks the same `eventName` `rct.mapbox.map.androidcallback` is re-used for different JS callback methods / callback-references.

Basically means that there is a high likelihood that callbacks are ignored when executed rapidly.




