### PR TITLE
Fixed methods/callbacks not all being executed when map is not yet ready

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -10,6 +10,7 @@ import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.util.Pair;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -99,7 +100,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     private Map<String, RCTSource> mSources;
 
     private CameraChangeTracker mCameraChangeTracker = new CameraChangeTracker();
-    private Map<Integer, ReadableArray> mPreRenderMethodMap = new HashMap<>();
+    private List<Pair<Integer, ReadableArray>> mPreRenderMethods = new ArrayList<>();
 
     private MapboxMap mMap;
 
@@ -180,7 +181,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     }
 
     public void enqueuePreRenderMapMethod(Integer methodID, @Nullable ReadableArray args) {
-        mPreRenderMethodMap.put(methodID, args);
+        mPreRenderMethods.add(new Pair<>(methodID, args));
     }
 
     public void addFeature(View childView, int childPosition) {
@@ -655,12 +656,12 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     @Override
     public void onDidFinishRenderingMap(boolean fully) {
         if (fully) {
-            if (mPreRenderMethodMap.size() > 0) {
-                for (Integer methodID : mPreRenderMethodMap.keySet()) {
-                    mManager.receiveCommand(this, methodID, mPreRenderMethodMap.get(methodID));
-                }
-                mPreRenderMethodMap.clear();
+            for (Pair<Integer, ReadableArray> preRenderMethod : mPreRenderMethods) {
+                Integer methodID = preRenderMethod.first;
+                ReadableArray args = preRenderMethod.second;
+                mManager.receiveCommand(this, methodID, args);
             }
+            mPreRenderMethods.clear();
             handleMapChangedEvent(EventTypes.DID_FINISH_RENDERING_MAP_FULLY);
         } else {
             handleMapChangedEvent(EventTypes.DID_FINISH_RENDERING_MAP);


### PR DESCRIPTION
There is a slight potential that multiple invocation to the same method are not fulfilled on Android. Only the last invocation will receive a callback. It's not easy to reproduce but I've experienced it a couple of times and found this to be the cause.

Only affected by calling methods before the map initialized. If the code manages to invoke the same method more than once before the map is initialized only the last invocation receives the callback meaning that some promises won't fulfil. 

The `args` were stored in `mPreRenderMethods` (Map) by `methodID`. In android `args` contains a unique `callbackID`for each invocation of that method. Multiple invocation to the same method can cancel out the previous `callbackID` stored in this `Map` 