### PR TITLE
Fix #497 Fix memory leak when removing subviews

### DIFF
--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -166,6 +166,7 @@ static double const M2PI = M_PI * 2;
     // underlying mapview action here.
     [self removeFromMap:subview];
     [_reactSubviews removeObject:(UIView *)subview];
+    [(UIView *)subview removeFromSuperview];
 }
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
Fix #497 This change fixes a memory leak by correctly removing the UIView.

RCTMGLMapView overrides `removeReactSubview` from the UIView+React.m class:
https://github.com/facebook/react-native/blob/aee88b6843cea63d6aa0b5879ad6ef9da4701846/React/Views/UIView%2BReact.m#L93
That method calls `[subview removeFromSuperview];` and the method in RCTMGLMapView did not.

Example app with memory usage:
```javascript
class App extends React.Component {
  state = {
    isLayerVisible: true,
  };
  constructor(props) {
    super(props);
    setInterval(() => {
      this.setState({isLayerVisible: !this.state.isLayerVisible});
    }, 1000);
  }
  render() {
    return (
      <View style={{flex: 1}}>
        <MapboxGL.MapView style={{flex: 1}}>
          {this.state.isLayerVisible && (
            <MapboxGL.ShapeSource
              url="https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson"
              id="eathquakes">
              <MapboxGL.CircleLayer
                id="circleLayer"
                style={{circleColor: 'red'}}
              />
            </MapboxGL.ShapeSource>
          )}
        </MapboxGL.MapView>
      </View>
    );
  }
}
```
Before change:
<img width="415" alt="Screen Shot 2019-10-30 at 3 20 05 PM" src="https://user-images.githubusercontent.com/410285/67957109-7fa58e80-fbcb-11e9-9f71-89b9ad7f7449.png">
After change:
<img width="436" alt="Screen Shot 2019-10-31 at 10 44 39 AM" src="https://user-images.githubusercontent.com/410285/67957122-83d1ac00-fbcb-11e9-94e9-1a42c357cd31.png">

