### PR TITLE
Fixed padding being reset when enabling followUserLocation

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
@@ -355,11 +355,13 @@ public class RCTMGLCamera extends AbstractMapFeature {
 
     private void updateLocationLayer(@NonNull Style style) {
         if (mLocationComponent == null) {
-            mLocationComponent = getMapboxMap().getLocationComponent();
+            MapboxMap mapboxMap = getMapboxMap();
+            mLocationComponent = mapboxMap.getLocationComponent();
 
             LocationComponentOptions.Builder builder = LocationComponentOptions.builder(mContext);
             if (!mShowUserLocation) {
                 builder = builder
+                        .padding(mapboxMap.getPadding())
                         .backgroundDrawable(R.drawable.empty)
                         .backgroundDrawableStale(R.drawable.empty)
                         .bearingDrawable(R.drawable.empty)


### PR DESCRIPTION
I noticed that map padding is reset when enabling `followUserLocation` on `Camera`.

The way we build a new `LocationComponentOptions` in order to enable tracking camera mode constructs an options object with a default padding of `0` which is then [applied by Mapbox](https://github.com/mapbox/mapbox-gl-native/blob/41980af4692006054a0fb851b2aacf9ddbfd9668/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java#L1295-L1302) resetting any padding currently present on the map.

_Note: I'm in the midst of refactoring the use of `locationComponent` a bit for #215 but for now this simple patch should fix that single issue._