### PR TITLE
Implementation of custom headers for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ npm install @react-native-mapbox-gl/maps --save
 * [OfflineManager](/docs/OfflineManager.md)
 * [SnapshotManager](/docs/snapshotManager.md)
 
+### Misc
+* [CustomHttpHeaders](/docs/CustomHttpHeaders.md)
+
+
 ## Expo Support
 We have a feature request open with Expo if you want to see it get in show your support https://expo.canny.io/feature-requests/p/add-mapbox-gl-support
 

--- a/docs/CustomHttpHeaders.md
+++ b/docs/CustomHttpHeaders.md
@@ -1,0 +1,86 @@
+## Custom http headers
+
+### Intro
+
+Custom headers are implemented using OkHttp interseptor for android and method swizzling for iOS.
+
+[Method swizzling](https://en.wikipedia.org/wiki/Monkey_patch) is done on the `[NSMutableURLRequest requestWithURL:]` to allow adding headers during runtime.
+
+### Prerequisites
+
+#### Android 
+
+None
+
+#### IOS
+
+To enable this on iOS you need to call `[MGLCustomHeaders initHeaders]` pretty early in the lifecycle of the application. This will swizzle the custom method.
+Suggested location is `[AppDelegate application: didFinishLaunchingWithOptions:]`
+
+#### Working example (AppDelegate.m)
+
+```obj-c
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
+                                                   moduleName:@"SampleApp"
+                                            initialProperties:nil];
+  // *** Init headers, add swizzle method
+  [MGLCustomHeaders initHeaders];
+  // *** Optionally you can add some global headers here
+  [[MGLCustomHeaders sharedInstance] addHeader:@"IP" forHeaderName:@"X-For-Real"];
+
+  ...
+  return YES;
+}
+
+...
+
+@end
+```
+
+
+### Sending custom http headers with the tile requests
+
+You can configure sending of custom http headers to your tile server. This is to support custom authentication or custom metadata which can't be included in the url.
+
+You can add and remove headers at runtime.
+
+#### To add a header
+
+```javascript
+    MapboxGL.addCustomHeader('Authorization', '{auth header}');
+```
+
+#### To remove a header
+
+```javascript
+    MapboxGL.removeCustomHeader('Authorization');
+```
+
+#### Working example
+
+```javascript
+export default class HelloWorldApp extends Component {
+  componentDidMount() {
+    MapboxGL.addCustomHeader('Authorization', '{auth header}');
+  }
+
+  render() {
+    MapboxGL.addCustomHeader('X-Some-Header', 'my-value');
+    return (
+      <View style={styles.page}>
+        <View style={styles.container}>
+          <MapboxGL.MapView 
+            style={styles.map} 
+            styleURL={STYLE_URL} />
+        </View>
+      </View>
+    );
+  }
+}
+```
+

--- a/ios/RCTMGL.xcodeproj/project.pbxproj
+++ b/ios/RCTMGL.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		431CDACE229D61A6008BE92D /* RCTMGLUserLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 431CDACC229D61A6008BE92D /* RCTMGLUserLocation.m */; };
+		641DE8A8231019E8003B792D /* MGLCustomHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 641DE8A7231019E8003B792D /* MGLCustomHeaders.m */; };
 		C410D5D51F7AD0B300CF822A /* RCTMGLLight.m in Sources */ = {isa = PBXBuildFile; fileRef = C410D5D41F7AD0B300CF822A /* RCTMGLLight.m */; };
 		C410D5D81F7AD0C100CF822A /* RCTMGLLightManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C410D5D71F7AD0C100CF822A /* RCTMGLLightManager.m */; };
 		C416015020112B5200006116 /* RNMBImageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = C416014F20112B5200006116 /* RNMBImageUtils.m */; };
@@ -83,6 +84,8 @@
 /* Begin PBXFileReference section */
 		431CDACC229D61A6008BE92D /* RCTMGLUserLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTMGLUserLocation.m; sourceTree = "<group>"; };
 		431CDACD229D61A6008BE92D /* RCTMGLUserLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTMGLUserLocation.h; sourceTree = "<group>"; };
+		641DE8A6231019E8003B792D /* MGLCustomHeaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLCustomHeaders.h; sourceTree = "<group>"; };
+		641DE8A7231019E8003B792D /* MGLCustomHeaders.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLCustomHeaders.m; sourceTree = "<group>"; };
 		C410D5D31F7AD0B300CF822A /* RCTMGLLight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTMGLLight.h; sourceTree = "<group>"; };
 		C410D5D41F7AD0B300CF822A /* RCTMGLLight.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTMGLLight.m; sourceTree = "<group>"; };
 		C410D5D61F7AD0C100CF822A /* RCTMGLLightManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTMGLLightManager.h; sourceTree = "<group>"; };
@@ -330,6 +333,8 @@
 		C4D144501F4E188F00396F26 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				641DE8A6231019E8003B792D /* MGLCustomHeaders.h */,
+				641DE8A7231019E8003B792D /* MGLCustomHeaders.m */,
 				C4D144511F4E190C00396F26 /* MGLModule.h */,
 				C4D144521F4E190C00396F26 /* MGLModule.m */,
 				C470F6AA1FA11C9500614A69 /* MGLOfflineModule.h */,
@@ -572,6 +577,7 @@
 				C4EAF17D1F6324970016DEE8 /* RCTMGLSource.m in Sources */,
 				C490EE0220DC565000CB2E57 /* RCTMGLLocationModule.m in Sources */,
 				C4FB11131F71EC9F0055AE1F /* RCTMGLSymbolLayerManager.m in Sources */,
+				641DE8A8231019E8003B792D /* MGLCustomHeaders.m in Sources */,
 				C4C87A601F844C820064AE95 /* FilterParser.m in Sources */,
 				C4FD1DBF1FCF54FB00213AF2 /* RCTMGLImageSource.m in Sources */,
 				C4EAF12A1F6084920016DEE8 /* CameraUpdateQueue.m in Sources */,

--- a/ios/RCTMGL/MGLCustomHeaders.h
+++ b/ios/RCTMGL/MGLCustomHeaders.h
@@ -12,8 +12,8 @@
 
 @property (nonatomic, strong) NSMutableDictionary<NSString*, NSString*> *currentHeaders;
 
-+ (void)initHeaders;
 + (id)sharedInstance;
+- (void)initHeaders;
 - (void)addHeader:(NSString*)value forHeaderName:(NSString *)header;
 - (void)removeHeader:(NSString *)header;
 

--- a/ios/RCTMGL/MGLCustomHeaders.h
+++ b/ios/RCTMGL/MGLCustomHeaders.h
@@ -1,0 +1,20 @@
+//
+//  MGLCustomHeaders.h
+//  RCTMGL
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSMutableURLRequest (CustomHeaders)
+@end
+
+@interface MGLCustomHeaders : NSObject
+
+@property (nonatomic, strong) NSMutableDictionary<NSString*, NSString*> *currentHeaders;
+
++ (void)initHeaders;
++ (id)sharedInstance;
+- (void)addHeader:(NSString*)value forHeaderName:(NSString *)header;
+- (void)removeHeader:(NSString *)header;
+
+@end

--- a/ios/RCTMGL/MGLCustomHeaders.m
+++ b/ios/RCTMGL/MGLCustomHeaders.m
@@ -10,15 +10,6 @@
 #import <MapBox/MGLNetworkConfiguration.h>
 
 @implementation NSMutableURLRequest (CustomHeaders)
-    + (void)load {
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            Class class = [self class];
-            Method oldMethod = class_getClassMethod(class, @selector(requestWithURL:));
-            Method newMethod = class_getClassMethod(class, @selector(__swizzle_requestWithURL:));
-            method_exchangeImplementations(oldMethod, newMethod);
-        });
-    }
 
     +(NSMutableURLRequest*) __swizzle_requestWithURL:(NSURL*)url {
         if([url.scheme isEqualToString:@"ws"]) {
@@ -62,10 +53,11 @@
 
 // This replaces the [NSMutableURLRequest requestWithURL:] with custom implementation which
 // adds runtime headers copied from [MGLCustomHeaders _currentHeaders]
-+(void)initHeaders
+-(void)initHeaders
 {
     if (!areHeadersAdded) {
-        areHeadersAdded = YES
+        areHeadersAdded = YES;
+        NSLog(@"Replace method [NSMutableURLRequest requestWithURL]");
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
             Class targetClass = [NSMutableURLRequest class];

--- a/ios/RCTMGL/MGLCustomHeaders.m
+++ b/ios/RCTMGL/MGLCustomHeaders.m
@@ -64,20 +64,23 @@
 // adds runtime headers copied from [MGLCustomHeaders _currentHeaders]
 +(void)initHeaders
 {
-    //TODO: Protect so this happens only once
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        Class targetClass = [NSMutableURLRequest class];
-        Method oldMethod = class_getClassMethod(targetClass, @selector(requestWithURL:));
-        Method newMethod = class_getClassMethod(targetClass, @selector(__swizzle_requestWithURL:));
-        method_exchangeImplementations(oldMethod, newMethod);
-    });
+    if (!areHeadersAdded) {
+        areHeadersAdded = YES
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            Class targetClass = [NSMutableURLRequest class];
+            Method oldMethod = class_getClassMethod(targetClass, @selector(requestWithURL:));
+            Method newMethod = class_getClassMethod(targetClass, @selector(__swizzle_requestWithURL:));
+            method_exchangeImplementations(oldMethod, newMethod);
+        });
+    }
 }
 
 - (instancetype)init
 {
     if (self = [super init]) {
         _currentHeaders = [[NSMutableDictionary alloc] init];
+        areHeadersAdded = NO;
     }
     return self;
 }

--- a/ios/RCTMGL/MGLCustomHeaders.m
+++ b/ios/RCTMGL/MGLCustomHeaders.m
@@ -1,0 +1,105 @@
+//
+//  MGLCustomHeaders.h
+//  RCTMGL
+//
+
+#import <objc/runtime.h>
+
+#import "MGLCustomHeaders.h"
+#import <Mapbox/Mapbox.h>
+#import <MapBox/MGLNetworkConfiguration.h>
+
+@implementation NSMutableURLRequest (CustomHeaders)
+    + (void)load {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            Class class = [self class];
+            Method oldMethod = class_getClassMethod(class, @selector(requestWithURL:));
+            Method newMethod = class_getClassMethod(class, @selector(__swizzle_requestWithURL:));
+            method_exchangeImplementations(oldMethod, newMethod);
+        });
+    }
+
+    +(NSMutableURLRequest*) __swizzle_requestWithURL:(NSURL*)url {
+        if([url.scheme isEqualToString:@"ws"]) {
+            return [NSMutableURLRequest __swizzle_requestWithURL:url];
+        }
+        
+        NSArray<NSString*>* stack = [NSThread callStackSymbols];
+        if ([stack count] < 2) {
+            return [NSMutableURLRequest __swizzle_requestWithURL:url];
+        }
+        
+        if ([stack[1] containsString:@"Mapbox"] == NO) {
+            return [NSMutableURLRequest __swizzle_requestWithURL:url];
+        }
+        
+        NSMutableURLRequest *req = [NSMutableURLRequest __swizzle_requestWithURL:url];
+        NSDictionary<NSString*, NSString*> *currentHeaders = [[[MGLCustomHeaders sharedInstance] currentHeaders] copy];
+        if(currentHeaders != nil && [currentHeaders count]>0) {
+            for (NSString* headerName in currentHeaders) {
+                id headerValue = currentHeaders[headerName];
+                [req setValue:headerValue forHTTPHeaderField:headerName];
+            }
+        }        
+        return req;
+    }
+
+@end
+
+@implementation MGLCustomHeaders {
+    NSMutableDictionary<NSString*, NSString*> *_currentHeaders;
+    BOOL areHeadersAdded;
+}
+
++ (id)sharedInstance
+{
+    static MGLCustomHeaders *customHeaders;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ customHeaders = [[self alloc] init]; });
+    return customHeaders;
+}
+
+// This replaces the [NSMutableURLRequest requestWithURL:] with custom implementation which
+// adds runtime headers copied from [MGLCustomHeaders _currentHeaders]
++(void)initHeaders
+{
+    //TODO: Protect so this happens only once
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class targetClass = [NSMutableURLRequest class];
+        Method oldMethod = class_getClassMethod(targetClass, @selector(requestWithURL:));
+        Method newMethod = class_getClassMethod(targetClass, @selector(__swizzle_requestWithURL:));
+        method_exchangeImplementations(oldMethod, newMethod);
+    });
+}
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _currentHeaders = [[NSMutableDictionary alloc] init];
+    }
+    return self;
+}
+
+- (void)addHeader:(NSString *)value forHeaderName:(NSString *)headerName {
+    
+    if(!areHeadersAdded) {
+        areHeadersAdded = YES;
+    }
+    
+    NSLog(@"Add custom header %@ %@", headerName, value);
+    [_currentHeaders setObject:value forKey:headerName];
+    [[[MGLNetworkConfiguration sharedManager] sessionConfiguration] setHTTPAdditionalHeaders:_currentHeaders];    
+}
+
+- (void)removeHeader:(NSString *)header {
+    if(!areHeadersAdded) {
+        return;
+    }
+    
+    NSLog(@"Remove custom header %@", header);
+    [_currentHeaders removeObjectForKey:header];
+}
+
+@end

--- a/ios/RCTMGL/MGLModule.m
+++ b/ios/RCTMGL/MGLModule.m
@@ -11,6 +11,7 @@
 #import "MGLOfflineModule.h"
 #import "CameraMode.h"
 #import "RCTMGLSource.h"
+#import "MGLCustomHeaders.h"
 @import Mapbox;
 
 @implementation MGLModule
@@ -243,12 +244,13 @@ RCT_EXPORT_METHOD(setAccessToken:(NSString *)accessToken)
 
 RCT_EXPORT_METHOD(addCustomHeader:(NSString *)headerName forHeaderValue:(NSString *) headerValue)
 {
-    // do nothing for now
+    //[RCTMGLImageQueue.sharedInstance addImage:url scale:scale bridge:bridge completionHandler:callback];
+    [MGLCustomHeaders.sharedInstance addHeader:headerValue forHeaderName:headerName];
 }
 
 RCT_EXPORT_METHOD(removeCustomHeader:(NSString *)headerName)
 {
-    // do nothing for now
+    [MGLCustomHeaders.sharedInstance removeHeader:headerName];
 }
 
 RCT_EXPORT_METHOD(getAccessToken:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/RCTMGL/MGLModule.m
+++ b/ios/RCTMGL/MGLModule.m
@@ -244,7 +244,6 @@ RCT_EXPORT_METHOD(setAccessToken:(NSString *)accessToken)
 
 RCT_EXPORT_METHOD(addCustomHeader:(NSString *)headerName forHeaderValue:(NSString *) headerValue)
 {
-    //[RCTMGLImageQueue.sharedInstance addImage:url scale:scale bridge:bridge completionHandler:callback];
     [MGLCustomHeaders.sharedInstance addHeader:headerValue forHeaderName:headerName];
 }
 


### PR DESCRIPTION
Second part of my custom headers pull req. Adding iOS implementation.

Uses method swizzling as the [MGLNetworkConfiguration sessionConfiguration] is used once early on and does not allow adding of headers at runtime.