### PR TITLE
Use `[RCTBridge moduleForName]` instead of deprecated `[RCTBridge imageLoader]`

### DIFF
--- a/ios/RCTMGL/RCTMGLImageQueueOperation.m
+++ b/ios/RCTMGL/RCTMGLImageQueueOperation.m
@@ -18,17 +18,18 @@
     if (self.isCancelled) {
         return;
     }
-    
+
     __weak RCTMGLImageQueueOperation *weakSelf = self;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        cancellationBlock = [weakSelf.bridge.imageLoader loadImageWithURLRequest:weakSelf.urlRequest
-                                                                            size:CGSizeZero
-                                                                           scale:self.scale
-                                                                         clipped:YES
-                                                                      resizeMode:RCTResizeModeStretch
-                                                                   progressBlock:nil
-                                                                partialLoadBlock:nil
-                                                                 completionBlock:weakSelf.completionHandler];
+        cancellationBlock = [[weakSelf.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES]
+                             loadImageWithURLRequest:weakSelf.urlRequest
+                             size:CGSizeZero
+                             scale:weakSelf.scale
+                             clipped:YES
+                             resizeMode:RCTResizeModeStretch
+                             progressBlock:nil
+                             partialLoadBlock:nil
+                             completionBlock:weakSelf.completionHandler];
     });
 }
 


### PR DESCRIPTION
The image loader module should now be loaded using this https://github.com/facebook/react-native/blob/80f64f1e5bddad6e4df88efa4c28e09db7462d04/Libraries/Image/RCTImageViewManager.m#L92.

The method was added 10 months ago so it should be fine for backwards compat.

Tested that the project builds and examples with images still work.