### PR TITLE
Jest: Fixed 'Cannot find module'

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0",
-    "@babel/plugin-proposal-class-properties": "7.4.4",
+    "@babel/core": "7.5.0",
+    "@babel/plugin-proposal-class-properties": "7.5.0",
     "@babel/plugin-transform-exponentiation-operator": "7.2.0",
-    "@babel/plugin-transform-flow-strip-types": "7.0.0",
-    "@babel/plugin-transform-runtime": "7.0.0",
-    "@babel/runtime": "7.0.0",
+    "@babel/plugin-transform-flow-strip-types": "7.4.4",
+    "@babel/plugin-transform-runtime": "7.5.0",
+    "@babel/runtime": "7.5.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "24.8.0",


### PR DESCRIPTION
Travis tests have been failing for some days with the error:

```
 Cannot find module '@babel/runtime/helpers/objectSpread2' from 'index.js'
```

Locally jest tests were running fine but after running `node_modules/.bin/jest --clearCache` I could reproduce the failing tests locally as well. I'm not sure yet why this error suddenly started showing up but after some searching I found several hints to update `@babel/runtime`. I tried it and that fixed the failing tests locally.

Let's see if it now runs on Travis too.