### PR TITLE
Fix casting of NSNumber to NSUInteger in RCTMGLLayer

### DIFF
--- a/ios/RCTMGL/RCTMGLLayer.m
+++ b/ios/RCTMGL/RCTMGLLayer.m
@@ -68,7 +68,7 @@
     _layerIndex = layerIndex;
     if (_styleLayer != nil) {
         [self removeFromMap:_style];
-        [self insertAtIndex:(NSUInteger)_layerIndex];
+        [self insertAtIndex:_layerIndex.unsignedIntegerValue];
     }
 }
 
@@ -157,7 +157,7 @@
     } else if (_belowLayerID != nil) {
         [self insertBelow:_belowLayerID];
     } else if (_layerIndex != nil) {
-        [self insertAtIndex:(NSUInteger)_layerIndex];
+        [self insertAtIndex:_layerIndex.unsignedIntegerValue];
     } else {
         [_style addLayer:_styleLayer];
         [_map layerAdded:_styleLayer];


### PR DESCRIPTION
Fix incorrect casting of object NSNumber to primitive NSUInteger. This incorrect casting resulted in a crash on iOS when using layerIndex. 

This PR should fix the issue: https://github.com/react-native-mapbox-gl/maps/issues/66

Closes: #66 