### PR TITLE
Prevent crash if layers added to the map before style loads

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
@@ -151,6 +151,7 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
         if (!hasInitialized()) {
             return;
         }
+        if (mMap.getStyle() == null) return;
 
         String userBackgroundID = UserLocationLayerConstants.BACKGROUND_LAYER_ID;
         Layer userLocationBackgroundLayer = mMap.getStyle().getLayer(userBackgroundID);
@@ -172,6 +173,7 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
                 if (!hasInitialized()) {
                     return;
                 }
+                if (mMap.getStyle() == null) return;
                 mMap.getStyle().addLayerAbove(mLayer, aboveLayerID);
                 mMapView.layerAdded(mLayer);
             }
@@ -184,6 +186,7 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
                 if (!hasInitialized()) {
                     return;
                 }
+                if (mMap.getStyle() == null) return;
                 mMap.getStyle().addLayerBelow(mLayer, belowLayerID);
                 mMapView.layerAdded(mLayer);
             }
@@ -194,11 +197,13 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
         if (!hasInitialized()) {
             return;
         }
+        if (mMap.getStyle() == null) return;
         mMap.getStyle().addLayerAt(mLayer, index);
         mMapView.layerAdded(mLayer);
     }
 
     protected void insertLayer() {
+        if (mMap.getStyle() == null) return;
         if (mMap.getStyle().getLayer(mID) != null) {
             return; // prevent adding a layer twice
         }
@@ -234,6 +239,8 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
     public void addToMap(RCTMGLMapView mapView) {
         mMap = mapView.getMapboxMap();
         mMapView = mapView;
+
+        if (mMap.getStyle() == null) return;
 
         T existingLayer = mMap.getStyle().<T>getLayerAs(mID);
         if (existingLayer != null) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
@@ -203,7 +203,7 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
     }
 
     protected void insertLayer() {
-        if (mMap.getStyle() == null) return;
+        if (mMap == null || mMap.getStyle() == null) return;
         if (mMap.getStyle().getLayer(mID) != null) {
             return; // prevent adding a layer twice
         }
@@ -240,7 +240,7 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
         mMap = mapView.getMapboxMap();
         mMapView = mapView;
 
-        if (mMap.getStyle() == null) return;
+        if (mMap == null || mMap.getStyle() == null) return;
 
         T existingLayer = mMap.getStyle().<T>getLayerAs(mID);
         if (existingLayer != null) {
@@ -259,7 +259,7 @@ public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
 
     @Override
     public void removeFromMap(RCTMGLMapView mapView) {
-        if (mMap.getStyle() != null) {
+        if (mMap != null && mMap.getStyle() != null) {
             mMap.getStyle().removeLayer(mLayer);
         }
     }


### PR DESCRIPTION
If layers are added to the map before the style is loaded a null pointer exception is thrown. This PR adds checks so that apps won't crash.

As far as I can tell, checking if the style is null and simply aborting is safe because the layers will be re-added when the style loads here: 
https://github.com/react-native-mapbox-gl/maps/blob/master/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTSource.java#L134

<img width="844" alt="Screen Shot 2019-07-01 at 4 53 51 PM" src="https://user-images.githubusercontent.com/118481/60474328-1fefa480-9c26-11e9-98db-acb45356387e.png">
