### PR TITLE
fix calls to getLastKnownLocation in UserLocation

### DIFF
--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -111,8 +111,6 @@ class UserLocation extends React.Component {
             coordinates: this._getCoordinatesFromLocation(lastKnownLocation),
           });
         }
-      } else {
-        locationManager.stop();
       }
     }
   };

--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -90,39 +90,40 @@ class UserLocation extends React.Component {
   }
 
   async componentDidMount() {
-    const lastKnownLocation = await locationManager.getLastKnownLocation();
-
-    if (lastKnownLocation) {
-      this.setState({
-        coordinates: this._getCoordinatesFromLocation(lastKnownLocation),
-      });
-    }
-
     locationManager.addListener(this._onLocationUpdate);
-    this.setLocationManager({
+    await this.setLocationManager({
       running: this.needsLocationManagerRunning(),
     });
   }
 
   locationManagerRunning = false;
 
-  setLocationManager({running}) {
+  setLocationManager = async ({running}) => {
     if (this.locationManagerRunning !== running) {
+      this.locationManagerRunning = running;
       if (running) {
         locationManager.start();
+
+        const lastKnownLocation = await locationManager.getLastKnownLocation();
+
+        if (lastKnownLocation) {
+          this.setState({
+            coordinates: this._getCoordinatesFromLocation(lastKnownLocation),
+          });
+        }
       } else {
         locationManager.stop();
       }
     }
-  }
+  };
 
   needsLocationManagerRunning() {
     return this.props.onUpdate || this.props.visible;
   }
 
-  componentWillUnmount() {
+  async componentWillUnmount() {
     locationManager.removeListener(this._onLocationUpdate);
-    this.setLocationManager({running: false});
+    await this.setLocationManager({running: false});
   }
 
   _onLocationUpdate(location) {
@@ -151,8 +152,8 @@ class UserLocation extends React.Component {
     }
   }
 
-  componentDidUpdate() {
-    this.setLocationManager({
+  async componentDidUpdate() {
+    await this.setLocationManager({
       running: this.needsLocationManagerRunning(),
     });
   }


### PR DESCRIPTION
I'm using `UserLocation` component like this:

```tsx
<Mapbox.UserLocation visible={locationPermissionGranted} />
```

Currently, when `UserLocation` mounts, it calls `getLastKnownLocation` even when visible is set to false. And `getLastKnownLocation` crashes on Android when permissions are denied.

This PR makes `UserLocation` request initial location only when it's really needed.

As a side-effect I remove a call to `locationManager.stop();` which was never called. The `stop` method doesn't even exist anymore.