### PR TITLE
Adds descriptions for Camera followUserLocation followUserMode

### DIFF
--- a/docs/Camera.md
+++ b/docs/Camera.md
@@ -35,8 +35,8 @@
 | maxBounds | `shape` | `none` | `false` | Restrict map panning so that the center is within these bounds |
 | &nbsp;&nbsp;ne | `array` | `none` | `true` | northEastCoordinates - North east coordinate of bound |
 | &nbsp;&nbsp;sw | `array` | `none` | `true` | southWestCoordinates - South west coordinate of bound |
-| followUserLocation | `bool` | `none` | `false` | FIX ME NO DESCRIPTION |
-| followUserMode | `enum` | `none` | `false` | FIX ME NO DESCRIPTION |
+| followUserLocation | `bool` | `none` | `false` | Should the map orientation follow the user's. |
+| followUserMode | `enum` | `none` | `false` | The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js) |
 | followZoomLevel | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | followPitch | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | followHeading | `number` | `none` | `false` | FIX ME NO DESCRIPTION |

--- a/docs/Camera.md
+++ b/docs/Camera.md
@@ -36,7 +36,7 @@
 | &nbsp;&nbsp;ne | `array` | `none` | `true` | northEastCoordinates - North east coordinate of bound |
 | &nbsp;&nbsp;sw | `array` | `none` | `true` | southWestCoordinates - South west coordinate of bound |
 | followUserLocation | `bool` | `none` | `false` | Should the map orientation follow the user's. |
-| followUserMode | `enum` | `none` | `false` | The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js) |
+| followUserMode | `enum` | `none` | `false` | The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](SetUserTrackingModes.js) |
 | followZoomLevel | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | followPitch | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | followHeading | `number` | `none` | `false` | FIX ME NO DESCRIPTION |

--- a/docs/Camera.md
+++ b/docs/Camera.md
@@ -36,7 +36,7 @@
 | &nbsp;&nbsp;ne | `array` | `none` | `true` | northEastCoordinates - North east coordinate of bound |
 | &nbsp;&nbsp;sw | `array` | `none` | `true` | southWestCoordinates - South west coordinate of bound |
 | followUserLocation | `bool` | `none` | `false` | Should the map orientation follow the user's. |
-| followUserMode | `enum` | `none` | `false` | The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](SetUserTrackingModes.js) |
+| followUserMode | `enum` | `none` | `false` | The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js) |
 | followZoomLevel | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | followPitch | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | followHeading | `number` | `none` | `false` | FIX ME NO DESCRIPTION |

--- a/docs/Camera.md
+++ b/docs/Camera.md
@@ -36,7 +36,7 @@
 | &nbsp;&nbsp;ne | `array` | `none` | `true` | northEastCoordinates - North east coordinate of bound |
 | &nbsp;&nbsp;sw | `array` | `none` | `true` | southWestCoordinates - South west coordinate of bound |
 | followUserLocation | `bool` | `none` | `false` | Should the map orientation follow the user's. |
-| followUserMode | `enum` | `none` | `false` | The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js) |
+| followUserMode | `enum` | `none` | `false` | The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](../example/src/examples/SetUserTrackingModes.js) |
 | followZoomLevel | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | followPitch | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | followHeading | `number` | `none` | `false` | FIX ME NO DESCRIPTION |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -677,7 +677,7 @@
         "required": false,
         "type": "enum",
         "default": "none",
-        "description": "The mode used to track the user location on the map. One of; \"normal\", \"compass\", \"course\". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js)"
+        "description": "The mode used to track the user location on the map. One of; \"normal\", \"compass\", \"course\". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](../example/src/examples/SetUserTrackingModes.js)"
       },
       {
         "name": "followZoomLevel",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -670,14 +670,14 @@
         "required": false,
         "type": "bool",
         "default": "none",
-        "description": "FIX ME NO DESCRIPTION"
+        "description": "Should the map orientation follow the user's."
       },
       {
         "name": "followUserMode",
         "required": false,
         "type": "enum",
         "default": "none",
-        "description": "FIX ME NO DESCRIPTION"
+        "description": "The mode used to track the user location on the map. One of; \"normal\", \"compass\", \"course\". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js)"
       },
       {
         "name": "followZoomLevel",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -677,7 +677,7 @@
         "required": false,
         "type": "enum",
         "default": "none",
-        "description": "The mode used to track the user location on the map. One of; \"normal\", \"compass\", \"course\". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](SetUserTrackingModes.js)"
+        "description": "The mode used to track the user location on the map. One of; \"normal\", \"compass\", \"course\". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js)"
       },
       {
         "name": "followZoomLevel",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -677,7 +677,7 @@
         "required": false,
         "type": "enum",
         "default": "none",
-        "description": "The mode used to track the user location on the map. One of; \"normal\", \"compass\", \"course\". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js)"
+        "description": "The mode used to track the user location on the map. One of; \"normal\", \"compass\", \"course\". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](SetUserTrackingModes.js)"
       },
       {
         "name": "followZoomLevel",

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -95,9 +95,14 @@ class Camera extends React.Component {
       sw: PropTypes.arrayOf(PropTypes.number).isRequired,
     }),
 
-    // user tracking
+    /**
+     * Should the map orientation follow the user's.
+     */
     followUserLocation: PropTypes.bool,
 
+    /**
+     * The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js)
+     */
     followUserMode: PropTypes.oneOf(['normal', 'compass', 'course']),
 
     followZoomLevel: PropTypes.number,

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -101,7 +101,7 @@ class Camera extends React.Component {
     followUserLocation: PropTypes.bool,
 
     /**
-     * The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js)
+     * The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](SetUserTrackingModes.js)
      */
     followUserMode: PropTypes.oneOf(['normal', 'compass', 'course']),
 

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -101,7 +101,7 @@ class Camera extends React.Component {
     followUserLocation: PropTypes.bool,
 
     /**
-     * The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](SetUserTrackingModes.js)
+     * The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js)
      */
     followUserMode: PropTypes.oneOf(['normal', 'compass', 'course']),
 

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -101,7 +101,7 @@ class Camera extends React.Component {
     followUserLocation: PropTypes.bool,
 
     /**
-     * The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](example/src/examples/SetUserTrackingModes.js)
+     * The mode used to track the user location on the map. One of; "normal", "compass", "course". Each mode string is also available as a member on the `MapboxGL.UserTrackingModes` object. `Follow` (normal), `FollowWithHeading` (compass), `FollowWithCourse` (course). NOTE: `followUserLocation` must be set to `true` for any of the modes to take effect. [Example](../example/src/examples/SetUserTrackingModes.js)
      */
     followUserMode: PropTypes.oneOf(['normal', 'compass', 'course']),
 


### PR DESCRIPTION
In the [Camera props docs](https://github.com/react-native-mapbox-gl/maps/blob/master/docs/Camera.md#props) `followUserLocation` and `followUserMode` where missing descriptions. This PR adds descriptions for each.