### PR TITLE
test: UserLocation tests with react-native-testing-library

### DIFF
--- a/__tests__/components/UserLocation.test.js
+++ b/__tests__/components/UserLocation.test.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import {render} from 'react-native-testing-library';
+
+import UserLocation from '../../javascript/components/UserLocation';
+import ShapeSource from '../../javascript/components/ShapeSource';
+import CircleLayer from '../../javascript/components/CircleLayer';
+
+jest.mock('../../javascript/modules/location/locationManager', () => ({
+  start: () => {},
+  addListener: () => {},
+  getLastKnownLocation: () => ({
+    coords: {
+      accuracy: 9.977999687194824,
+      altitude: 44.64373779296875,
+      heading: 251.5358428955078,
+      latitude: 51.5462244,
+      longitude: 4.1036916,
+      speed: 0.08543474227190018,
+    },
+    timestamp: 1573730357879,
+  }),
+}));
+
+describe('UserLocation', () => {
+  test('renders with CircleLayers by default', done => {
+    const {getAllByType} = render(<UserLocation />);
+
+    setTimeout(() => {
+      const shapeSource = getAllByType(ShapeSource);
+      const circleLayer = getAllByType(CircleLayer);
+
+      expect(shapeSource.length).toBe(1);
+      expect(circleLayer.length).toBe(3);
+      done();
+    });
+  });
+
+  test('does not render with visible set to false', done => {
+    const {queryByType} = render(<UserLocation visible={false} />);
+
+    setTimeout(() => {
+      const shapeSource = queryByType(ShapeSource);
+      const circleLayer = queryByType(CircleLayer);
+
+      expect(shapeSource).toEqual(null);
+      expect(circleLayer).toEqual(null);
+      done();
+    });
+  });
+
+  test('renders with CustomChild when provided', done => {
+    const circleLayerProps = {
+      key: 'testUserLocationCircle',
+      id: 'testUserLocationCircle',
+      style: {
+        circleRadius: 5,
+        circleColor: '#ccc',
+        circleOpacity: 1,
+        circlePitchAlignment: 'map',
+      },
+    };
+
+    const {queryByType} = render(
+      <UserLocation>
+        <CircleLayer {...circleLayerProps} />
+      </UserLocation>,
+    );
+
+    setTimeout(() => {
+      const shapeSource = queryByType(ShapeSource);
+      const circleLayer = queryByType(CircleLayer);
+
+      expect(shapeSource).toBeDefined();
+      expect(circleLayer).toBeDefined();
+
+      expect(circleLayer.props.style).toEqual(circleLayerProps.style);
+      done();
+    });
+  });
+});

--- a/__tests__/components/UserLocation.test.js
+++ b/__tests__/components/UserLocation.test.js
@@ -1,29 +1,42 @@
-import React from 'react';
-import {render} from 'react-native-testing-library';
+import React from "react";
+import {
+  render,
+  fireEvent,
+  flushMicrotasksQueue
+} from "react-native-testing-library";
 
-import UserLocation from '../../javascript/components/UserLocation';
-import ShapeSource from '../../javascript/components/ShapeSource';
-import CircleLayer from '../../javascript/components/CircleLayer';
+import UserLocation from "../../javascript/components/UserLocation";
+import ShapeSource from "../../javascript/components/ShapeSource";
+import CircleLayer from "../../javascript/components/CircleLayer";
 
-jest.mock('../../javascript/modules/location/locationManager', () => ({
-  start: () => {},
-  addListener: () => {},
-  getLastKnownLocation: () => ({
-    coords: {
-      accuracy: 9.977999687194824,
-      altitude: 44.64373779296875,
-      heading: 251.5358428955078,
-      latitude: 51.5462244,
-      longitude: 4.1036916,
-      speed: 0.08543474227190018,
-    },
-    timestamp: 1573730357879,
-  }),
-}));
+import locationManager from "../../javascript/modules/location/locationManager";
 
-describe('UserLocation', () => {
-  test('renders with CircleLayers by default', done => {
-    const {getAllByType} = render(<UserLocation />);
+const position = {
+  coords: {
+    accuracy: 9.977999687194824,
+    altitude: 44.64373779296875,
+    heading: 251.5358428955078,
+    latitude: 51.5462244,
+    longitude: 4.1036916,
+    speed: 0.08543474227190018
+  },
+  timestamp: 1573730357879
+};
+
+describe("UserLocation", () => {
+  beforeEach(() => {
+    jest.spyOn(locationManager, "start").mockImplementation(jest.fn());
+    jest
+      .spyOn(locationManager, "getLastKnownLocation")
+      .mockImplementation(() => position);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("renders with CircleLayers by default", done => {
+    const { getAllByType } = render(<UserLocation />);
 
     setTimeout(() => {
       const shapeSource = getAllByType(ShapeSource);
@@ -35,8 +48,8 @@ describe('UserLocation', () => {
     });
   });
 
-  test('does not render with visible set to false', done => {
-    const {queryByType} = render(<UserLocation visible={false} />);
+  test("does not render with visible set to false", done => {
+    const { queryByType } = render(<UserLocation visible={false} />);
 
     setTimeout(() => {
       const shapeSource = queryByType(ShapeSource);
@@ -48,33 +61,65 @@ describe('UserLocation', () => {
     });
   });
 
-  test('renders with CustomChild when provided', done => {
+  test("renders with CustomChild when provided", done => {
     const circleLayerProps = {
-      key: 'testUserLocationCircle',
-      id: 'testUserLocationCircle',
+      key: "testUserLocationCircle",
+      id: "testUserLocationCircle",
       style: {
         circleRadius: 5,
-        circleColor: '#ccc',
+        circleColor: "#ccc",
         circleOpacity: 1,
-        circlePitchAlignment: 'map',
-      },
+        circlePitchAlignment: "map"
+      }
     };
 
-    const {queryByType} = render(
+    const { queryByType, queryAllByType } = render(
       <UserLocation>
         <CircleLayer {...circleLayerProps} />
-      </UserLocation>,
+      </UserLocation>
     );
 
     setTimeout(() => {
       const shapeSource = queryByType(ShapeSource);
-      const circleLayer = queryByType(CircleLayer);
+      const circleLayer = queryAllByType(CircleLayer);
 
       expect(shapeSource).toBeDefined();
-      expect(circleLayer).toBeDefined();
+      expect(circleLayer[0]).toBeDefined();
+      expect(circleLayer.length).toBe(1);
 
-      expect(circleLayer.props.style).toEqual(circleLayerProps.style);
+      expect(circleLayer[0].props.style).toEqual(circleLayerProps.style);
       done();
     });
+  });
+
+  test("calls onUpdate callback when new location is received", () => {
+    const onUpdateCallback = jest.fn();
+
+    render(<UserLocation onUpdate={onUpdateCallback} />);
+
+    locationManager.onUpdate({
+      coords: {
+        accuracy: 9.977999687194824,
+        altitude: 44.64373779296875,
+        heading: 251.5358428955078,
+        latitude: 51.5462244,
+        longitude: 4.1036916,
+        speed: 0.08543474227190018
+      },
+      timestamp: 1573730357879
+    });
+
+    expect(onUpdateCallback).toHaveBeenCalled();
+  });
+
+  test("calls onPress callback when location icon is pressed", () => {
+    const onPressCallback = jest.fn();
+
+    const { queryByType } = render(<UserLocation onPress={onPressCallback} />);
+
+    const shapeSource = queryByType(ShapeSource);
+    fireEvent(shapeSource, "onPress");
+    fireEvent(shapeSource, "onPress");
+    expect(onPressCallback).toHaveBeenCalledTimes(2);
   });
 });

--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -173,3 +173,8 @@ class UserLocation extends React.Component {
 }
 
 export default UserLocation;
+
+// TODO:
+// * why is there even a RenderMode if children are rendered regardless?
+// * why is #userIconLayers a getter?!
+// * state.shouldShowUserLocation is unused

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "react-native": ">=0.57.6"
   },
   "dependencies": {
-    "@turf/helpers": ">= 4.6.0 <7.0.0",
-    "@turf/distance": ">= 4.0.0 <7.0.0",
-    "@turf/along": ">= 4.0.0 <7.0.0",
     "@mapbox/geo-viewport": ">= 0.4.0",
+    "@turf/along": ">= 4.0.0 <7.0.0",
+    "@turf/distance": ">= 4.0.0 <7.0.0",
+    "@turf/helpers": ">= 4.6.0 <7.0.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
@@ -77,6 +77,7 @@
     "react": "16.8.6",
     "react-docgen": "^5.0.0-beta.1",
     "react-native": "0.59.10",
+    "react-native-testing-library": "^1.11.1",
     "react-test-renderer": "16.8.3"
   },
   "jest": {


### PR DESCRIPTION
Noticed we didn't have tests for the js components.

This PR adds `react-native-testing-library` to the dev dependencies.
Which is a nice way to test RN uis I think.

Had to resort to to some weird `setTimeout` magic, as the UserLocation is rendering asynchronously 🤷‍♂ 

Edit: Added more, will leave it at that.

Additionally added some todos for `UserLocation`


Looking forward to a review.