### PR TITLE
Bump native deps to fix collisions with content insets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Breaking changes:
 
-* iOS mapbox libraries updated to [5.1.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v5.1.0) android libraries updated to [8.1.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.1.0)
-* `StyleSheet.create` removed.  
-Mapbox styles are now just a map no need for `StyleSheet.create`.  
+* iOS mapbox libraries updated to [5.2.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v5.2.0) android libraries updated to [8.2.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.2.1)
+* `StyleSheet.create` removed.
+Mapbox styles are now just a map no need for `StyleSheet.create`.
 `StylesSheet.identity` also removed, use expressions array instead:
    ```jsx
    mapboxStyle=MapboxGL.Stylesheet.create({..., fillColor: MapboxGL.Stylesheet.identity('color') ...})
@@ -14,7 +14,7 @@ Mapbox styles are now just a map no need for `StyleSheet.create`.
      <FillLayer style={mapboxStyle}... />
    </MapView>
    ```
-   
+
    is now:
    ```jsx
    mapboxStyle={..., fillColor: ['get', 'color'] ...}
@@ -37,9 +37,9 @@ Mapbox styles are now just a map no need for `StyleSheet.create`.
       ...
    </MapView>
    ```
-    
+
    is now:
-   
+
    ```jsx
    <MapView
      ...
@@ -60,9 +60,9 @@ Mapbox styles are now just a map no need for `StyleSheet.create`.
       ...
    </MapView>
    ```
-    
+
    is now:
-   
+
    ```jsx
    <MapView
      ...
@@ -72,11 +72,11 @@ Mapbox styles are now just a map no need for `StyleSheet.create`.
         followUserMode="normal"
      />
    </MapView>
-   ``` 
+   ```
    The following properties were changed:
    * MapView#userTrackingMode is now Camera#followUserMode and Camera#followUserLocation
    * followUserMode is now a string with ('normal','compass','course'), and UserTrackingModes enum is deprecated
-   * MapView#onUserTrackingModeChange is now Camera#onUserTrackingModeChange and payload contains followUserMode and followUserLocation. 
+   * MapView#onUserTrackingModeChange is now Camera#onUserTrackingModeChange and payload contains followUserMode and followUserLocation.
 
 * ShapeSource#images was depreacted, use Images#images instead.
    ```jsx

--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     // Mapbox SDK
 
     implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.8.0'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:8.1.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:8.2.1'
 
     // Dependencies
     implementation "com.android.support:support-vector-drawable:${safeExtGet('supportLibVersion', '28.0.0')}"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/react-native-mapbox-gl/maps"
   },
   "scripts": {
-    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 5.1.0",
+    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 5.2.0",
     "fetch:style:spec": ". ./scripts/download-style-spec.sh",
     "generate": "node ./scripts/autogenerate",
     "preinstall": "npm run fetch:ios:sdk",

--- a/scripts/autogenerate.js
+++ b/scripts/autogenerate.js
@@ -17,8 +17,8 @@ if (!styleSpecJSON) {
 }
 
 const layers = [];
-const androidVersion = '8.1.0';
-const iosVersion = '5.1.0';
+const androidVersion = '8.2.1';
+const iosVersion = '5.2.0';
 
 const TMPL_PATH = path.join(__dirname, 'templates');
 


### PR DESCRIPTION
Version 8.1.0 / 5.1.0 has a bug when using content insets. Bump native lib versions to bring in the fix https://github.com/mapbox/mapbox-gl-native/pull/15130.