### PR TITLE
Fix crash when with compass margins on Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -960,7 +960,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
             uiSettings.setCompassEnabled(mCompassEnabled);
         }
 
-        if (mCompassEnabled != null && uiSettings.isCompassEnabled()) {
+        if (mCompassViewMargins != null && uiSettings.isCompassEnabled()) {
             int pixelDensity = (int)getResources().getDisplayMetrics().density;
 
             int xMargin = mCompassViewMargins.getInt("x") * pixelDensity;


### PR DESCRIPTION
Looks like a copy-paste error, the variable that needs to be checked is `mCompassViewMargins` and not `mCompassEnabled`.