### PR TITLE
documentation module no longer needs to be globally installed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,7 @@ commit the changes and push them to a fork for creating a pull request.
 1. If you add a feature, make sure you add it to the documentation
 1. If you add an objective-c or java method, make sure you update the declaration file: `index.d.ts`.
 
-
 ## Documentation
 
-1. Documentation is auto-generated from code blocks and comments. To generate documentation:
-  1. `npm install -g documentation` to install documentation generator
-  1. `npm run generate` to generate updated documentation
+Documentation is auto-generated from code blocks and comments.
+Run `npm run generate` to generate updated documentation.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "24.8.0",
+    "documentation": "12.1.2",
     "ejs": "^2.5.7",
     "ejs-lint": "^0.3.0",
     "eslint": "^6.0.0",

--- a/scripts/autogenHelpers/DocJSONBuilder.js
+++ b/scripts/autogenHelpers/DocJSONBuilder.js
@@ -231,7 +231,7 @@ class DocJSONBuilder {
   generateModulesTask(results, filePath) {
     return new Promise((resolve, reject) => {
       exec(
-        `documentation build ${MODULES_PATH} -f json`,
+        `npx documentation build ${MODULES_PATH} -f json`,
         (err, stdout, stderr) => {
           if (err || stderr) {
             reject(err || stderr);


### PR DESCRIPTION
This small change makes it unnecessary to globally install the `documentation` module. [When contributing a PR](https://github.com/react-native-mapbox-gl/maps/pull/384#issuecomment-532775880) I had failed to read the CONTRIBUTING.md which would have told me that it is necessary to globally install, so I was getting a confusing crash when running `npm run generate`. This will make future PRs smoother.

The other upside is that now we'll manage the version of `documentation` ourselves.