### PR TITLE
Added ability to set layer visibility by sourceId / sourceLayerId

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/LayerSourceInfo.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/LayerSourceInfo.java
@@ -1,0 +1,59 @@
+package com.mapbox.rctmgl.components.mapview;
+
+import com.mapbox.mapboxsdk.style.layers.CircleLayer;
+import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
+import com.mapbox.mapboxsdk.style.layers.FillLayer;
+import com.mapbox.mapboxsdk.style.layers.HeatmapLayer;
+import com.mapbox.mapboxsdk.style.layers.HillshadeLayer;
+import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.RasterLayer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+
+import javax.annotation.Nullable;
+
+class LayerSourceInfo {
+    final String sourceId;
+
+    @Nullable
+    final String sourceLayerId;
+
+    LayerSourceInfo(Layer layer) {
+        if (layer instanceof CircleLayer) {
+            CircleLayer symbolLayer = (CircleLayer) layer;
+            sourceId = symbolLayer.getSourceId();
+            sourceLayerId = symbolLayer.getSourceLayer();
+        } else if (layer instanceof FillExtrusionLayer) {
+            FillExtrusionLayer fillExtrusionLayer = (FillExtrusionLayer)layer;
+            sourceId = fillExtrusionLayer.getSourceId();
+            sourceLayerId = fillExtrusionLayer.getSourceLayer();
+        } else if (layer instanceof FillLayer) {
+            FillLayer fillLayer = (FillLayer)layer;
+            sourceId = fillLayer.getSourceId();
+            sourceLayerId = fillLayer.getSourceLayer();
+        } else if (layer instanceof HeatmapLayer) {
+            HeatmapLayer heatmapLayer = (HeatmapLayer)layer;
+            sourceId = heatmapLayer.getSourceId();
+            sourceLayerId = heatmapLayer.getSourceLayer();
+        } else if (layer instanceof HillshadeLayer) {
+            HillshadeLayer hillshadeLayer = (HillshadeLayer)layer;
+            sourceId = hillshadeLayer.getSourceId();
+            sourceLayerId = null;
+        } else if (layer instanceof LineLayer) {
+            LineLayer lineLayer = (LineLayer)layer;
+            sourceId = lineLayer.getSourceId();
+            sourceLayerId = lineLayer.getSourceLayer();
+        } else if (layer instanceof RasterLayer) {
+            RasterLayer rasterLayer = (RasterLayer) layer;
+            sourceId = rasterLayer.getSourceId();
+            sourceLayerId = null;
+        } else if (layer instanceof SymbolLayer) {
+            SymbolLayer symbolLayer = (SymbolLayer)layer;
+            sourceId = symbolLayer.getSourceId();
+            sourceLayerId = symbolLayer.getSourceLayer();
+        } else {
+            sourceId = "";
+            sourceLayerId = null;
+        }
+    }
+}

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -15,6 +15,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
+
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -41,23 +42,14 @@ import com.mapbox.mapboxsdk.plugins.annotation.OnSymbolDragListener;
 import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.CircleLayer;
-import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
-import com.mapbox.mapboxsdk.style.layers.FillLayer;
-import com.mapbox.mapboxsdk.style.layers.HeatmapLayer;
-import com.mapbox.mapboxsdk.style.layers.HillshadeLayer;
 import com.mapbox.mapboxsdk.style.layers.Layer;
-import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.RasterLayer;
-import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.rctmgl.R;
 import com.mapbox.rctmgl.components.AbstractMapFeature;
 import com.mapbox.rctmgl.components.annotation.RCTMGLPointAnnotation;
 import com.mapbox.rctmgl.components.camera.RCTMGLCamera;
 import com.mapbox.rctmgl.components.mapview.helpers.CameraChangeTracker;
 import com.mapbox.rctmgl.components.styles.layers.RCTLayer;
-import com.mapbox.rctmgl.components.styles.layers.RCTMGLSymbolLayer;
 import com.mapbox.rctmgl.components.styles.light.RCTMGLLight;
 import com.mapbox.rctmgl.components.styles.sources.RCTMGLShapeSource;
 import com.mapbox.rctmgl.components.styles.sources.RCTSource;
@@ -913,40 +905,9 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
             public void onStyleLoaded(@NonNull Style style) {
                 List<Layer> layers = style.getLayers();
                 for (Layer layer : layers) {
-                    String source = "";
-                    String sourceLayer = null;
-                    if (layer instanceof CircleLayer) {
-                        CircleLayer symbolLayer = (CircleLayer) layer;
-                        source = symbolLayer.getSourceId();
-                        sourceLayer = symbolLayer.getSourceLayer();
-                    } else if (layer instanceof FillExtrusionLayer) {
-                        FillExtrusionLayer fillExtrusionLayer = (FillExtrusionLayer)layer;
-                        source = fillExtrusionLayer.getSourceId();
-                        sourceLayer = fillExtrusionLayer.getSourceLayer();
-                    } else if (layer instanceof FillLayer) {
-                        FillLayer fillLayer = (FillLayer)layer;
-                        source = fillLayer.getSourceId();
-                        sourceLayer = fillLayer.getSourceLayer();
-                    } else if (layer instanceof HeatmapLayer) {
-                        HeatmapLayer heatmapLayer = (HeatmapLayer)layer;
-                        source = heatmapLayer.getSourceId();
-                        sourceLayer = heatmapLayer.getSourceLayer();
-                    } else if (layer instanceof HillshadeLayer) {
-                        HillshadeLayer hillshadeLayer = (HillshadeLayer)layer;
-                        source = hillshadeLayer.getSourceId();
-                    } else if (layer instanceof LineLayer) {
-                        LineLayer lineLayer = (LineLayer)layer;
-                        source = lineLayer.getSourceId();
-                        sourceLayer = lineLayer.getSourceLayer();
-                    } else if (layer instanceof RasterLayer) {
-                        RasterLayer rasterLayer = (RasterLayer) layer;
-                        source = rasterLayer.getSourceId();
-                    } else if (layer instanceof SymbolLayer) {
-                        SymbolLayer symbolLayer = (SymbolLayer)layer;
-                        source = symbolLayer.getSourceId();
-                        sourceLayer = symbolLayer.getSourceLayer();
-                    }
-                    if (source.equals(sourceId) && (sourceLayerId == null || sourceLayerId.equals(sourceLayer))) {
+                    LayerSourceInfo layerSourceInfo = new LayerSourceInfo(layer);
+                    if (layerSourceInfo.sourceId.equals(sourceId) && (sourceLayerId == null
+                            || sourceLayerId.equals(layerSourceInfo.sourceLayerId))) {
                         layer.setProperties(visibility(visible ? Property.VISIBLE : Property.NONE));
                     }
                 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -9,12 +9,11 @@ import android.location.Location;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.util.Pair;
 import android.view.Gravity;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.MotionEvent;
 
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
@@ -24,14 +23,9 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.mapbox.android.gestures.MoveGestureDetector;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.mapboxsdk.annotations.Marker;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
-import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
-import com.mapbox.mapboxsdk.plugins.annotation.OnSymbolDragListener;
-import com.mapbox.mapboxsdk.plugins.annotation.OnSymbolClickListener;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdate;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -40,12 +34,25 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.maps.UiSettings;
+import com.mapbox.mapboxsdk.plugins.annotation.OnSymbolClickListener;
+import com.mapbox.mapboxsdk.plugins.annotation.OnSymbolDragListener;
+import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
+import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
+import com.mapbox.mapboxsdk.style.layers.CircleLayer;
+import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
+import com.mapbox.mapboxsdk.style.layers.FillLayer;
+import com.mapbox.mapboxsdk.style.layers.HeatmapLayer;
+import com.mapbox.mapboxsdk.style.layers.HillshadeLayer;
 import com.mapbox.mapboxsdk.style.layers.Layer;
-import com.mapbox.android.gestures.MoveGestureDetector;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.style.layers.RasterLayer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.rctmgl.R;
 import com.mapbox.rctmgl.components.AbstractMapFeature;
-import com.mapbox.rctmgl.components.annotation.RCTMGLCallout;
 import com.mapbox.rctmgl.components.annotation.RCTMGLPointAnnotation;
 import com.mapbox.rctmgl.components.camera.RCTMGLCamera;
 import com.mapbox.rctmgl.components.mapview.helpers.CameraChangeTracker;
@@ -62,7 +69,6 @@ import com.mapbox.rctmgl.events.constants.EventTypes;
 import com.mapbox.rctmgl.utils.BitmapUtils;
 import com.mapbox.rctmgl.utils.GeoJSONUtils;
 import com.mapbox.rctmgl.utils.GeoViewport;
-import com.mapbox.rctmgl.R;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,6 +78,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nullable;
+
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
 
 /**
  * Created by nickitaliano on 8/18/17.
@@ -894,6 +902,56 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     public void showAttribution() {
         View attributionView = findViewById(com.mapbox.mapboxsdk.R.id.attributionView);
         attributionView.callOnClick();
+    }
+
+    public void setSourceVisibility(final boolean visible, @NonNull final String sourceId, @Nullable final String sourceLayerId) {
+        if (mMap == null) {
+            return;
+        }
+        mMap.getStyle(new Style.OnStyleLoaded() {
+            @Override
+            public void onStyleLoaded(@NonNull Style style) {
+                List<Layer> layers = style.getLayers();
+                for (Layer layer : layers) {
+                    String source = "";
+                    String sourceLayer = null;
+                    if (layer instanceof CircleLayer) {
+                        CircleLayer symbolLayer = (CircleLayer) layer;
+                        source = symbolLayer.getSourceId();
+                        sourceLayer = symbolLayer.getSourceLayer();
+                    } else if (layer instanceof FillExtrusionLayer) {
+                        FillExtrusionLayer fillExtrusionLayer = (FillExtrusionLayer)layer;
+                        source = fillExtrusionLayer.getSourceId();
+                        sourceLayer = fillExtrusionLayer.getSourceLayer();
+                    } else if (layer instanceof FillLayer) {
+                        FillLayer fillLayer = (FillLayer)layer;
+                        source = fillLayer.getSourceId();
+                        sourceLayer = fillLayer.getSourceLayer();
+                    } else if (layer instanceof HeatmapLayer) {
+                        HeatmapLayer heatmapLayer = (HeatmapLayer)layer;
+                        source = heatmapLayer.getSourceId();
+                        sourceLayer = heatmapLayer.getSourceLayer();
+                    } else if (layer instanceof HillshadeLayer) {
+                        HillshadeLayer hillshadeLayer = (HillshadeLayer)layer;
+                        source = hillshadeLayer.getSourceId();
+                    } else if (layer instanceof LineLayer) {
+                        LineLayer lineLayer = (LineLayer)layer;
+                        source = lineLayer.getSourceId();
+                        sourceLayer = lineLayer.getSourceLayer();
+                    } else if (layer instanceof RasterLayer) {
+                        RasterLayer rasterLayer = (RasterLayer) layer;
+                        source = rasterLayer.getSourceId();
+                    } else if (layer instanceof SymbolLayer) {
+                        SymbolLayer symbolLayer = (SymbolLayer)layer;
+                        source = symbolLayer.getSourceId();
+                        sourceLayer = symbolLayer.getSourceLayer();
+                    }
+                    if (source.equals(sourceId) && (sourceLayerId == null || sourceLayerId.equals(sourceLayer))) {
+                        layer.setProperties(visibility(visible ? Property.VISIBLE : Property.NONE));
+                    }
+                }
+            }
+        });
     }
 
     public void init() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -208,6 +208,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     public static final int METHOD_GET_CENTER = 9;
     public static final int METHOD_SET_HANDLED_MAP_EVENTS = 10;
     public static final int METHOD_SHOW_ATTRIBUTION = 11;
+    public static final int METHOD_SET_SOURCE_VISIBILITY = 12;
 
     @Nullable
     @Override
@@ -223,6 +224,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                 .put("getCenter", METHOD_GET_CENTER)
                 .put( "setHandledMapChangedEvents", METHOD_SET_HANDLED_MAP_EVENTS)
                 .put("showAttribution", METHOD_SHOW_ATTRIBUTION)
+                .put("setSourceVisibility", METHOD_SET_SOURCE_VISIBILITY)
                 .build();
     }
 
@@ -280,6 +282,13 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
             case METHOD_SHOW_ATTRIBUTION:
                 mapView.showAttribution();
                 break;
+            case METHOD_SET_SOURCE_VISIBILITY:
+                mapView.setSourceVisibility(
+                        args.getBoolean(1),
+                        args.getString(2),
+                        args.getString(3)
+                );
+
         }
     }
 

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -177,6 +177,24 @@ const center = await this._map.getCenter();
 ```
 
 
+#### setSourceVisibility(visible, sourceId[, sourceLayerId])
+
+Sets the visibility of all the layers referencing the specified `sourceLayerId` and/or `sourceId`
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `visible` | `boolean` | `Yes` | Visibility of the layers |
+| `sourceId` | `String` | `Yes` | Identifier of the target source (e.g. 'composite') |
+| `sourceLayerId` | `String` | `No` | Identifier of the target source-layer (e.g. 'building') |
+
+
+
+```javascript
+await this._map.setSourceVisibility(false, 'composite', 'building')
+```
+
+
 #### showAttribution()
 
 Show the attribution and telemetry action sheet.<br/>If you implement a custom attribution button, you should add this action to the button.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2602,6 +2602,42 @@
         ]
       },
       {
+        "name": "setSourceVisibility",
+        "docblock": "Sets the visibility of all the layers referencing the specified `sourceLayerId` and/or `sourceId`\n\n@example\nawait this._map.setSourceVisibility(false, 'composite', 'building')\n\n@param {boolean} visible - Visibility of the layers\n@param {String} sourceId - Identifier of the target source (e.g. 'composite')\n@param {String=} sourceLayerId - Identifier of the target source-layer (e.g. 'building')",
+        "modifiers": [],
+        "params": [
+          {
+            "name": "visible",
+            "description": "Visibility of the layers",
+            "type": {
+              "name": "boolean"
+            },
+            "optional": false
+          },
+          {
+            "name": "sourceId",
+            "description": "Identifier of the target source (e.g. 'composite')",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          },
+          {
+            "name": "sourceLayerId",
+            "description": "Identifier of the target source-layer (e.g. 'building')",
+            "type": {
+              "name": "String"
+            },
+            "optional": true
+          }
+        ],
+        "returns": null,
+        "description": "Sets the visibility of all the layers referencing the specified `sourceLayerId` and/or `sourceId`",
+        "examples": [
+          "\nawait this._map.setSourceVisibility(false, 'composite', 'building')\n\n"
+        ]
+      },
+      {
         "name": "showAttribution",
         "docblock": "Show the attribution and telemetry action sheet.\nIf you implement a custom attribution button, you should add this action to the button.",
         "modifiers": [],

--- a/example/src/examples/SourceLayerVisibility.js
+++ b/example/src/examples/SourceLayerVisibility.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import {Text} from 'react-native';
+import MapboxGL from '@react-native-mapbox-gl/maps';
+
+import BaseExamplePropTypes from './common/BaseExamplePropTypes';
+import Page from './common/Page';
+import Bubble from './common/Bubble';
+
+const defaultCamera = {
+  centerCoordinate: [-74.005974, 40.712776],
+  zoomLevel: 13,
+};
+
+class SourceLayerVisibility extends React.Component {
+  static propTypes = {
+    ...BaseExamplePropTypes,
+  };
+
+  state = {
+    show: true,
+  };
+
+  onPress = () => {
+    this.setState(
+      {
+        show: !this.state.show,
+      },
+      () => {
+        this._map.setSourceVisibility(this.state.show, 'composite', 'road');
+      },
+    );
+  };
+
+  render() {
+    return (
+      <Page {...this.props}>
+        <MapboxGL.MapView
+          ref={c => (this._map = c)}
+          onPress={this.onPress}
+          style={{flex: 1}}
+        >
+          <MapboxGL.Camera defaultSettings={defaultCamera} />
+        </MapboxGL.MapView>
+        <Bubble onPress={this.onPress}>
+          <Text>{`${
+            this.state.show ? 'Hide' : 'Show'
+          } 'Roads' source layer`}</Text>
+        </Bubble>
+      </Page>
+    );
+  }
+}
+
+export default SourceLayerVisibility;

--- a/example/src/scenes/Home.js
+++ b/example/src/scenes/Home.js
@@ -42,6 +42,7 @@ import Heatmap from '../examples/Heatmap';
 import RestrictMapBounds from '../examples/RestrictMapBounds';
 import ShowAndHideLayer from '../examples/ShowAndHideLayer';
 import ChangeLayerColor from '../examples/ChangeLayerColor';
+import SourceLayerVisibility from '../examples/SourceLayerVisibility';
 
 const styles = StyleSheet.create({
   header: {
@@ -118,6 +119,7 @@ const Examples = [
   new ExampleItem('Heatmap', Heatmap),
   new ExampleItem('Show and hide a layer', ShowAndHideLayer),
   new ExampleItem('Change Layer Color', ChangeLayerColor),
+  new ExampleItem('Source Layer Visiblity', SourceLayerVisibility),
 ];
 
 class Home extends React.Component {

--- a/index.d.ts
+++ b/index.d.ts
@@ -153,6 +153,7 @@ declare namespace MapboxGL {
     getZoom(): Promise<number>;
     getCenter(): Promise<GeoJSON.Position>;
     showAttribution(): void;
+    setSourceVisibility(visible: Boolean, sourceId: string, sourceLayerId?: string): void;
   }
 
   type Padding = number | [number, number] | [number, number, number, number];

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -23,6 +23,7 @@
 @end
 
 typedef void (^FoundLayerBlock) (MGLStyleLayer* layer);
+typedef void (^StyleLoadedBlock) (MGLStyle* style);
 
 @interface RCTMGLMapView : MGLMapView<RCTInvalidating>
 
@@ -36,6 +37,7 @@ typedef void (^FoundLayerBlock) (MGLStyleLayer* layer);
 @property (nonatomic, copy) NSArray<NSNumber *> *reactContentInset;
 
 @property (nonatomic, strong) NSMutableDictionary<NSString*, NSMutableArray<FoundLayerBlock>*> *layerWaiters;
+@property (nonatomic, strong) NSMutableArray<StyleLoadedBlock> *styleWaiters;
 
 @property (nonatomic, assign) BOOL reactLocalizeLabels;
 @property (nonatomic, assign) BOOL reactScrollEnabled;
@@ -76,5 +78,9 @@ typedef void (^FoundLayerBlock) (MGLStyleLayer* layer);
 - (void)didChangeUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated;
 
 - (void)waitForLayerWithID:(nonnull NSString*)layerID then:(void (^)(MGLStyleLayer* layer))foundLayer;
+
+- (void)setSourceVisibility:(BOOL)visiblity sourceId:(nonnull NSString*)sourceId sourceLayerId:(nullable NSString*)sourceLayerId;
+
+- (void)notifyStyleLoaded;
 
 @end

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -102,13 +102,10 @@ static double const M2PI = M_PI * 2;
 
 - (void)notifyStyleLoaded {
     if (!self.style) return;
-    for (int i = (int)self.styleWaiters.count - 1; i >= 0; i--) {
-        StyleLoadedBlock styleLoadedBlock = self.styleWaiters[i];
-        if (styleLoadedBlock) {
-            styleLoadedBlock(self.style);
-        }
-        [self.styleWaiters removeObjectAtIndex:i];
+    for (StyleLoadedBlock styleLoadedBlock in self.styleWaiters) {
+        styleLoadedBlock(self.style);
     }
+    [self.styleWaiters removeAllObjects];
 }
 
 

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -33,6 +33,7 @@ static double const M2PI = M_PI * 2;
         _pointAnnotations = [[NSMutableArray alloc] init];
         _reactSubviews = [[NSMutableArray alloc] init];
         _layerWaiters = [[NSMutableDictionary alloc] init];
+        _styleWaiters = [[NSMutableArray alloc] init];
     }
     return self;
 }
@@ -90,6 +91,26 @@ static double const M2PI = M_PI * 2;
         // TODO
     }
 }
+
+- (void)getStyle:(void (^)(MGLStyle* style))onStyleLoaded {
+    if (self.style) {
+        onStyleLoaded(self.style);
+    } else {
+        [_styleWaiters addObject:onStyleLoaded];
+    }
+}
+
+- (void)notifyStyleLoaded {
+    if (!self.style) return;
+    for (int i = (int)self.styleWaiters.count - 1; i >= 0; i--) {
+        StyleLoadedBlock styleLoadedBlock = self.styleWaiters[i];
+        if (styleLoadedBlock) {
+            styleLoadedBlock(self.style);
+        }
+        [self.styleWaiters removeObjectAtIndex:i];
+    }
+}
+
 
 - (void) addToMap:(id<RCTComponent>)subview
 {
@@ -149,6 +170,27 @@ static double const M2PI = M_PI * 2;
         RCTLogWarn(@"The following layers were waited on but never added to the map: %@", [_layerWaiters allKeys]);
         [_layerWaiters removeAllObjects];
     }
+}
+
+- (void)setSourceVisibility:(BOOL)visible sourceId:(NSString *)sourceId sourceLayerId:(NSString *)sourceLayerId {
+    __weak typeof(self) weakSelf = self;
+    [self getStyle:^(MGLStyle *style) {
+        __strong typeof(self) strongSelf = weakSelf;
+        for (MGLStyleLayer *layer in strongSelf.style.layers) {
+            if ([layer isKindOfClass:[MGLForegroundStyleLayer class]]) {
+                MGLForegroundStyleLayer *foregroundLayer = (MGLForegroundStyleLayer*)layer;
+                if (![foregroundLayer.sourceIdentifier isEqualToString:sourceId]) continue;
+                if (sourceLayerId == nil || sourceLayerId.length == 0) {
+                    layer.visible = visible;
+                } else if ([layer isKindOfClass:[MGLVectorStyleLayer class]]) {
+                    MGLVectorStyleLayer *vectorLayer = (MGLVectorStyleLayer*)layer;
+                    if ([vectorLayer.sourceLayerIdentifier isEqualToString:sourceLayerId]) {
+                        layer.visible = visible;
+                    }
+                }
+            }
+        }
+    }];
 }
 
 #pragma clang diagnostic push

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -303,6 +303,27 @@ RCT_EXPORT_METHOD(showAttribution:(nonnull NSNumber *)reactTag
     }];
 }
 
+RCT_EXPORT_METHOD(setSourceVisibility:(nonnull NSNumber *)reactTag
+                  visible:(BOOL)visible
+                  sourceId:(nonnull NSString*)sourceId
+                  sourceLayerId:(nullable NSString*)sourceLayerId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        
+        if (![view isKindOfClass:[RCTMGLMapView class]]) {
+            RCTLogError(@"Invalid react tag, could not find RCTMGLMapView");
+            return;
+        }
+        
+        __weak RCTMGLMapView *reactMapView = (RCTMGLMapView*)view;
+        [reactMapView setSourceVisibility:visible sourceId:sourceId sourceLayerId:sourceLayerId];
+        resolve(nil);
+    }];
+}
+
 #pragma mark - UIGestureRecognizers
 
 - (void)didTapMap:(UITapGestureRecognizer *)recognizer
@@ -519,6 +540,7 @@ RCT_EXPORT_METHOD(showAttribution:(nonnull NSNumber *)reactTag
         reactMapView.light.map = reactMapView;
     }
     
+    [reactMapView notifyStyleLoaded];
     [self reactMapDidChange:reactMapView eventType:RCT_MAPBOX_DID_FINISH_LOADING_STYLE];
 }
 

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -494,6 +494,24 @@ class MapView extends NativeBridgeComponent(React.Component) {
   }
 
   /**
+   * Sets the visibility of all the layers referencing the specified `sourceLayerId` and/or `sourceId`
+   *
+   * @example
+   * await this._map.setSourceVisibility(false, 'composite', 'building')
+   *
+   * @param {boolean} visible - Visibility of the layers
+   * @param {String} sourceId - Identifier of the target source (e.g. 'composite')
+   * @param {String=} sourceLayerId - Identifier of the target source-layer (e.g. 'building')
+   */
+  setSourceVisibility(visible, sourceId, sourceLayerId = undefined) {
+    this._runNativeCommand('setSourceVisibility', this._nativeRef, [
+      visible,
+      sourceId,
+      sourceLayerId,
+    ]);
+  }
+
+  /**
    * Show the attribution and telemetry action sheet.
    * If you implement a custom attribution button, you should add this action to the button.
    */


### PR DESCRIPTION
This PR adds the possibility to toggle the visibility of layers by `source` / `source-layer`.  If the [source](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layer-source) or [source-layer](https://docs.mapbox.com/mapbox-gl-js/style-spec/#layer-source-layer) is known this function can be used to toggle all attached layers.

This could be useful when one or more style layers need to be shown or hidden without knowing each individual style layer identifier.

![ show-hide-source-layer2](https://user-images.githubusercontent.com/706368/71414904-6c59f100-2659-11ea-875a-b7ec81fca032.gif)
