### PR TITLE
snapshotManager types fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -250,8 +250,8 @@ declare namespace MapboxGL {
     unsubscribe(packName: string): void;
   }
 
-  class snapshotManager extends Component {
-    takeSnap(options: SnapshotOptions): Promise<void>;
+  class snapshotManager {
+    static takeSnap(options: SnapshotOptions): Promise<string>;
   }
 
   interface OfflinePack {


### PR DESCRIPTION
Types for `MapboxGL.snapshotManager.takeSnap` seemed incorrect and this fixes for my use. Not sure if it's a 100% correct.