### PR TITLE
Android: fix local image asset scaling

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/DownloadMapImageTask.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/DownloadMapImageTask.java
@@ -70,7 +70,7 @@ public class DownloadMapImageTask extends AsyncTask<Map.Entry<String, ImageEntry
                 images.add(new AbstractMap.SimpleEntry<>(object.getKey(), bitmap));
             } else {
                 // local asset required from JS require('image.png') or import icon from 'image.png' while in release mode
-                Bitmap bitmap = BitmapUtils.getBitmapFromResource(context, uri, getBitmapOptions(metrics, imageEntry.scale));
+                Bitmap bitmap = BitmapUtils.getBitmapFromResource(context, uri, null);
                 if (bitmap != null) {
                     images.add(new AbstractMap.SimpleEntry<>(object.getKey(), bitmap));
                 } else {


### PR DESCRIPTION
After #71 the image scale from react native is being used to determine the original resolution of the local asset image used. However, this causes a problem when used with [Android app bundling](https://developer.android.com/platform/technology/app-bundle) and installed on a phone that can dynamically change resolutions. 

Consider the following scenario of an app installed on a Samsung S9. On a Samsung s9, a user can change the resolution of the phone at runtime to HD+, FHD+, and WQHD+. Which corresponds to a scale of 2x, 3x and 4x respectively.  The default density of the device is `420dpi`, determined using `DisplayMetrics.DENSITY_DEVICE_STABLE`. This corresponds to a scale of 3x. However, at runtime, the device can also switch to `320dpi`(2x scale) or `640dpi`(4x scale). The density of the device at runtime can be determined using `DensityMetrics.densityDpi `.

Say an App has 1x (mdpi), 2x(xhdpi), 3x(xxhdpi), 4x(xxxhdpi) images for a local asset. If the app is bundled using android app bundle process and installed from the play store on a Samsung S9 device. Only the 3x image of the local asset will be installed on the phone. When a user switches to HD+ resolution, at runtime the image must be downscaled to 2x from 3x. But the image scale sent from react-native would still be pointing to 2x as while building the offline bundle the 2x image was present in the bundle. This means that we cannot rely on the image scale sent from react-native to determine the original resolution of the local asset image.

The simple fix for this scenario is to not pass any bitmap options for a local asset. The framework can then be able to find the original resolution of the image. In general, for a local asset, we need not send any bitmap options unless we don't need the default scaling behavior. Which is not the case here.