### PR TITLE
Fix install instruction for iOS and auto linking

### DIFF
--- a/ios/install.md
+++ b/ios/install.md
@@ -1,6 +1,13 @@
 # iOS Installation
 
-## If you are using autolinking feature introduced in React-Native `0.60.0` you do not need any additional steps.
+## React-Native > `0.60.0` 
+If you are using autolinking feature introduced in 0.60.0
+You do only need 1 additional step:
+
+Add the following entry to Build Settings -> Framework Search Paths (Debug and Release)
+${PROJECT_DIR}/../node_modules/@react-native-mapbox-gl/maps (recursive)
+
+
 
 ## Using CocoaPods
 

--- a/ios/install.md
+++ b/ios/install.md
@@ -7,7 +7,7 @@ You do only need 1 additional step:
 Add the following entry to Build Settings -> Framework Search Paths (Debug and Release)
 ${PROJECT_DIR}/../node_modules/@react-native-mapbox-gl/maps (recursive)
 
-![alt text](https://user-images.githubusercontent.com/6492229/64736515-19658f00-d4eb-11e9-974f-3aa3f03406d8.png)
+![](https://user-images.githubusercontent.com/6492229/64736515-19658f00-d4eb-11e9-974f-3aa3f03406d8.png)
 
 ## Using CocoaPods
 

--- a/ios/install.md
+++ b/ios/install.md
@@ -7,7 +7,7 @@ You do only need 1 additional step:
 Add the following entry to Build Settings -> Framework Search Paths (Debug and Release)
 ${PROJECT_DIR}/../node_modules/@react-native-mapbox-gl/maps (recursive)
 
-
+![alt text](https://user-images.githubusercontent.com/6492229/64736515-19658f00-d4eb-11e9-974f-3aa3f03406d8.png)
 
 ## Using CocoaPods
 


### PR DESCRIPTION
It did not compile and did have an error Framework not found till I added the framework to the search path