### PR TITLE
Allow existing layers to be updated

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -48,6 +48,8 @@ import com.mapbox.rctmgl.components.annotation.RCTMGLCallout;
 import com.mapbox.rctmgl.components.annotation.RCTMGLPointAnnotation;
 import com.mapbox.rctmgl.components.camera.RCTMGLCamera;
 import com.mapbox.rctmgl.components.mapview.helpers.CameraChangeTracker;
+import com.mapbox.rctmgl.components.styles.layers.RCTLayer;
+import com.mapbox.rctmgl.components.styles.layers.RCTMGLSymbolLayer;
 import com.mapbox.rctmgl.components.styles.light.RCTMGLLight;
 import com.mapbox.rctmgl.components.styles.sources.RCTMGLShapeSource;
 import com.mapbox.rctmgl.components.styles.sources.RCTSource;
@@ -198,6 +200,8 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
             RCTMGLCamera camera = (RCTMGLCamera) childView;
             mCamera = camera;
             feature = (AbstractMapFeature) childView;
+        } else if (childView instanceof RCTLayer) {
+            feature = (RCTLayer) childView;
         } else if (childView instanceof ViewGroup) {
             ViewGroup children = (ViewGroup) childView;
 

--- a/example/src/examples/ChangeLayerColor.js
+++ b/example/src/examples/ChangeLayerColor.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {Text} from 'react-native';
+import MapboxGL from '@react-native-mapbox-gl/maps';
+
+import BaseExamplePropTypes from './common/BaseExamplePropTypes';
+import Page from './common/Page';
+import Bubble from './common/Bubble';
+
+const defaultCamera = {
+  centerCoordinate: [12.338, 45.4385],
+  zoomLevel: 17.4,
+};
+
+class ChangeLayerColor extends React.Component {
+  static propTypes = {
+    ...BaseExamplePropTypes,
+  };
+
+  state = {
+    fillColor: '',
+  };
+
+  onPress = () => {
+    const fillColor = `#${Math.random()
+      .toString(16)
+      .substr(-6)}`;
+    this.setState({fillColor});
+  };
+
+  render() {
+    const {fillColor} = this.state;
+    return (
+      <Page {...this.props}>
+        <MapboxGL.MapView
+          ref={c => (this._map = c)}
+          onPress={this.onPress}
+          style={{flex: 1}}
+        >
+          <MapboxGL.Camera defaultSettings={defaultCamera} />
+          {!!fillColor && <MapboxGL.FillLayer id="water" style={{fillColor}} />}
+        </MapboxGL.MapView>
+        <Bubble onPress={this.onPress}>
+          <Text>Paint Water</Text>
+        </Bubble>
+      </Page>
+    );
+  }
+}
+
+export default ChangeLayerColor;

--- a/example/src/examples/ShowAndHideLayer.js
+++ b/example/src/examples/ShowAndHideLayer.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {Text} from 'react-native';
+import MapboxGL from '@react-native-mapbox-gl/maps';
+
+import BaseExamplePropTypes from './common/BaseExamplePropTypes';
+import Page from './common/Page';
+import Bubble from './common/Bubble';
+
+const defaultCamera = {
+  centerCoordinate: [-77.036532, 38.897318],
+  zoomLevel: 16,
+};
+
+class ShowAndHideLayer extends React.Component {
+  static propTypes = {
+    ...BaseExamplePropTypes,
+  };
+
+  state = {
+    show: true,
+  };
+
+  onPress = () => {
+    this.setState({
+      show: !this.state.show,
+    });
+  };
+
+  render() {
+    const visibility = this.state.show ? 'visible' : 'none';
+    return (
+      <Page {...this.props}>
+        <MapboxGL.MapView
+          ref={c => (this._map = c)}
+          onPress={this.onPress}
+          style={{flex: 1}}
+        >
+          <MapboxGL.Camera defaultSettings={defaultCamera} />
+          <MapboxGL.FillLayer id="building" style={{visibility}} />
+          <MapboxGL.LineLayer id="building-outline" style={{visibility}} />
+        </MapboxGL.MapView>
+        <Bubble onPress={this.onPress}>
+          <Text>{this.state.show ? 'Hide Buildings' : 'Show Buildings'}</Text>
+        </Bubble>
+      </Page>
+    );
+  }
+}
+
+export default ShowAndHideLayer;

--- a/example/src/scenes/Home.js
+++ b/example/src/scenes/Home.js
@@ -40,6 +40,8 @@ import GetCenter from '../examples/GetCenter';
 import UserLocationChange from '../examples/UserLocationChange';
 import Heatmap from '../examples/Heatmap';
 import RestrictMapBounds from '../examples/RestrictMapBounds';
+import ShowAndHideLayer from '../examples/ShowAndHideLayer';
+import ChangeLayerColor from '../examples/ChangeLayerColor';
 
 const styles = StyleSheet.create({
   header: {
@@ -114,6 +116,8 @@ const Examples = [
   new ExampleItem('Get Center', GetCenter),
   new ExampleItem('User Location Updates', UserLocationChange),
   new ExampleItem('Heatmap', Heatmap),
+  new ExampleItem('Show and hide a layer', ShowAndHideLayer),
+  new ExampleItem('Change Layer Color', ChangeLayerColor),
 ];
 
 class Home extends React.Component {

--- a/ios/RCTMGL/RCTMGLLayer.m
+++ b/ios/RCTMGL/RCTMGLLayer.m
@@ -84,6 +84,16 @@
     }
 }
 
+- (void)setMap:(RCTMGLMapView *)map {
+    if (map == nil) {
+        [self removeFromMap:_map.style];
+        _map = nil;
+    } else {
+        _map = map;
+        [self addToMap:map style:map.style];
+    }
+}
+
 -(void)setReactStyle:(NSDictionary *)reactStyle
 {
     _reactStyle = reactStyle;
@@ -97,6 +107,9 @@
 
 - (void)addToMap:(RCTMGLMapView*) map style:(MGLStyle *)style
 {
+    if (style == nil) {
+        return;
+    }
     _map = map;
     _style = style;
     if (_id == nil) {

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -30,6 +30,7 @@ typedef void (^FoundLayerBlock) (MGLStyleLayer* layer);
 @property (nonatomic, weak) id<RCTMGLMapViewCamera> reactCamera;
 @property (nonatomic, strong) NSMutableArray<id<RCTComponent>> *reactSubviews;
 @property (nonatomic, strong) NSMutableArray<RCTMGLSource*> *sources;
+@property (nonatomic, strong) NSMutableArray<RCTMGLLayer*> *layers;
 @property (nonatomic, strong) NSMutableArray<RCTMGLPointAnnotation*> *pointAnnotations;
 @property (nonatomic, strong) RCTMGLLight *light;
 @property (nonatomic, copy) NSArray<NSNumber *> *reactContentInset;

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -29,6 +29,7 @@ static double const M2PI = M_PI * 2;
         _pendingInitialLayout = YES;
         _cameraUpdateQueue = [[CameraUpdateQueue alloc] init];
         _sources = [[NSMutableArray alloc] init];
+        _layers = [[NSMutableArray alloc] init];
         _pointAnnotations = [[NSMutableArray alloc] init];
         _reactSubviews = [[NSMutableArray alloc] init];
         _layerWaiters = [[NSMutableDictionary alloc] init];
@@ -107,6 +108,10 @@ static double const M2PI = M_PI * 2;
     } else if ([subview isKindOfClass:[RCTMGLCamera class]]) {
         RCTMGLCamera *camera = (RCTMGLCamera *)subview;
         camera.map = self;
+    } else if ([subview isKindOfClass:[RCTMGLLayer class]]) {
+        RCTMGLLayer *layer = (RCTMGLLayer*)subview;
+        layer.map = self;
+        [_layers addObject:layer];
     } else {
         NSArray<id<RCTComponent>> *childSubviews = [subview reactSubviews];
 
@@ -129,6 +134,10 @@ static double const M2PI = M_PI * 2;
     } else if ([subview isKindOfClass:[RCTMGLCamera class]]) {
         RCTMGLCamera *camera = (RCTMGLCamera *)subview;
         camera.map = nil;
+    } else if ([subview isKindOfClass:[RCTMGLLayer class]]) {
+        RCTMGLLayer *layer = (RCTMGLLayer*)subview;
+        layer.map = nil;
+        [_layers removeObject:layer];
     } else {
         NSArray<id<RCTComponent>> *childSubViews = [subview reactSubviews];
         

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -506,11 +506,13 @@ RCT_EXPORT_METHOD(showAttribution:(nonnull NSNumber *)reactTag
     RCTMGLMapView *reactMapView = (RCTMGLMapView*)mapView;
     //style.localizesLabels = reactMapView.reactLocalizeLabels;
     
-    if (reactMapView.sources.count > 0) {
-        for (int i = 0; i < reactMapView.sources.count; i++) {
-            RCTMGLSource *source = reactMapView.sources[i];
-            source.map = reactMapView;
-        }
+    for (int i = 0; i < reactMapView.sources.count; i++) {
+        RCTMGLSource *source = reactMapView.sources[i];
+        source.map = reactMapView;
+    }
+    for (int i = 0; i < reactMapView.layers.count; i++) {
+        RCTMGLLayer *layer = reactMapView.layers[i];
+        layer.map = reactMapView;
     }
     
     if (reactMapView.light != nil) {


### PR DESCRIPTION
Provides functionality similar to:
- https://docs.mapbox.com/android/maps/examples/change-a-layers-color/
- https://docs.mapbox.com/android/maps/examples/show-and-hide-layer/

Allows overriding / customization of existing map layers by referencing them by `id`:
```jsx
<MapboxGL.FillLayer id="building" style={{visibility: "none"}} />
<MapboxGL.FillLayer id="water" style={{fillColor: "#556f8a}} />
```

![change-water-color2](https://user-images.githubusercontent.com/706368/65699318-34ed9f80-e07e-11e9-9034-02b368326baf.gif)
![toggle-buildings2](https://user-images.githubusercontent.com/706368/65699319-35863600-e07e-11e9-84b0-99f6f7af8c8d.gif)
