### PR TITLE
Make it clear PointAnnotation is deprecated

### DIFF
--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -1,3 +1,5 @@
+_**deprecated and buggy, use [SymbolLayer](https://github.com/react-native-mapbox-gl/maps/blob/master/docs/SymbolLayer.md) instead**_
+
 ## <MapboxGL.PointAnnotation />
 ### PointAnnotation represents a one-dimensional shape located at a single geographical coordinate.
 

--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -1,7 +1,7 @@
 _**deprecated and buggy, use [SymbolLayer](https://github.com/react-native-mapbox-gl/maps/blob/master/docs/SymbolLayer.md) instead**_
 
 ## <MapboxGL.PointAnnotation />
-### PointAnnotation represents a one-dimensional shape located at a single geographical coordinate.
+### PointAnnotation represents a one-dimensional shape located at a single geographical coordinate. PointAnnotation is legacy, soon to be deprecated, and should use ShapeSource and SymbolLayer instead.
 
 ### props
 | Prop | Type | Default | Required | Description |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2698,21 +2698,51 @@
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "This event is triggered whenever the currently displayed map region is about to change."
+        "description": "This event is triggered whenever the currently displayed map region is about to change.",
+        "params": [
+          {
+            "name": "feature",
+            "description": "The geojson point feature at the camera center, properties contains zoomLevel, visibleBounds",
+            "type": {
+              "name": "PointFeature"
+            },
+            "optional": false
+          }
+        ]
       },
       {
         "name": "onRegionIsChanging",
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "This event is triggered whenever the currently displayed map region is changing."
+        "description": "This event is triggered whenever the currently displayed map region is changing.",
+        "params": [
+          {
+            "name": "feature",
+            "description": "The geojson point feature at the camera center, properties contains zoomLevel, visibleBounds",
+            "type": {
+              "name": "PointFeature"
+            },
+            "optional": false
+          }
+        ]
       },
       {
         "name": "onRegionDidChange",
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "This event is triggered whenever the currently displayed map region finished changing"
+        "description": "This event is triggered whenever the currently displayed map region finished changing",
+        "params": [
+          {
+            "name": "feature",
+            "description": "The geojson point feature at the camera center, properties contains zoomLevel, visibleBounds",
+            "type": {
+              "name": "PointFeature"
+            },
+            "optional": false
+          }
+        ]
       },
       {
         "name": "onWillStartLoadingMap",
@@ -2805,7 +2835,7 @@
     "name": "MapView"
   },
   "PointAnnotation": {
-    "description": "PointAnnotation represents a one-dimensional shape located at a single geographical coordinate.",
+    "description": "PointAnnotation represents a one-dimensional shape located at a single geographical coordinate. PointAnnotation is legacy, soon to be deprecated, and should use ShapeSource and SymbolLayer instead.",
     "displayName": "PointAnnotation",
     "methods": [],
     "props": [

--- a/javascript/components/PointAnnotation.js
+++ b/javascript/components/PointAnnotation.js
@@ -16,7 +16,7 @@ const styles = StyleSheet.create({
 });
 
 /**
- * PointAnnotation represents a one-dimensional shape located at a single geographical coordinate.
+ * PointAnnotation represents a one-dimensional shape located at a single geographical coordinate. PointAnnotation is legacy, soon to be deprecated, and should use ShapeSource and SymbolLayer instead.
  */
 class PointAnnotation extends React.PureComponent {
   static propTypes = {


### PR DESCRIPTION
related to [#54](https://github.com/react-native-mapbox-gl/maps/issues/54): I spent to much time trying to fix a bug on a PointAnnotation... if it was clearer, it would have been much better !