### PR TITLE
defaultSettings should ignore followUserLocation

### DIFF
--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -417,7 +417,7 @@ class Camera extends React.Component {
         ...this.props.defaultSettings,
         animationMode: Camera.Mode.Move,
       },
-      false,
+      true,
     );
     return this.defaultCamera;
   }


### PR DESCRIPTION
By design Camera#defaultSettings should ignore followUserLocation.
So even if followUserLocation is set it should set initial camera position/zoom level etc. which will be corrected once the user location is available.