### PR TITLE
[IOS] Allow filters to be cleared

### DIFF
--- a/ios/RCTMGL/RCTMGLLayer.m
+++ b/ios/RCTMGL/RCTMGLLayer.m
@@ -78,9 +78,7 @@
     
     if (_styleLayer != nil) {
         NSPredicate *predicate = [self buildFilters];
-        if (predicate) {
-            [self updateFilter:predicate];
-        }
+        [self updateFilter:predicate];
     }
 }
 


### PR DESCRIPTION
We need to allow empty setting empty filters too. So that a filter can be cleared.
Consider this:
```
<SymbolLayer filter={this.state.filter} ...>
```
Where `filter` changes from `nil` to `non-nil` then to `nil` again. The removed `if` statement prevents resetting the filter to nil.

Bug was introduced at:
https://github.com/react-native-mapbox-gl/maps/commit/3b03f649256f368d80741be05644ede0387f2a76#diff-79220b28bb9c8c50280ea315ef9a4f9cR81