### PR TITLE
Prevent crash when applying invalid Styles

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLBackgroundLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLBackgroundLayer.java
@@ -22,6 +22,10 @@ public class RCTMGLBackgroundLayer extends RCTLayer<BackgroundLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setBackgroundLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        try {
+            RCTMGLStyleFactory.setBackgroundLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLCircleLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLCircleLayer.java
@@ -42,7 +42,11 @@ public class RCTMGLCircleLayer extends RCTLayer<CircleLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setCircleLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        try {
+            RCTMGLStyleFactory.setCircleLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillExtrusionLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillExtrusionLayer.java
@@ -42,7 +42,11 @@ public class RCTMGLFillExtrusionLayer extends RCTLayer<FillExtrusionLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setFillExtrusionLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        try {
+            RCTMGLStyleFactory.setFillExtrusionLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLFillLayer.java
@@ -42,7 +42,11 @@ public class RCTMGLFillLayer extends RCTLayer<FillLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setFillLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        try {
+            RCTMGLStyleFactory.setFillLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLHeatmapLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLHeatmapLayer.java
@@ -42,7 +42,11 @@ public class RCTMGLHeatmapLayer extends RCTLayer<HeatmapLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setHeatmapLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        try {
+            RCTMGLStyleFactory.setHeatmapLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLLineLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLLineLayer.java
@@ -42,7 +42,11 @@ public class RCTMGLLineLayer extends RCTLayer<LineLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setLineLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        try {
+            RCTMGLStyleFactory.setLineLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLRasterLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLRasterLayer.java
@@ -22,6 +22,10 @@ public class RCTMGLRasterLayer extends RCTLayer<RasterLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setRasterLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        try {
+            RCTMGLStyleFactory.setRasterLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLSymbolLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTMGLSymbolLayer.java
@@ -42,7 +42,11 @@ public class RCTMGLSymbolLayer extends RCTLayer<SymbolLayer> {
 
     @Override
     public void addStyles() {
-        RCTMGLStyleFactory.setSymbolLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        try {
+            RCTMGLStyleFactory.setSymbolLayerStyle(mLayer, new RCTMGLStyle(getContext(), mReactStyle, mMap));
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public void setSourceLayerID(String sourceLayerID) {

--- a/javascript/components/AbstractLayer.js
+++ b/javascript/components/AbstractLayer.js
@@ -37,23 +37,29 @@ class AbstractLayer extends React.PureComponent {
 
     const nativeStyle = {};
     const styleProps = Object.keys(this.props.style);
-    for (const styleProp of styleProps) {
-      const styleType = getStyleType(styleProp);
-      let rawStyle = this.props.style[styleProp];
 
-      if (styleType === 'color' && typeof rawStyle === 'string') {
-        rawStyle = processColor(rawStyle);
-      } else if (styleType === 'image' && typeof rawStyle === 'number') {
-        rawStyle = resolveAssetSource(rawStyle) || {};
+    try {
+      for (const styleProp of styleProps) {
+        const styleType = getStyleType(styleProp);
+        let rawStyle = this.props.style[styleProp];
+  
+        if (styleType === 'color' && typeof rawStyle === 'string') {
+          rawStyle = processColor(rawStyle);
+        } else if (styleType === 'image' && typeof rawStyle === 'number') {
+          rawStyle = resolveAssetSource(rawStyle) || {};
+        }
+  
+        const bridgeValue = new BridgeValue(rawStyle);
+        nativeStyle[styleProp] = {
+          styletype: styleType,
+          stylevalue: bridgeValue.toJSON(),
+        };
       }
-
-      const bridgeValue = new BridgeValue(rawStyle);
-      nativeStyle[styleProp] = {
-        styletype: styleType,
-        stylevalue: bridgeValue.toJSON(),
-      };
+    } catch (err) {
+      console.warn(err.message);
+      return;
     }
-
+  
     return nativeStyle;
   }
 


### PR DESCRIPTION
Currently, when we give incorrect styles to layers it causes Mapbox and the app to crash.
This is an inconvenient behaviour if we want to let users define their own custom layers.
This PR contains 2 changes :

- I've added try catch in the addStyles() of all the layers in Java. This is to counter the problem when we give the wrong value for a style (e.g. a string instead of a number) and conversions fail. We could refactor to do it once in RCTLayer. I didn't do it for iOS because it doesn't seem to cause crashes.

- I've added a try catch in the getStyle() of AbstractLayer. This is to counter the problem when we give a style name that doesn't exist (e.g. iconSi instead of iconSize). 