### PR TITLE
Don't use class.getSimpleName for module names to fix proguard compat

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLCalloutManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLCalloutManager.java
@@ -8,7 +8,7 @@ import com.facebook.react.uimanager.ViewGroupManager;
  */
 
 public class RCTMGLCalloutManager extends ViewGroupManager<RCTMGLCallout> {
-    public static final String REACT_CLASS = RCTMGLCallout.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLCallout";
 
     @Override
     public String getName() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotationManager.java
@@ -16,7 +16,7 @@ import java.util.Map;
  */
 
 public class RCTMGLPointAnnotationManager extends AbstractEventEmitter<RCTMGLPointAnnotation> {
-    public static final String REACT_CLASS = RCTMGLPointAnnotation.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLPointAnnotation";
 
     public RCTMGLPointAnnotationManager(ReactApplicationContext reactApplicationContext) {
         super(reactApplicationContext);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCameraManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCameraManager.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class RCTMGLCameraManager extends AbstractEventEmitter<RCTMGLCamera> {
-    public static final String REACT_CLASS = RCTMGLCamera.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLCamera";
 
     private ReactApplicationContext mContext;
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLAndroidTextureMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLAndroidTextureMapViewManager.java
@@ -11,7 +11,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 
 public class RCTMGLAndroidTextureMapViewManager extends RCTMGLMapViewManager {
     public static final String LOG_TAG = RCTMGLAndroidTextureMapViewManager.class.getSimpleName();
-    public static final String REACT_CLASS = RCTMGLAndroidTextureMapView.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLAndroidTextureMapView";
 
     public RCTMGLAndroidTextureMapViewManager(ReactApplicationContext context) {
         super(context);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -36,7 +36,7 @@ import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
 
 public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     public static final String LOG_TAG = RCTMGLMapViewManager.class.getSimpleName();
-    public static final String REACT_CLASS = RCTMGLMapView.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLMapView";
 
     private Map<Integer, RCTMGLMapView> mViews;
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLBackgroundLayerManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLBackgroundLayerManager.java
@@ -10,7 +10,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
  */
 
 public class RCTMGLBackgroundLayerManager extends ViewGroupManager<RCTMGLBackgroundLayer> {
-    public static final String REACT_CLASS = RCTMGLBackgroundLayer.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLBackgroundLayer";
 
     @Override
     public String getName() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLCircleLayerManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLCircleLayerManager.java
@@ -13,11 +13,11 @@ import java.util.ArrayList;
  */
 
 public class RCTMGLCircleLayerManager extends ViewGroupManager<RCTMGLCircleLayer> {
-    public static final String REACT_Class = RCTMGLCircleLayer.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLCircleLayer";
 
     @Override
     public String getName() {
-        return REACT_Class;
+        return REACT_CLASS;
     }
 
     @Override

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillExtrusionLayerManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillExtrusionLayerManager.java
@@ -16,7 +16,7 @@ import java.util.Map;
  */
 
 public class RCTMGLFillExtrusionLayerManager extends ViewGroupManager<RCTMGLFillExtrusionLayer> {
-    public static final String REACT_CLASS = RCTMGLFillExtrusionLayer.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLFillExtrusionLayer";
 
     @Override
     public String getName() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillLayerManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillLayerManager.java
@@ -16,7 +16,7 @@ import java.util.Map;
  */
 
 public class RCTMGLFillLayerManager extends ViewGroupManager<RCTMGLFillLayer> {
-    public static final String REACT_CLASS = RCTMGLFillLayer.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLFillLayer";
 
     @Override
     public String getName() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLHeatmapLayerManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLHeatmapLayerManager.java
@@ -13,11 +13,11 @@ import java.util.ArrayList;
  */
 
 public class RCTMGLHeatmapLayerManager extends ViewGroupManager<RCTMGLHeatmapLayer>{
-    public static final String REACT_Class = RCTMGLHeatmapLayer.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLHeatmapLayer";
 
     @Override
     public String getName() {
-        return REACT_Class;
+        return REACT_CLASS;
     }
 
     @Override
@@ -74,4 +74,4 @@ public class RCTMGLHeatmapLayerManager extends ViewGroupManager<RCTMGLHeatmapLay
     public void setFilter(RCTMGLHeatmapLayer layer, ReadableArray filterList) {
         layer.setFilter(filterList);
     }
-}
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLLineLayerManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLLineLayerManager.java
@@ -15,7 +15,7 @@ import java.util.Map;
  */
 
 public class RCTMGLLineLayerManager extends ViewGroupManager<RCTMGLLineLayer> {
-    public static final String REACT_CLASS = RCTMGLLineLayer.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLLineLayer";
 
     @Override
     public String getName() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLRasterLayerManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLRasterLayerManager.java
@@ -10,7 +10,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
  */
 
 public class RCTMGLRasterLayerManager extends ViewGroupManager<RCTMGLRasterLayer> {
-    public static final String REACT_CLASS = RCTMGLRasterLayer.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLRasterLayer";
 
     @Override
     public String getName() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLSymbolLayerManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLSymbolLayerManager.java
@@ -11,7 +11,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
  */
 
 public class RCTMGLSymbolLayerManager extends ViewGroupManager<RCTMGLSymbolLayer> {
-    public static final String REACT_CLASS = RCTMGLSymbolLayer.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLSymbolLayer";
 
     @Override
     public String getName() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/light/RCTMGLLightManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/light/RCTMGLLightManager.java
@@ -10,7 +10,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
  */
 
 public class RCTMGLLightManager extends ViewGroupManager<RCTMGLLight> {
-    public static final String REACT_CLASS = RCTMGLLight.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLLight";
 
     @Override
     public String getName() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLImageSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLImageSourceManager.java
@@ -17,7 +17,7 @@ import com.mapbox.rctmgl.utils.GeoJSONUtils;
  */
 
 public class RCTMGLImageSourceManager extends ViewGroupManager<RCTMGLImageSource> {
-    final String REACT_CLASS = RCTMGLImageSource.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLImageSource";
 
     @Override
     public String getName() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLRasterSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLRasterSourceManager.java
@@ -11,7 +11,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
  */
 
 public class RCTMGLRasterSourceManager extends ViewGroupManager<RCTMGLRasterSource> {
-    public static final String REACT_CLASS = RCTMGLRasterSource.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLRasterSource";
 
     @Override
     public String getName() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
@@ -37,7 +37,7 @@ import java.util.Map;
 
 public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSource> {
     public static final String LOG_TAG = RCTMGLShapeSourceManager.class.getSimpleName();
-    public static final String REACT_CLASS = RCTMGLShapeSource.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLShapeSource";
 
     private ReactApplicationContext mContext;
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLVectorSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLVectorSourceManager.java
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 
 public class RCTMGLVectorSourceManager extends AbstractEventEmitter<RCTMGLVectorSource> {
-    public static final String REACT_CLASS = RCTMGLVectorSource.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLVectorSource";
 
     public RCTMGLVectorSourceManager(ReactApplicationContext reactApplicationContext) {
         super(reactApplicationContext);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLocationModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLocationModule.java
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 import com.mapbox.android.core.location.LocationEngineCallback;
 import com.mapbox.android.core.location.LocationEngineResult;
@@ -16,8 +17,9 @@ import com.mapbox.rctmgl.events.IEvent;
 import com.mapbox.rctmgl.events.LocationEvent;
 import com.mapbox.rctmgl.location.LocationManager;
 
+@ReactModule(name = RCTMGLLocationModule.REACT_CLASS)
 public class RCTMGLLocationModule extends ReactContextBaseJavaModule {
-    public static final String REACT_CLASS = RCTMGLLocationModule.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLLocationModule";
     public static final String LOCATION_UPDATE = "MapboxUserLocationUpdate";
 
     private boolean isEnabled;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.module.annotations.ReactModule;
 import com.mapbox.mapboxsdk.maps.TelemetryDefinition;
 import com.mapbox.mapboxsdk.Mapbox;
 // import com.mapbox.mapboxsdk.constants.Style;
@@ -37,8 +38,9 @@ import javax.annotation.Nullable;
  * Created by nickitaliano on 8/18/17.
  */
 
+@ReactModule(name = RCTMGLModule.REACT_CLASS)
 public class RCTMGLModule extends ReactContextBaseJavaModule {
-    public static final String REACT_CLASS = RCTMGLModule.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLModule";
 
     private static boolean customHeaderInterceptorAdded = false;
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 import com.mapbox.geojson.FeatureCollection;
 // import com.mapbox.mapboxsdk.constants.Style;
@@ -42,8 +43,9 @@ import java.util.Locale;
  * Created by nickitaliano on 10/24/17.
  */
 
+@ReactModule(name = RCTMGLOfflineModule.REACT_CLASS)
 public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
-    public static final String REACT_CLASS = RCTMGLOfflineModule.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLOfflineModule";
 
     public static final int INACTIVE_REGION_DOWNLOAD_STATE = OfflineRegion.STATE_INACTIVE;
     public static final int ACTIVE_REGION_DOWNLOAD_STATE = OfflineRegion.STATE_ACTIVE;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLSnapshotModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLSnapshotModule.java
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.module.annotations.ReactModule;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.geojson.Point;
@@ -37,8 +38,9 @@ import static android.content.Context.CONTEXT_IGNORE_SECURITY;
  * Created by nickitaliano on 11/30/17.
  */
 
+@ReactModule(name = RCTMGLSnapshotModule.REACT_CLASS)
 public class RCTMGLSnapshotModule extends ReactContextBaseJavaModule {
-    public static final String REACT_CLASS = RCTMGLSnapshotModule.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLSnapshotModule";
 
     private ReactApplicationContext mContext;
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -80,7 +80,7 @@ apply from: "../../node_modules/react-native/react.gradle"
 
 
 def enableSeparateBuildPerCPUArchitecture = false
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion


### PR DESCRIPTION
When using proguard class names will get minified so it is not safe to use them for the module name. This simply replaces it by static strings. Also add `@ReactModule` annotation to native modules.

Tested in the example app.