### PR TITLE
Upgrade iOS SDK to 5.3.2 to include important new updates from Mapbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes:
 
-* iOS mapbox libraries updated to [5.2.0](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v5.2.0) android libraries updated to [8.2.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.2.1)
+* iOS mapbox libraries updated to [5.3.2](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v5.3.2) android libraries updated to [8.2.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.2.1)
 * `StyleSheet.create` removed.
 Mapbox styles are now just a map no need for `StyleSheet.create`.
 `StylesSheet.identity` also removed, use expressions array instead:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/react-native-mapbox-gl/maps"
   },
   "scripts": {
-    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 5.2.0",
+    "fetch:ios:sdk": "node ./scripts/download-mapbox-gl-native-ios-if-on-mac.js 5.3.2",
     "fetch:style:spec": ". ./scripts/download-style-spec.sh",
     "generate": "node ./scripts/autogenerate",
     "preinstall": "npm run fetch:ios:sdk",

--- a/scripts/autogenerate.js
+++ b/scripts/autogenerate.js
@@ -18,7 +18,7 @@ if (!styleSpecJSON) {
 
 const layers = [];
 const androidVersion = '8.2.1';
-const iosVersion = '5.2.0';
+const iosVersion = '5.3.2';
 
 const TMPL_PATH = path.join(__dirname, 'templates');
 


### PR DESCRIPTION
Some important updates, fixes, and improvements starting at version 5.3 including major announcement for increasing tile limits for offline modes.

https://github.com/mapbox/mapbox-gl-native/blob/ios-v5.4.0/platform/ios/CHANGELOG.md