### PR TITLE
Fix ShapeSource tolerance prop on iOS

### DIFF
--- a/ios/RCTMGL/RCTMGLShapeSource.h
+++ b/ios/RCTMGL/RCTMGLShapeSource.h
@@ -26,7 +26,7 @@
 
 @property (nonatomic, strong) NSNumber *maxZoomLevel;
 @property (nonatomic, strong) NSNumber *buffer;
-@property (nonatomic, strong) NSNumber *tolerence;
+@property (nonatomic, strong) NSNumber *tolerance;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 @property (nonatomic, assign) BOOL hasPressListener;

--- a/ios/RCTMGL/RCTMGLShapeSource.m
+++ b/ios/RCTMGL/RCTMGLShapeSource.m
@@ -98,8 +98,8 @@ static UIImage * _placeHolderImage;
         options[MGLShapeSourceOptionBuffer] = _buffer;
     }
     
-    if (_tolerence != nil) {
-        options[MGLShapeSourceOptionSimplificationTolerance] = _tolerence;
+    if (_tolerance != nil) {
+        options[MGLShapeSourceOptionSimplificationTolerance] = _tolerance;
     }
     
     return options;


### PR DESCRIPTION
Fixes a spelling error that caused the ShapeSource `tolerance` prop to crash on iOS.

Re: https://github.com/nitaliano/react-native-mapbox-gl/issues/1394