### PR TITLE
Expose native resetDatabase function

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -122,6 +122,23 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void resetDatabase(final Promise promise) {
+        activateFileSource();
+        final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
+        offlineManager.resetDatabase(new OfflineManager.FileSourceCallback() {
+            @Override
+            public void onSuccess() {
+                promise.resolve(null);
+            }
+
+            @Override
+            public void onError(String error) {
+                promise.reject("resetDatabase", error);
+            }
+        });
+    }
+
+    @ReactMethod
     public void getPackStatus(final String name, final Promise promise) {
         activateFileSource();
 

--- a/docs/OfflineManager.md
+++ b/docs/OfflineManager.md
@@ -47,6 +47,22 @@ await MapboxGL.offlineManager.deletePack('packName')
 ```
 
 
+#### resetDatabase()
+
+Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+
+
+
+
+```javascript
+await MapboxGL.offlineManager.resetDatabase();
+```
+
+
 #### getPacks()
 
 Retrieves all the current offline packs that are stored in the database.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5159,6 +5159,20 @@
         }
       },
       {
+        "name": "resetDatabase",
+        "description": "Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.resetDatabase();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
         "name": "getPacks",
         "description": "Retrieves all the current offline packs that are stored in the database.",
         "params": [],

--- a/ios/RCTMGL/MGLOfflineModule.m
+++ b/ios/RCTMGL/MGLOfflineModule.m
@@ -128,6 +128,18 @@ RCT_EXPORT_METHOD(getPacks:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseR
     });
 }
 
+RCT_EXPORT_METHOD(resetDatabase:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [[MGLOfflineStorage sharedOfflineStorage] resetDatabaseWithCompletionHandler:^(NSError *error) {
+        if (error != nil) {
+            reject(@"resetDatabase", error.description, error);
+            return;
+        }
+        resolve(nil);
+    }];
+    
+}
+
 RCT_EXPORT_METHOD(getPackStatus:(NSString *)name
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -91,6 +91,19 @@ class OfflineManager {
   }
 
   /**
+   * Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.
+   *
+   * @example
+   * await MapboxGL.offlineManager.resetDatabase();
+   *
+   * @return {void}
+   */
+  async resetDatabase() {
+    await this._initialize();
+    await MapboxGLOfflineManager.resetDatabase();
+  }
+
+  /**
    * Retrieves all the current offline packs that are stored in the database.
    *
    * @example


### PR DESCRIPTION
I added a function for calling the native resetDatabase function to clear the ambient cache and reinitialize the offline manager. 