### PR TITLE
performance fix: Prevent onUpdate  from firing constantly in Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
@@ -23,8 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import timber.log.Timber;
-
 /**
  * Created by nickitaliano on 12/12/17.
  */

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
@@ -22,7 +22,6 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.logging.Logger;
 
 /**
  * Created by nickitaliano on 12/12/17.

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
@@ -22,6 +22,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.logging.Logger;
 
 /**
  * Created by nickitaliano on 12/12/17.
@@ -30,7 +31,7 @@ import java.util.Locale;
 @SuppressWarnings({"MissingPermission"})
 public class LocationManager implements LocationEngineCallback<LocationEngineResult> {
     static final long DEFAULT_FASTEST_INTERVAL_MILLIS = 1000;
-    static final long DEFAULT_INTERVAL_MILLIS = 1000;
+    static final long DEFAULT_INTERVAL_MILLIS = 1000 * 5;
 
     public static final String LOG_TAG = LocationManager.class.getSimpleName();
 
@@ -135,14 +136,84 @@ public class LocationManager implements LocationEngineCallback<LocationEngineRes
         return locationEngine;
     }
 
+    private static final int TWO_MINUTES = 1000 * 60 * 2;
+
+
+    /** Determines whether one Location reading is better than the current Location fix
+     * taken from Android Examples https://developer.android.com/guide/topics/location/strategies.html
+     *
+     * @param location  The new Location that you want to evaluate
+     * @param currentBestLocation  The current Location fix, to which you want to compare the new one
+     */
+    private boolean isBetterLocation(Location location, Location currentBestLocation) {
+        if (currentBestLocation == null) {
+            // A new location is always better than no location
+            return true;
+        }
+
+        // Check whether the new location fix is newer or older
+        long timeDelta = location.getTime() - currentBestLocation.getTime();
+        boolean isSignificantlyNewer = timeDelta > TWO_MINUTES;
+        boolean isSignificantlyOlder = timeDelta < -TWO_MINUTES;
+        boolean isNewer = timeDelta > 0;
+
+        // If it's been more than two minutes since the current location, use the new location
+        // because the user has likely moved
+        if (isSignificantlyNewer) {
+            // If the new location is more than two minutes older, it must be worse
+        } else if (isSignificantlyOlder) {
+            return false;
+        }
+
+        // Check whether the new location fix is more or less accurate
+        float accuracyDelta = (location.getAccuracy() - currentBestLocation.getAccuracy());
+        boolean isLessAccurate = accuracyDelta > 0;
+        boolean isMoreAccurate = accuracyDelta < 0;
+        boolean isSignificantlyLessAccurate = accuracyDelta > 200;
+
+        // events keeps firing with very low change constantly
+        boolean notSignificant = accuracyDelta > -1 && accuracyDelta < 1;
+
+
+        // Check if the old and new location are from the same provider
+        boolean isFromSameProvider = isSameProvider(location.getProvider(),
+                currentBestLocation.getProvider());
+
+        // Determine location quality using a combination of timeliness and accuracy
+        if (isMoreAccurate && !notSignificant) {
+            return true;
+        } else if (isNewer && !isLessAccurate && !notSignificant) {
+            return true;
+        } else if (isNewer && !isSignificantlyLessAccurate && isFromSameProvider && !notSignificant) {
+            return true;
+        }
+
+        return false;
+    }
+    /** Checks whether two providers are the same */
+    private boolean isSameProvider(String provider1, String provider2) {
+        if (provider1 == null) {
+            return provider2 == null;
+        }
+        return provider1.equals(provider2);
+    }
+
+
     public void onLocationChanged(Location location) {
-        lastLocation = location;
+
         Log.d(LOG_TAG, String.format(Locale.ENGLISH, "Tick [%f, %f]", location.getLongitude(), location.getLatitude()));
         Log.d(LOG_TAG, String.format(Locale.ENGLISH, "Listener count %d", listeners.size()));
 
-        for (OnUserLocationChange listener : listeners) {
-            listener.onLocationChange(location);
+        if (isBetterLocation(location, lastLocation)) {
+            for (OnUserLocationChange listener : listeners) {
+                listener.onLocationChange(location);
+
+            }
+            
+            lastLocation = location;
         }
+
+
     }
 
     @Override


### PR DESCRIPTION
GPS on Android devices seems a little flawed, it keeps changing without even a movement of the device. This code prevents this while keeping updating when something really changed.

We could probably make a different prop in the UserLocationComponent where we could listen to long-lat changes with more checks to check if the location changed significantly yes/no.