### PR TITLE
Add setConnected() method [Android only]

### DIFF
--- a/__tests__/__mocks__/react-native-mapbox-gl.mock.js
+++ b/__tests__/__mocks__/react-native-mapbox-gl.mock.js
@@ -83,6 +83,7 @@ NativeModules.MGLModule = {
   setAccessToken: jest.fn(),
   getAccessToken: () => Promise.resolve('test-token'),
   setTelemetryEnabled: jest.fn(),
+  setConnected: jest.fn(),
 };
 
 NativeModules.MGLOfflineModule = {

--- a/__tests__/interface.test.js
+++ b/__tests__/interface.test.js
@@ -71,6 +71,7 @@ describe('Public Interface', () => {
       'setAccessToken',
       'getAccessToken',
       'setTelemetryEnabled',
+      'setConnected',
       'requestAndroidLocationPermissions',
 
       // utils

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
@@ -341,6 +341,16 @@ public class RCTMGLModule extends ReactContextBaseJavaModule {
         });
     }
 
+    @ReactMethod
+    public void setConnected(final boolean connected) {
+        mReactContext.runOnUiQueueThread(new Runnable() {
+            @Override
+            public void run() {
+                Mapbox.setConnected(connected);
+            }
+        });
+    }
+
     private Dispatcher getDispatcher() {
         Dispatcher dispatcher = new Dispatcher();
         // Matches core limit set on

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -22,6 +22,8 @@ MapboxGL.setAccessToken("<YOUR_ACCESSTOKEN>");
 
 If you are hosting styles and sources on localhost, you might need to set the connection status manually for Mapbox to be able to use them. See [mapbox/mapbox-gl-native#12819](https://github.com/mapbox/mapbox-gl-native/issues/12819).
 
+Manually sets the connectivity state of the app, bypassing any checks to the ConnectivityManager. Set to `true` for connected, `false` for disconnected, and `null` for ConnectivityManager to determine.
+
 ```js
 import MapboxGL from "@react-native-mapbox-gl/maps";
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,21 +1,31 @@
 # Getting Started
 
-Congratulations, you successfully installed react-native-mapbox-gl/maps! 🎉  
-Where to go from here?  
-You can head straight to [examples](/example) folder if you want to jump into the deep end.  
+Congratulations, you successfully installed react-native-mapbox-gl/maps! 🎉
+Where to go from here?
+You can head straight to [examples](/example) folder if you want to jump into the deep end.
 However, if you prefer an easier ramp-up, then make sure to stick around and check out the guides below.
 
 ## Setting your accessToken
 
-In order to work, mapbox requires you to create an accessToken and set it in your app.  
-If you haven't created on yet, make sure to sign up for an account [here](https://www.mapbox.com/signup/)  
-You can create and manage your access tokens on your [Mapbox Account page](https://www.mapbox.com/account/)  
+In order to work, mapbox requires you to create an accessToken and set it in your app.
+If you haven't created on yet, make sure to sign up for an account [here](https://www.mapbox.com/signup/)
+You can create and manage your access tokens on your [Mapbox Account page](https://www.mapbox.com/account/)
 Once you have your accessToken, set it like this
 
 ```js
 import MapboxGL from "@react-native-mapbox-gl/maps";
 
 MapboxGL.setAccessToken("<YOUR_ACCESSTOKEN>");
+```
+
+## Setting connection status [Android only]
+
+If you are hosting styles and sources on localhost, you might need to set the connection status manually for Mapbox to be able to use them. See [mapbox/mapbox-gl-native#12819](https://github.com/mapbox/mapbox-gl-native/issues/12819).
+
+```js
+import MapboxGL from "@react-native-mapbox-gl/maps";
+
+MapboxGL.setConneced(true);
 ```
 
 ## Disabling Telemetry

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,6 +102,7 @@ declare namespace MapboxGL {
   function setAccessToken(accessToken: string): void;
   function getAccessToken(): Promise<void>;
   function setTelemetryEnabled(telemetryEnabled: boolean): void;
+  function setConnected(connected: boolean): void;
   function requestAndroidLocationPermissions(): Promise<boolean>;
 
   /**


### PR DESCRIPTION
We run a server on localhost to serve styles and tiles for offline maps. Recently, rctmgl has stopped showing any map when offline, and it appears due to the Android Mapbox SDK reading the system connection status and not trying to load the map when offline (I'm not sure why it sometimes works and sometimes doesn't).

According to [mapbox/mapbox-gl-native#12819](https://github.com/mapbox/mapbox-gl-native/issues/12819) the workaround for this it the `Mapbox.setConnected(true)` method. This PR exposes this method to React Native.

This is an Android-only method - there is ([currently](https://github.com/mapbox/mapbox-gl-native/pull/15650)) no equivalent iOS method.

I am not sure how to best document or write an Android-only method for this library - there don't seem to be any existing platform-dependent methods. I have tested this works on Android, but not on iOS. We need it for https://github.com/digidem/mapeo-mobile


