### PR TITLE
Add compass positioning and margins

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -934,8 +934,10 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         }
 
         if (mCompassEnabled != null && uiSettings.isCompassEnabled()) {
-            int xMargin = mCompassViewMargins.getInt("x") * 2;
-            int yMargin = mCompassViewMargins.getInt("y") * 2;
+            Double pixelDensity = getResources().getDisplayMetrics().density;
+
+            int xMargin = mCompassViewMargins.getInt("x") * pixelDensity;
+            int yMargin = mCompassViewMargins.getInt("y") * pixelDensity;
             uiSettings.setCompassMargins(xMargin, yMargin, xMargin, yMargin);
         }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -109,6 +109,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     private int[] mAttributionMargin;
     private Boolean mLogoEnabled;
     private Boolean mCompassEnabled;
+    private ReadableMap mCompassViewMargins;
     private Boolean mZoomEnabled;
 
     private MarkerViewManager markerViewManager;
@@ -714,6 +715,11 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         updateUISettings();
     }
 
+    public void setReactCompassViewMargins(ReadableMap compassViewMargins) {
+        mCompassViewMargins = compassViewMargins;
+        updateUISettings();
+    }
+
     public void setReactAttributionEnabled(boolean attributionEnabled) {
         mAttributionEnabled = attributionEnabled;
         updateUISettings();
@@ -925,6 +931,12 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
 
         if (mCompassEnabled != null && uiSettings.isCompassEnabled() != mCompassEnabled) {
             uiSettings.setCompassEnabled(mCompassEnabled);
+        }
+
+        if (mCompassEnabled != null && uiSettings.isCompassEnabled()) {
+            int xMargin = mCompassViewMargins.getInt("x") * 2;
+            int yMargin = mCompassViewMargins.getInt("y") * 2;
+            uiSettings.setCompassMargins(xMargin, yMargin, xMargin, yMargin);
         }
 
         if (mZoomEnabled != null && uiSettings.isZoomGesturesEnabled() != mZoomEnabled) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -934,7 +934,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         }
 
         if (mCompassEnabled != null && uiSettings.isCompassEnabled()) {
-            Double pixelDensity = getResources().getDisplayMetrics().density;
+            int pixelDensity = (int)getResources().getDisplayMetrics().density;
 
             int xMargin = mCompassViewMargins.getInt("x") * pixelDensity;
             int yMargin = mCompassViewMargins.getInt("y") * pixelDensity;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -169,6 +169,11 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
         mapView.setReactCompassEnabled(compassEnabled);
     }
 
+    @ReactProp(name="compassViewMargins")
+    public void setCompassViewMargins(RCTMGLMapView mapView, ReadableMap compassViewMargins){
+        mapView.setReactCompassViewMargins(compassViewMargins);
+    }
+
     @ReactProp(name="contentInset")
     public void setContentInset(RCTMGLMapView mapView, ReadableArray array) {
         mapView.setReactContentInset(array);

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -134,7 +134,6 @@ Map camera will perform updates based on provided config. Deprecated use Camera#
 
 
 
-
 #### takeSnap(writeToDisk)
 
 Takes snapshot of map with current tiles and returns a URI to the image

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -17,6 +17,8 @@
 | attributionPosition | `union` | `none` | `false` | Adds attribution offset, e.g. `{top: 8, left: 8}` will put attribution button in top-left corner of the map |
 | logoEnabled | `bool` | `true` | `false` | Enable/Disable the logo on the map. |
 | compassEnabled | `bool` | `none` | `false` | Enable/Disable the compass from appearing on the map |
+| compassViewPosition | `number` | `1` | `false` | Change corner of map the compass starts at. (iOS only) 0: TopLeft, 1: TopRight, 2: BottomLeft, 3: BottomRight |
+| compassViewMargins | `object` | `none` | `false` | Add margins to the compass. |
 | surfaceView | `bool` | `false` | `false` | [Android only] Enable/Disable use of GLSurfaceView insted of TextureView. |
 | onPress | `func` | `none` | `false` | Map press listener, gets called when a user presses the map |
 | onLongPress | `func` | `none` | `false` | Map long press listener, gets called when a user long presses the map |
@@ -129,6 +131,7 @@ Map camera will perform updates based on provided config. Deprecated use Camera#
 ##### arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
+
 
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -179,6 +179,8 @@ export interface MapViewProps extends ViewProperties {
     attributionPosition?: AttributionPosition;
     logoEnabled?: boolean;
     compassEnabled?: boolean;
+    compassViewPosition?: number;
+    compassViewMargins?: object;
     surfaceView?: boolean;
     regionWillChangeDebounceTime?: number;
     regionDidChangeDebounceTime?: number;

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -46,6 +46,9 @@ typedef void (^FoundLayerBlock) (MGLStyleLayer* layer);
 @property (nonatomic, assign) BOOL reactCompassEnabled;
 @property (nonatomic, assign) BOOL reactZoomEnabled;
 
+@property (nonatomic, assign) NSInteger *reactCompassViewPosition;
+// @property (nonatomic, assign) NSDictionary <NSString *, NSNumber *>*reactCompassViewMargins;
+
 @property (nonatomic, copy) NSString *reactStyleURL;
 @property (nonatomic, assign) NSInteger *reactPreferredFramesPerSecond;
 

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -47,7 +47,7 @@ typedef void (^FoundLayerBlock) (MGLStyleLayer* layer);
 @property (nonatomic, assign) BOOL reactZoomEnabled;
 
 @property (nonatomic, assign) NSInteger *reactCompassViewPosition;
-// @property (nonatomic, assign) NSDictionary <NSString *, NSNumber *>*reactCompassViewMargins;
+@property (nonatomic, assign) CGPoint reactCompassViewMargins;
 
 @property (nonatomic, copy) NSString *reactStyleURL;
 @property (nonatomic, assign) NSInteger *reactPreferredFramesPerSecond;

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -41,7 +41,7 @@ static double const M2PI = M_PI * 2;
     [super layoutSubviews];
     if (_pendingInitialLayout) {
         _pendingInitialLayout = NO;
-
+        
         [   _reactCamera initialLayout];
     }
 }
@@ -109,7 +109,7 @@ static double const M2PI = M_PI * 2;
         camera.map = self;
     } else {
         NSArray<id<RCTComponent>> *childSubviews = [subview reactSubviews];
-
+        
         for (int i = 0; i < childSubviews.count; i++) {
             [self addToMap:childSubviews[i]];
         }
@@ -245,14 +245,12 @@ static double const M2PI = M_PI * 2;
     }
 }
 
-//- (void)setReactCompassViewMargins:(NSDictionary *)reactCompassViewMargins
-//{
-//    CGPoint point;
-//    _reactCompassViewMargins = reactCompassViewMargins;
-//    point.x = ([reactCompassViewMargins objectForKey: @"x"]);
-//    point.y = ([reactCompassViewMargins objectForKey: @"y"]);
-//    self.compassViewMargins = point;
-//}
+- (void)setReactCompassViewMargins:(CGPoint)reactCompassViewMargins
+{
+    CGPoint point;
+    point = reactCompassViewMargins;
+    self.compassViewMargins = point;
+}
 
 - (void)setReactShowUserLocation:(BOOL)reactShowUserLocation
 {

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -236,6 +236,24 @@ static double const M2PI = M_PI * 2;
     self.compassView.hidden = !_reactCompassEnabled;
 }
 
+- (void)setReactCompassViewPosition:(NSInteger *)reactCompassViewPosition
+{
+    if(!self.compassView.hidden)
+    {
+        _reactCompassViewPosition = reactCompassViewPosition;
+        self.compassViewPosition = _reactCompassViewPosition;
+    }
+}
+
+//- (void)setReactCompassViewMargins:(NSDictionary *)reactCompassViewMargins
+//{
+//    CGPoint point;
+//    _reactCompassViewMargins = reactCompassViewMargins;
+//    point.x = ([reactCompassViewMargins objectForKey: @"x"]);
+//    point.y = ([reactCompassViewMargins objectForKey: @"y"]);
+//    self.compassViewMargins = point;
+//}
+
 - (void)setReactShowUserLocation:(BOOL)reactShowUserLocation
 {
     // FMTODO

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -247,9 +247,12 @@ static double const M2PI = M_PI * 2;
 
 - (void)setReactCompassViewMargins:(CGPoint)reactCompassViewMargins
 {
-    CGPoint point;
-    point = reactCompassViewMargins;
-    self.compassViewMargins = point;
+    if(!self.compassView.hidden)
+    {
+        CGPoint point;
+        point = reactCompassViewMargins;
+        self.compassViewMargins = point;
+    }
 }
 
 - (void)setReactShowUserLocation:(BOOL)reactShowUserLocation

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -41,7 +41,7 @@ static double const M2PI = M_PI * 2;
     [super layoutSubviews];
     if (_pendingInitialLayout) {
         _pendingInitialLayout = NO;
-        
+
         [   _reactCamera initialLayout];
     }
 }
@@ -109,7 +109,7 @@ static double const M2PI = M_PI * 2;
         camera.map = self;
     } else {
         NSArray<id<RCTComponent>> *childSubviews = [subview reactSubviews];
-        
+
         for (int i = 0; i < childSubviews.count; i++) {
             [self addToMap:childSubviews[i]];
         }

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -79,7 +79,7 @@ RCT_REMAP_VIEW_PROPERTY(compassEnabled, reactCompassEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(zoomEnabled, reactZoomEnabled, BOOL)
 
 RCT_REMAP_VIEW_PROPERTY(compassViewPosition, reactCompassViewPosition, NSInteger *)
-// RCT_REMAP_VIEW_PROPERTY(compassViewMargins, reactCompassViewMargins, NSDictionary <NSString *, CGFloat *>*)
+RCT_REMAP_VIEW_PROPERTY(compassViewMargins, reactCompassViewMargins, CGPoint)
 
 
 RCT_REMAP_VIEW_PROPERTY(contentInset, reactContentInset, NSArray)

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -78,6 +78,10 @@ RCT_REMAP_VIEW_PROPERTY(logoEnabled, reactLogoEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(compassEnabled, reactCompassEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(zoomEnabled, reactZoomEnabled, BOOL)
 
+RCT_REMAP_VIEW_PROPERTY(compassViewPosition, reactCompassViewPosition, NSInteger *)
+// RCT_REMAP_VIEW_PROPERTY(compassViewMargins, reactCompassViewMargins, NSDictionary <NSString *, CGFloat *>*)
+
+
 RCT_REMAP_VIEW_PROPERTY(contentInset, reactContentInset, NSArray)
 RCT_REMAP_VIEW_PROPERTY(styleURL, reactStyleURL, NSString)
 RCT_REMAP_VIEW_PROPERTY(preferredFramesPerSecond, reactPreferredFramesPerSecond, NSInteger)

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -128,12 +128,12 @@ class MapView extends NativeBridgeComponent(React.Component) {
     /**
      * Position the compass on a corner of the map
      */
-    compassPosition: PropTypes.string,
+    compassViewPosition: PropTypes.string,
 
     /**
      * Add margins to the compass with x and y values
      */
-    compassMargins: PropTypes.object,
+    compassViewMargins: PropTypes.object,
 
     /**
      * [Android only] Enable/Disable use of GLSurfaceView insted of TextureView.

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -126,6 +126,16 @@ class MapView extends NativeBridgeComponent(React.Component) {
     compassEnabled: PropTypes.bool,
 
     /**
+     * Position the compass on a corner of the map
+     */
+    compassPosition: PropTypes.string,
+
+    /**
+     * Add margins to the compass with x and y values
+     */
+    compassMargins: PropTypes.object,
+
+    /**
      * [Android only] Enable/Disable use of GLSurfaceView insted of TextureView.
      */
     surfaceView: PropTypes.bool,


### PR DESCRIPTION
This PR features:
- Added numeral enum for compass position. 
   https://docs.mapbox.com/ios/api/maps/5.0.0/Enums/MGLOrnamentPosition.html
  (iOS only) Have not found gravity values for corners to work with [setCompassGravity](https://docs.mapbox.com/android/api/map-sdk/5.1.2/com/mapbox/mapboxsdk/maps/UiSettings.html#setCompassGravity-int-)
- Added use of compass margins (multiplied android values by 2 for better device scaling)
- Added info to docs.
