### PR TITLE
Fixed bug where camera moves to incorrect position on physical iOS devices

### DIFF
--- a/ios/RCTMGL/CameraUpdateItem.m
+++ b/ios/RCTMGL/CameraUpdateItem.m
@@ -90,7 +90,7 @@
     if ([self _isCoordValid:_cameraStop.coordinate]) {
         nextCamera.centerCoordinate = _cameraStop.coordinate;
     } else if ([self _areBoundsValid:_cameraStop.bounds]) {
-        MGLMapCamera *boundsCamera = [mapView camera:_cameraStop fittingCoordinateBounds:_cameraStop.bounds edgePadding: _cameraStop.boundsPadding];
+        MGLMapCamera *boundsCamera = [mapView camera:nextCamera fittingCoordinateBounds:_cameraStop.bounds edgePadding: _cameraStop.boundsPadding];
         nextCamera.centerCoordinate = boundsCamera.centerCoordinate;
         nextCamera.altitude = boundsCamera.altitude;
     }


### PR DESCRIPTION
Our app suffered from a weird camera issue that only happened on physical iOS devices. It seemed to zoom to somewhat random surrounding areas on physical devices while running normally within the simulator under the same parameters.

I narrowed it down to this call where the `camera: fittingCoordinateBounds` that is used to calculate the target `centerCoordinate` / `altitude` from incoming `bounds`. The idea is that this call uses the current camera configuration (taking into account target `pitch` / `heading`). However it was given the `_cameraStop` that contained possible invalid properties. Such as a `pitch` + `heading` with a `nil` value and a coordinate value of `0,0` in case the client only updates with `bounds`. This call should have used `nextCamera` in the first place since that object is based on the current map camera + incoming updates applied on top.

After changing this the camera behaves as expected on device + simulator.

I'm still  in the dark on why this issue didn't manifest in the iOS simulator though.