### PR TITLE
Automatically generate files precommit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ script:
   - yarn global add -g 'jest@24.8.0'
   - yarn install
   - yarn run unittest
+  - yarn run generate
 deploy:
   provider: npm
   email: kristfallro@gmail.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,5 +20,7 @@ commit the changes and push them to a fork for creating a pull request.
 
 ## Documentation
 
-Documentation is auto-generated from code blocks and comments.
-Run `npm run generate` to generate updated documentation.
+Documentation is generated from code blocks and comments.
+It will be auto-generated when you commit changes.
+If any changes are generated from your edits, the changed files will need to be added using `git add` before attempting the commit again.
+To manually generate the changes, run `npm run generate`.

--- a/javascript/utils/BridgeValue.js
+++ b/javascript/utils/BridgeValue.js
@@ -64,7 +64,9 @@ export default class BridgeValue {
       value = this.rawValue;
     } else {
       throw new Error(
-        `[value - ${this.rawValue}] BridgeValue must be a primitive/array/object`,
+        `[value - ${
+          this.rawValue
+        }] BridgeValue must be a primitive/array/object`,
       );
     }
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "unittest": "jest --coverage --verbose",
     "unittest:single": "jest --testNamePattern",
     "format": "npm run lint -- --fix",
-    "lint": "./node_modules/eslint/bin/eslint.js ./javascript/** ./example/src/** ./__tests__/**",
-    "precommit": "lint-staged"
+    "lint": "./node_modules/eslint/bin/eslint.js ./javascript/** ./example/src/** ./__tests__/**"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.8",
@@ -67,7 +66,7 @@
     "eslint-plugin-react": "7.13.0",
     "eslint-plugin-react-native": "^3.6.0",
     "flow-bin": "^0.95.1",
-    "husky": "^0.14.3",
+    "husky": "3.0.5",
     "jest": "24.8.0",
     "jest-cli": "^24.8.0",
     "lint-staged": "^8.2.0",
@@ -92,6 +91,11 @@
       "example",
       "__tests__/__mocks__"
     ]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged && npm run generate"
+    }
   },
   "lint-staged": {
     "linters": {

--- a/scripts/autogenHelpers/DocJSONBuilder.js
+++ b/scripts/autogenHelpers/DocJSONBuilder.js
@@ -218,7 +218,9 @@ class DocJSONBuilder {
             return;
           }
 
-          results[fileName] = docgen.parse(content);
+          results[fileName] = docgen.parse(content, undefined, undefined, {
+            filename: fileName,
+          });
           this.postprocess(results[fileName], fileName);
 
           next();

--- a/scripts/autogenerate.js
+++ b/scripts/autogenerate.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const styleSpecJSON = require('../style-spec/v8.json');
 const ejs = require('ejs');
+const {execSync} = require('child_process');
 const prettier = require('prettier')
 
 const DocJSONBuilder = require('./autogenHelpers/DocJSONBuilder');
@@ -22,7 +23,7 @@ const iosVersion = '5.2.0';
 
 const TMPL_PATH = path.join(__dirname, 'templates');
 
-const outputToExample = true;
+const outputToExample = false;
 const OUTPUT_EXAMPLE_PREFIX = [
   '..',
   'example',
@@ -282,40 +283,61 @@ function getAllowedFunctionTypes(paintAttr) {
   return allowedFunctionTypes;
 }
 
-// autogenerate code
-[
-  {
-    input: path.join(TMPL_PATH, 'RCTMGLStyle.h.ejs'),
-    output: path.join(IOS_OUTPUT_PATH, 'RCTMGLStyle.h'),
-  },
-  {
-    input: path.join(TMPL_PATH, 'index.d.ts.ejs'),
-    output: path.join(IOS_OUTPUT_PATH, 'index.d.ts'),
-  },
-  {
-    input: path.join(TMPL_PATH, 'RCTMGLStyle.m.ejs'),
-    output: path.join(IOS_OUTPUT_PATH, 'RCTMGLStyle.m'),
-  },
-  {
-    input: path.join(TMPL_PATH, 'RCTMGLStyleFactory.java.ejs'),
-    output: path.join(ANDROID_OUTPUT_PATH, 'RCTMGLStyleFactory.java'),
-  },
-  {
-    input: path.join(TMPL_PATH, 'styleMap.js.ejs'),
-    output: path.join(JS_OUTPUT_PATH, 'styleMap.js'),
-  },
-].forEach(({input, output}) => {
-  const filename = output.split('/').pop();
-  console.log(`Generating ${filename}`);
-  const tmpl = ejs.compile(fs.readFileSync(input, 'utf8'), {strict: true});
-  let results = tmpl({layers});
-  if (filename.endsWith('ts')) {
-    results = prettier.format(results, {filepath: filename});
-  }
-  fs.writeFileSync(output, results);
-});
 
-// autogenerate docs
-const docBuilder = new DocJSONBuilder(layers);
-const markdownBuilder = new MarkdownBuilder();
-docBuilder.generate().then(() => markdownBuilder.generate());
+async function generate() {
+  const templateMappings = [
+    {
+      input: path.join(TMPL_PATH, 'RCTMGLStyle.h.ejs'),
+      output: path.join(IOS_OUTPUT_PATH, 'RCTMGLStyle.h'),
+    },
+    {
+      input: path.join(TMPL_PATH, 'index.d.ts.ejs'),
+      output: path.join(IOS_OUTPUT_PATH, 'index.d.ts'),
+    },
+    {
+      input: path.join(TMPL_PATH, 'RCTMGLStyle.m.ejs'),
+      output: path.join(IOS_OUTPUT_PATH, 'RCTMGLStyle.m'),
+    },
+    {
+      input: path.join(TMPL_PATH, 'RCTMGLStyleFactory.java.ejs'),
+      output: path.join(ANDROID_OUTPUT_PATH, 'RCTMGLStyleFactory.java'),
+    },
+    {
+      input: path.join(TMPL_PATH, 'styleMap.js.ejs'),
+      output: path.join(JS_OUTPUT_PATH, 'styleMap.js'),
+    },
+  ];
+  const outputPaths = templateMappings.map(m => m.output);
+
+  // autogenerate code
+  templateMappings.forEach(({input, output}) => {
+    const filename = output.split('/').pop();
+    console.log(`Generating ${filename}`);
+    const tmpl = ejs.compile(fs.readFileSync(input, 'utf8'), {strict: true});
+    let results = tmpl({layers});
+    if (filename.endsWith('ts')) {
+      results = prettier.format(results, {filepath: filename});
+    }
+    fs.writeFileSync(output, results);
+  });
+
+  // autogenerate docs
+  const docBuilder = new DocJSONBuilder(layers);
+  const markdownBuilder = new MarkdownBuilder();
+  await docBuilder.generate();
+  await markdownBuilder.generate();
+
+  // Check if any generated files changed
+  try {
+    execSync(`git diff --exit-code docs/ ${outputPaths.join(' ')}`);
+  } catch (error) {
+    console.error(
+      '\n\nThere are unstaged changes in the generated code. ' +
+        'Please add them to your commit.\n' +
+        'If you would really like to exlude them, run "git commit -n" to skip.\n\n',
+    );
+    process.exit(1);
+  }
+}
+
+generate();


### PR DESCRIPTION
This change automatically generates the generated files in the precommit hook, simplifying contributors' workflows. 

I created this PR because I have noticed many commits where the
documentation hadn't been generated, then a later commit does generate
it which results in messy commits with unrelated changes. This should
ensure that any changes to generated files are committed with the actual
changes that caused them.

Also, when submitting a PR myself recently I forgot to generate documentation, @kristfal kindly reminded me to do so, and it slowed down the PR. I think this should make everyone's lives easier contributing to this project since we'll never have to remember this step.

The question is, do we want it to automatically include the generated file changes into your commit (by staging them precommit), or do we want precommit to fail with a message asking the user to manually `git add` the changed generated files? This branch currently automatically stages the changes, but if we don't want such magic happening I'm fine with just removing the [latest commit](https://github.com/react-native-mapbox-gl/maps/commit/f78a8abcc02a2a690320f3db131d35de5a629e10) that makes it auto-stage.

