### PR TITLE
[ios] move local framework dependency from Mapbox.framework > RNMapbo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ package-lock.json
 yarn.lock
 
 # project specific
-ios/Mapbox.framework
+ios/RNMapbox.framework
 ios/temp.zip
 ios/.framework_version
 ios/Pods/

--- a/example/ios/RNMapboxGLExample.xcodeproj/project.pbxproj
+++ b/example/ios/RNMapboxGLExample.xcodeproj/project.pbxproj
@@ -501,11 +501,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNMapboxGLExample/Pods-RNMapboxGLExample-frameworks.sh",
-				"${PODS_ROOT}/../../node_modules/@react-native-mapbox-gl/maps/ios/Mapbox.framework",
+				"${PODS_ROOT}/../../node_modules/@react-native-mapbox-gl/maps/ios/RNMapbox.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNMapbox.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/install.md
+++ b/ios/install.md
@@ -52,9 +52,9 @@ Then run `pod install` and rebuild your project.
 
 ### Add Native Mapbox SDK Framework
 
-Select your project in the `Project navigator`. Click `General` tab then add `node_modules/@react-native-mapbox-gl/maps/ios/Mapbox.framework` to `Embedded Binaries`. :collision: **Important, make sure you're adding it to general -> `Embedded Binaries` :collision:**
+Select your project in the `Project navigator`. Click `General` tab then add `node_modules/@react-native-mapbox-gl/maps/ios/RNMapbox.framework` to `Embedded Binaries`. :collision: **Important, make sure you're adding it to general -> `Embedded Binaries` :collision:**
 
-Click 'Add other' to open the file browser and select Mapbox.framework.
+Click 'Add other' to open the file browser and select RNMapbox.framework.
 
 ![](https://s3.systemlevel.com/docs-public/addother.png)
 
@@ -103,7 +103,7 @@ In the `Build Phases` tab, click the plus sign and then `New Run Script Phase`.
 Open the newly added `Run Script` and paste:
 
 ```bash
- "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework/strip-frameworks.sh"
+ "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNMapbox.framework/strip-frameworks.sh"
 ```
 
 ![](https://s3.systemlevel.com/docs-public/runscript.png)

--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source      	= { :git => "https://github.com/@react-native-mapbox-gl/maps.git" }
   s.source_files	= "ios/RCTMGL/**/*.{h,m}"
 
-  s.vendored_frameworks = 'ios/Mapbox.framework'
+  s.vendored_frameworks = 'ios/RNMapbox.framework'
   s.dependency 'React'
 end

--- a/scripts/download-mapbox-gl-native-ios.sh
+++ b/scripts/download-mapbox-gl-native-ios.sh
@@ -4,7 +4,7 @@ cd ios/
 
 VERSION=$1
 if type /usr/libexec/PlistBuddy &> /dev/null; then
-  CURRENT_VERSION=$(/usr/libexec/PlistBuddy -c "Print :MGLSemanticVersionString" Mapbox.framework/Info.plist)
+  CURRENT_VERSION=$(/usr/libexec/PlistBuddy -c "Print :MGLSemanticVersionString" RNMapbox.framework/Info.plist)
 else
   CURRENT_VERSION=$(cat .framework_version)
 fi
@@ -19,19 +19,19 @@ echo "Downloading Mapbox GL iOS $VERSION, this may take a minute."
 if ! which curl > /dev/null; then echo "curl command not found. Please install curl"; exit 1; fi;
 if ! which unzip > /dev/null; then echo "unzip command not found. Please install unzip"; exit 1; fi;
 
-if [ -d ./Mapbox.framework ]; then
+if [ -d ./RNMapbox.framework ]; then
     echo "Old Mapbox.framework found. Removing it and installing a $VERSION"
-    rm -rf ./Mapbox.framework
+    rm -rf ./RNMapbox.framework
 fi
 
 curl -sS https://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-ios-sdk-$VERSION-dynamic.zip > temp.zip
 unzip -o temp.zip -d temp
-mv temp/dynamic/Mapbox.framework ./Mapbox.framework
+mv temp/dynamic/Mapbox.framework ./RNMapbox.framework
 rm -r temp
 rm temp.zip
 
-if ! [ -d ./Mapbox.framework ]; then
-  echo "Mapbox.framework not found. Please reinstall react-native-mapbox-gl"; exit 1;
+if ! [ -d ./RNMapbox.framework ]; then
+  echo "RNMapbox.framework not found. Please reinstall react-native-mapbox-gl"; exit 1;
 fi;
 
 echo "$VERSION" > .framework_version


### PR DESCRIPTION
…x.framework

Fixes #232 

The issue from #232 is still relevant for any apps that try to include both the Mapbox Navigation SDK and react-native-mapbox-gl/maps. The suggested rename was pending a change https://github.com/nitaliano/react-native-mapbox-gl/pull/1533 that seems to never have landed on this repo.

I'm still testing this change on our end, but I wanted to open the PR to see if this approach will work for everyone.