### PR TITLE
Fix camera fitBounds animation android

### DIFF
--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -291,7 +291,7 @@ class Camera extends React.Component {
         ...pad,
       },
       animationDuration,
-      animationMode: Camera.Mode.Move,
+      animationMode: animationDuration === 0.0 ? Camera.Mode.Move : Camera.Mode.Ease,
     });
   }
 

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -291,7 +291,7 @@ class Camera extends React.Component {
         ...pad,
       },
       animationDuration,
-      animationMode: animationDuration === 0.0 ? Camera.Mode.Move : Camera.Mode.Ease,
+      animationMode: Camera.Mode.Ease,
     });
   }
 


### PR DESCRIPTION
Despite `this.camera.fitBounds(northEastCoordinates, southWestCoordinates[, padding][, animationDuration])` accepts `animationDuration` parameter, the animation does not work on Android. The reason for this is that this method sets `animationMode` to `Camera.Mode.Move` which is mapped later to `CameraModes.None` which in turn causes absence of animation.

I propose to use `Camera.Mode.Ease` for cases when `animationDuration` is not equal to `0.0` as in this case it is properly mapped and causes animation to appear. Other solution is to always use `Camera.Mode.Ease` animation in this method instead of `Camera.Mode.Move`, which will simplify the fix even more.