### PR TITLE
Add  MGLLocationModule mock

### DIFF
--- a/__tests__/__mocks__/react-native-mapbox-gl.mock.js
+++ b/__tests__/__mocks__/react-native-mapbox-gl.mock.js
@@ -107,3 +107,9 @@ NativeModules.MGLSnapshotModule = {
     return Promise.resolve('file://test.png');
   },
 };
+
+NativeModules.MGLLocationModule = {
+  getLastKnownLocation: jest.fn(),
+  start: jest.fn(),
+  pause: jest.fn(),
+};


### PR DESCRIPTION
To test my app that uses `@react-native-mapbox-gl/maps` I have to mock it. So I found that this package already has some mock setup, and I use it like this:
```
setupFilesAfterEnv: [
    '<rootDir>/jest.setup.ts',
    '<rootDir>/node_modules/react-native-gesture-handler/jestSetup.js',
    '<rootDir>/node_modules/@react-native-mapbox-gl/maps/__tests__/__mocks__/react-native-mapbox-gl.mock.js',
  ],
```

Currently this file is a bit outdated and jest will complain about missing native module. This PR made it work for me.