### PR TITLE
Android setMin/MaxZoom before applying camera

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
@@ -135,10 +135,10 @@ public class RCTMGLCamera extends AbstractMapFeature {
         mMapView = mapView;
 
         setInitialCamera();
+        updateMaxMinZoomLevel();
         if (mCameraStop != null) {
             updateCamera();
         }
-        updateMaxMinZoomLevel();
 
         if (mShowUserLocation || mFollowUserLocation) {
             enableLocation();


### PR DESCRIPTION
Fixes: #193

It seems that setMin/MaxZoom cancels pending camera transitions, so we should do this before applying camera