### PR TITLE
Make query filter parameters consistent with JS API

### DIFF
--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -209,7 +209,7 @@ RCT_EXPORT_METHOD(getCenter:(nonnull NSNumber*)reactTag
 
 RCT_EXPORT_METHOD(queryRenderedFeaturesAtPoint:(nonnull NSNumber*)reactTag
                   atPoint:(NSArray<NSNumber*>*)point
-                  withFilter:(NSArray<NSDictionary<NSString *, id> *> *)filter
+                  withFilter:(NSArray*)filter
                   withLayerIDs:(NSArray<NSString*>*)layerIDs
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
@@ -246,7 +246,7 @@ RCT_EXPORT_METHOD(queryRenderedFeaturesAtPoint:(nonnull NSNumber*)reactTag
 
 RCT_EXPORT_METHOD(queryRenderedFeaturesInRect:(nonnull NSNumber*)reactTag
                   withBBox:(NSArray<NSNumber*>*)bbox
-                  withFilter:(NSArray<NSDictionary<NSString *, id> *> *)filter
+                  withFilter:(NSArray*)filter
                   withLayerIDs:(NSArray<NSString*>*)layerIDs
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
Issue #431 is occurring because of a mismatch in the JS->iOS bridge. The JS API accepts an array of strings for the query filter, but the iOS API was expecting an array of dictionaries.

This caused the bridging code to throw an error whenever a non-null filter array was passed in.

I'm not an iOS developer by trade, nor am I super familiar with this library, so there might be more work to do. That said, this change fixes #431 for me.

Closes: #431 