### PR TITLE
feat(location): pass smallestDisplacement as param

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/RCTMGLPackage.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/RCTMGLPackage.java
@@ -39,14 +39,22 @@ import com.mapbox.rctmgl.modules.RCTMGLSnapshotModule;
 
 public class RCTMGLPackage implements ReactPackage {
 
+    private int smallestDisplacement = 0;
+
+    public RCTMGLPackage(int... args) {
+        smallestDisplacement = args.length > 0 ? args[0] : 0;
+    }
+
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
         List<NativeModule> modules = new ArrayList<>();
 
+        RCTMGLLocationModule locationModule = new RCTMGLLocationModule(reactApplicationContext, smallestDisplacement);
+
         modules.add(new RCTMGLModule(reactApplicationContext));
         modules.add(new RCTMGLOfflineModule(reactApplicationContext));
         modules.add(new RCTMGLSnapshotModule(reactApplicationContext));
-        modules.add(new RCTMGLLocationModule(reactApplicationContext));
+        modules.add(locationModule);
 
         return modules;
     }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
@@ -56,16 +56,15 @@ public class LocationManager implements LocationEngineCallback<LocationEngineRes
         void onLocationChange(Location location);
     }
 
-    private LocationManager(Context context) {
+    private LocationManager(Context context, int smallestDisplacement) {
         this.context = context;
         locationEngine = LocationEngineProvider.getBestLocationEngine(context.getApplicationContext());
-        // locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
+
         locationEngineRequest = new LocationEngineRequest.Builder(DEFAULT_INTERVAL_MILLIS)
                 .setFastestInterval(DEFAULT_FASTEST_INTERVAL_MILLIS)
                 .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+                .setDisplacement(smallestDisplacement)
                 .build();
-        // locationEngine.addLocationEngineListener(this);
-        //locationEngine.setFastestInterval(1000);
     }
 
     public void addLocationListener(OnUserLocationChange listener) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLocationModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLocationModule.java
@@ -58,9 +58,9 @@ public class RCTMGLLocationModule extends ReactContextBaseJavaModule {
         }
     };
 
-    public RCTMGLLocationModule(ReactApplicationContext reactContext) {
+    public RCTMGLLocationModule(ReactApplicationContext reactContext, int smallestDisplacement) {
         super(reactContext);
-        locationManager = LocationManager.getInstance(reactContext);
+        locationManager = LocationManager.getInstance(reactContext, smallestDisplacement);
         reactContext.addLifecycleEventListener(lifecycleEventListener);
     }
 


### PR DESCRIPTION
## Rationale
When a new LocationEngineRequest is build it is instantiated with
`displacement` set to `0` (default value).

Under this circumstance location updates are fired every second
(`.setFastestInterval` takes presedence).

This will cause location updates even when not moving.

Fortunatly `displacement` takes care of that.
Location updates will only be fired when the location has changed
according to the `displacement` value in meters.

## Usage
In `MainApplication.java` add `RCTMGLPackage` either with or without a displacement value:
`packages.add(new RCTMGLPackage(5)); // 5 meters before location update`


## Potential issues
* this has no iOS counterpart - no iOS dev :(
* how would this work when autolinking in the future?
* I'm no android dev, is this a good approach?