### PR TITLE
Use Fresco image pipeline to load images on Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/BitmapUtils.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/BitmapUtils.java
@@ -55,16 +55,6 @@ public class BitmapUtils {
         return bitmap;
     }
 
-    public static Bitmap getBitmapFromPath(String path, BitmapFactory.Options options) {
-        try {
-            Bitmap bitmap = BitmapFactory.decodeFile(path, options);
-            return bitmap;
-        } catch (Exception e) {
-            Log.w(LOG_TAG, e.getLocalizedMessage());
-            return Bitmap.createBitmap(1, 1, Bitmap.Config.ALPHA_8); // Returns a transparent bitmap
-        }
-    }
-
     public static Bitmap getBitmapFromResource(Context context, String resourceName, BitmapFactory.Options options) {
         Resources resources = context.getResources();
         int resID = resources.getIdentifier(resourceName, "drawable", context.getPackageName());

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/DownloadMapImageTask.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/DownloadMapImageTask.java
@@ -9,6 +9,16 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 
 import com.facebook.common.logging.FLog;
+import com.facebook.common.references.CloseableReference;
+import com.facebook.datasource.DataSource;
+import com.facebook.datasource.DataSources;
+import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.imagepipeline.common.RotationOptions;
+import com.facebook.imagepipeline.image.CloseableImage;
+import com.facebook.imagepipeline.image.CloseableStaticBitmap;
+import com.facebook.imagepipeline.request.ImageRequest;
+import com.facebook.imagepipeline.request.ImageRequestBuilder;
+import com.facebook.react.views.imagehelper.ImageSource;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 
@@ -32,11 +42,13 @@ public class DownloadMapImageTask extends AsyncTask<Map.Entry<String, ImageEntry
     private WeakReference<MapboxMap> mMap;
     @Nullable
     private OnAllImagesLoaded mCallback;
+    private final Object mCallerContext;
 
     public DownloadMapImageTask(Context context, MapboxMap map, @Nullable OnAllImagesLoaded callback) {
         mContext = new WeakReference<>(context.getApplicationContext());
         mMap = new WeakReference<>(map);
         mCallback = callback;
+        mCallerContext = this;
     }
 
     public interface OnAllImagesLoaded {
@@ -58,16 +70,44 @@ public class DownloadMapImageTask extends AsyncTask<Map.Entry<String, ImageEntry
             ImageEntry imageEntry = object.getValue();
 
             String uri = imageEntry.uri;
-            if (uri.contains("://")) { // has scheme attempt to get bitmap from url
+
+            if (uri.startsWith("http://") || uri.startsWith("https://") ||
+                uri.startsWith("file://") || uri.startsWith("asset://") || uri.startsWith("data:")) {
+                ImageSource source = new ImageSource(context, uri);
+                ImageRequest request = ImageRequestBuilder.newBuilderWithSource(source.getUri())
+                    .setRotationOptions(RotationOptions.autoRotate())
+                    .build();
+
+                DataSource<CloseableReference<CloseableImage>> dataSource =
+                    Fresco.getImagePipeline().fetchDecodedImage(request, mCallerContext);
+
+                CloseableReference<CloseableImage> result = null;
                 try {
-                    Bitmap bitmap = BitmapUtils.getBitmapFromURL(uri, getBitmapOptions(metrics, imageEntry.scale));
-                    images.add(new AbstractMap.SimpleEntry<>(object.getKey(), bitmap));
-                } catch (Exception e) {
+                    result = DataSources.waitForFinalResult(dataSource);
+                    if (result != null) {
+                        CloseableImage image = result.get();
+                        if (image instanceof CloseableStaticBitmap) {
+                            CloseableStaticBitmap closeableStaticBitmap = (CloseableStaticBitmap) image;
+                            Bitmap bitmap = closeableStaticBitmap.getUnderlyingBitmap()
+                                // Copy the bitmap to make sure it doesn't get recycled when we release
+                                // the fresco reference.
+                                .copy(Bitmap.Config.ARGB_8888, true);
+                            bitmap.setDensity((int)((double)DisplayMetrics.DENSITY_DEFAULT * imageEntry.scale));
+                            images.add(new AbstractMap.SimpleEntry<>(object.getKey(), bitmap));
+                        } else {
+                            FLog.e(LOG_TAG, "Failed to load bitmap from: " + uri);
+                        }
+                    } else {
+                        FLog.e(LOG_TAG, "Failed to load bitmap from: " + uri);
+                    }
+                } catch (Throwable e) {
                     Log.w(LOG_TAG, e.getLocalizedMessage());
+                } finally {
+                    dataSource.close();
+                    if (result != null) {
+                        CloseableReference.closeSafely(result);
+                    }
                 }
-            } else if (uri.startsWith("/")) {
-                Bitmap bitmap = BitmapUtils.getBitmapFromPath(uri, getBitmapOptions(metrics, imageEntry.scale));
-                images.add(new AbstractMap.SimpleEntry<>(object.getKey(), bitmap));
             } else {
                 // local asset required from JS require('image.png') or import icon from 'image.png' while in release mode
                 Bitmap bitmap = BitmapUtils.getBitmapFromResource(context, uri, getBitmapOptions(metrics, imageEntry.scale));


### PR DESCRIPTION
Currently images are loaded using a custom implementation to create bitmap from urls or resources. This changes it to leverage the Fresco image pipeline instead which is used by react-native images. This will allow sharing the image cache with other RN images and supporting more formats (webp for example).

Based loosely on https://github.com/react-native-community/react-native-maps/blob/master/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java and https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java#L72

Tested that images local and remote images work in both debug and release modes.