### PR TITLE
fixing incorrect accessToken file instruction

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -20,7 +20,12 @@ Not a Mapbox user yet? [Sign up for an account here](https://www.mapbox.com/sign
 ```
 cd example
 ```
-* Create a file called `accesstoken` in the root of the example project and just paste in your [Mapbox access token](https://www.mapbox.com/studio/account/tokens/).
+* Create a file called `env.json` in the root of the example project and just paste in your [Mapbox access token](https://www.mapbox.com/studio/account/tokens/) in the property `accessToken`.
+```
+{
+  accessToken: {accessToken}
+}
+```
 
 * Install our dependencies using `npm install`.
 ## Start React Native Packager


### PR DESCRIPTION
I don't know why it was written to create a file called `accesstoken` in the root of the example project because that's not how it works ! I changed the readme following what I did and it worked.