### PR TITLE
🤖 Fix crash when no location permission on Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
@@ -122,7 +122,13 @@ public class LocationManager implements LocationEngineCallback<LocationEngineRes
             callback.onFailure(new Exception("LocationEngine not initialized"));
         }
 
-        locationEngine.getLastLocation(callback);
+        try {
+            locationEngine.getLastLocation(callback);
+        }
+        catch(Exception exception) {
+            Log.w(LOG_TAG, exception);
+            callback.onFailure(exception);
+        }
     }
 
     public LocationEngine getEngine() {


### PR DESCRIPTION
If the user denies the location permission, an Exception is raised and the current behavior is a complete crash at map display.

Here is the exception in adb:
```
09-10 20:12:38.529 15010 15066 E AndroidRuntime: FATAL EXCEPTION: mqt_native_modules
09-10 20:12:38.529 15010 15066 E AndroidRuntime: Process: com.sparks, PID: 15010
09-10 20:12:38.529 15010 15066 E AndroidRuntime: java.lang.SecurityException: "passive" location provider requires ACCESS_FINE_LOCATION permission.
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at android.os.Parcel.createException(Parcel.java:1950)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at android.os.Parcel.readException(Parcel.java:1918)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at android.os.Parcel.readException(Parcel.java:1868)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at android.location.ILocationManager$Stub$Proxy.getLastLocation(ILocationManager.java:907)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at android.location.LocationManager.getLastKnownLocation(LocationManager.java:1511)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.mapbox.android.core.location.AndroidLocationEngineImpl.getLastLocationFor(AndroidLocationEngineImpl.java:58)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.mapbox.android.core.location.MapboxFusedLocationEngineImpl.getBestLastLocation(MapboxFusedLocationEngineImpl.java:81)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.mapbox.android.core.location.MapboxFusedLocationEngineImpl.getLastLocation(MapboxFusedLocationEngineImpl.java:36)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.mapbox.android.core.location.LocationEngineProxy.getLastLocation(LocationEngineProxy.java:25)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.mapbox.rctmgl.location.LocationManager.getLastKnownLocation(LocationManager.java:125)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.mapbox.rctmgl.modules.RCTMGLLocationModule.getLastKnownLocation(RCTMGLLocationModule.java:90)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:158)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:873)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:193)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:232)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:764)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: Caused by: android.os.RemoteException: Remote stack trace:
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.android.server.LocationManagerService.checkResolutionLevelIsSufficientForProviderUse(LocationManagerService.java:1571)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at com.android.server.LocationManagerService.getLastLocation(LocationManagerService.java:2414)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at android.location.ILocationManager$Stub.onTransact(ILocationManager.java:159)
09-10 20:12:38.529 15010 15066 E AndroidRuntime: 	at android.os.Binder.execTransact(Binder.java:752)
```


This PR solves the issue by handling the Exception correctly.

