### PR TITLE
Typescript definitions for updated VectorSource / RasterSource

### DIFF
--- a/example/scripts/watch_rngl.js
+++ b/example/scripts/watch_rngl.js
@@ -20,6 +20,9 @@ async function main () {
     console.log('Copying javascript');
     await copyFile(path.join(RNGL_EXAMPLE_DIR, 'javascript'), path.join(RNGL_DIR, 'javascript'));
 
+    console.log('Copying typescript');
+    await copyFile(path.join(RNGL_EXAMPLE_DIR, 'index.d.ts'), path.join(RNGL_DIR, 'index.d.ts'));
+
     console.log('Copying java');
     await copyFile(path.join(RNGL_EXAMPLE_DIR, 'android', 'rctmgl', 'src'), path.join(RNGL_DIR, 'android', 'rctmgl', 'src'));
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -478,9 +478,15 @@ export interface CalloutProps extends ViewProps {
 
 }
 
-export interface VectorSourceProps extends ViewProps {
+export interface TileSourceProps extends ViewProps {
     id?: string;
     url?: string;
+    tileUrlTemplates?: Array<string>;
+    minZoomLevel?: number;
+    maxZoomLevel?: number;
+}
+
+export interface VectorSourceProps extends TileSourceProps {
     onPress?: (...args: any[]) => any;
     hitbox?: {
         width: number;
@@ -506,14 +512,8 @@ export interface ShapeSourceProps extends ViewProps {
     };
 }
 
-export interface RasterSourceProps extends ViewProps {
-    id?: MapboxGL.StyleSource;
-    url?: string;
-    minZoomLevel?: number;
-    maxZoomLevel?: number;
+export interface RasterSourceProps extends TileSourceProps {
     tileSize?: number;
-    tms?: boolean;
-    attribution?: string;
 }
 
 export interface LayerBaseProps extends ViewProps {


### PR DESCRIPTION
Typescript related changes for #402
Also updated `copy:changes` script to copy `index.d.ts` from example directory.