### PR TITLE
Prevent componentWillReceiveProps warning from showing.

### DIFF
--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -110,7 +110,7 @@ class Camera extends React.Component {
     Ease: 'easeTo',
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this._handleCameraChange(this.props, nextProps);
   }
 

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -269,7 +269,7 @@ class MapView extends NativeBridgeComponent {
     this._onDebouncedRegionDidChange.cancel();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this._setHandledMapChangedEvents(nextProps);
   }
 


### PR DESCRIPTION
In reference to https://github.com/react-native-mapbox-gl/maps/issues/289
This suppresses the warning from showing up when people use the component. However we should look to refactor to `componentDidUpdate` as suggested here: https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops

My head is not right into how this component is working in terms of NativeComponent etc. and I have not worked out how to run tests or anything like that so I don't want to provide a `componentDidUpdate` version at this point. Someone who has been working on this should be able to refactor the components pretty quickly to use the `componentDidUpdate` methods to sync the nativeComponents. This PR can help by however preventing people attempting to use this component and getting bad DX which I think is important. 