### PR TITLE
childview check for instanceof ViewGroup in RCTMGLMapView

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -191,7 +191,7 @@ public class RCTMGLMapView extends MapView implements
             RCTMGLCamera camera = (RCTMGLCamera) childView;
             mCamera = camera;
             feature = (AbstractMapFeature) childView;
-        } else {
+        } else if (childView instanceof ViewGroup) {
             ViewGroup children = (ViewGroup) childView;
 
             for (int i = 0; i < children.getChildCount(); i++) {


### PR DESCRIPTION
The issue documented in the previous mapbox project ([issue #953)](https://github.com/nitaliano/react-native-mapbox-gl/issues/953) is still occurring on Android. Seems like childview casts should all be checked in a similar way and this does not appear to cause any side effects.

see https://github.com/nitaliano/react-native-mapbox-gl/issues/953