### PR TITLE
feat(lint): simplify lint setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,93 +1,90 @@
 module.exports = {
-  "parser": "babel-eslint",
-  "plugins": [
-    "react",
-    "react-native",
-    "prettier",
-    "fp",
-    "flowtype",
-  ],
-  "env": {
-    "jest": true
+  parser: "babel-eslint",
+  plugins: ["react", "react-native", "prettier", "fp", "flowtype"],
+  env: {
+    jest: true
   },
-  "settings": {
-    "react": {
-      "version": require('./package.json').dependencies.react,
+  settings: {
+    react: {
+      version: require("./package.json").dependencies.react
     },
     "import/resolver": {
-      "node": {
-        "extensions": [
-          ".js",
-          ".jsx"
-        ]
+      node: {
+        extensions: [".js", ".jsx"]
       }
     },
-    "react": {
-      "pragma": "React",
-      "version": "16.6.1",
-      "flowVersion": "0.87"
+    react: {
+      pragma: "React",
+      version: "16.6.1",
+      flowVersion: "0.87"
     },
-    "parserOptions": {
-      "ecmaFeatures": {
-        "jsx": true,
-        "modules": true
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+        modules: true
       }
     }
   },
-  "globals": {
-    "fetch": true,
-    "FormData": true,
-    "requestAnimationFrame": true,
-    "cancelAnimationFrame": true,
-    "WebSocket": true,
-    "__DEV__": true,
-    "window": true,
-    "document": true,
-    "navigator": true,
-    "XMLSerializer": true,
+  globals: {
+    fetch: true,
+    FormData: true,
+    requestAnimationFrame: true,
+    cancelAnimationFrame: true,
+    WebSocket: true,
+    __DEV__: true,
+    window: true,
+    document: true,
+    navigator: true,
+    XMLSerializer: true
   },
-  "extends": [
+  extends: [
     "eslint:recommended",
     "plugin:react/recommended",
     "airbnb-base",
     "prettier",
     "plugin:flowtype/recommended"
   ],
-  "rules": {
+  rules: {
     "react/no-deprecated": "warn",
     "react/no-string-refs": "warn",
     "import/named": [2],
     "import/no-named-default": [0],
-    "import/order": ["error", { "groups": ["builtin", "external", "parent", "sibling", "index"], "newlines-between": "always" }],
+    "import/order": [
+      "error",
+      {
+        groups: ["builtin", "external", "parent", "sibling", "index"],
+        "newlines-between": "always"
+      }
+    ],
     "import/exports-last": [0],
     "import/no-useless-path-segments": [2],
-    "camelcase": [0],
+    camelcase: [0],
     "no-console": [0],
     "import/prefer-default-export": "off",
     "jsx-a11y/href-no-hash": "off",
     "react/prop-types": [2],
-    "quotes": [2, "single"],
+    quotes: [2, "single"],
     "eol-last": [0],
     "no-continue": [1],
     "class-methods-use-this": [1],
     "no-bitwise": [1],
     "prefer-destructuring": [1],
     "consistent-return": [1],
-    "no-warning-comments": [2],
+    "no-warning-comments": [1],
     "no-mixed-requires": [0],
     "no-return-assign": 0,
     "no-underscore-dangle": [0],
     "no-await-in-loop": 0,
     "no-restricted-syntax": 0,
-    "no-use-before-define": ["error", { "functions": false }],
-    "no-unused-expressions": ["error", { "allowTaggedTemplates": true }],
-    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
+    "no-use-before-define": ["error", { functions: false }],
+    "no-unused-expressions": ["error", { allowTaggedTemplates: true }],
+    "no-plusplus": ["error", { allowForLoopAfterthoughts: true }],
     "prettier/prettier": [
       "error",
       {
-        "singleQuote": true,
-        "trailingComma": "all",
-        "bracketSpacing": false
+        singleQuote: true,
+        trailingComma: "all",
+        bracketSpacing: false
       }
     ],
     "fp/no-mutating-methods": "warn"

--- a/__tests__/components/UserLocation.test.js
+++ b/__tests__/components/UserLocation.test.js
@@ -1,15 +1,10 @@
-import React from "react";
-import {
-  render,
-  fireEvent,
-  flushMicrotasksQueue
-} from "react-native-testing-library";
+import React from 'react';
+import {render, fireEvent} from 'react-native-testing-library';
 
-import UserLocation from "../../javascript/components/UserLocation";
-import ShapeSource from "../../javascript/components/ShapeSource";
-import CircleLayer from "../../javascript/components/CircleLayer";
-
-import locationManager from "../../javascript/modules/location/locationManager";
+import UserLocation from '../../javascript/components/UserLocation';
+import ShapeSource from '../../javascript/components/ShapeSource';
+import CircleLayer from '../../javascript/components/CircleLayer';
+import locationManager from '../../javascript/modules/location/locationManager';
 
 const position = {
   coords: {
@@ -18,16 +13,16 @@ const position = {
     heading: 251.5358428955078,
     latitude: 51.5462244,
     longitude: 4.1036916,
-    speed: 0.08543474227190018
+    speed: 0.08543474227190018,
   },
-  timestamp: 1573730357879
+  timestamp: 1573730357879,
 };
 
-describe("UserLocation", () => {
+describe('UserLocation', () => {
   beforeEach(() => {
-    jest.spyOn(locationManager, "start").mockImplementation(jest.fn());
+    jest.spyOn(locationManager, 'start').mockImplementation(jest.fn());
     jest
-      .spyOn(locationManager, "getLastKnownLocation")
+      .spyOn(locationManager, 'getLastKnownLocation')
       .mockImplementation(() => position);
   });
 
@@ -35,8 +30,8 @@ describe("UserLocation", () => {
     jest.restoreAllMocks();
   });
 
-  test("renders with CircleLayers by default", done => {
-    const { getAllByType } = render(<UserLocation />);
+  test('renders with CircleLayers by default', done => {
+    const {getAllByType} = render(<UserLocation />);
 
     setTimeout(() => {
       const shapeSource = getAllByType(ShapeSource);
@@ -48,8 +43,8 @@ describe("UserLocation", () => {
     });
   });
 
-  test("does not render with visible set to false", done => {
-    const { queryByType } = render(<UserLocation visible={false} />);
+  test('does not render with visible set to false', done => {
+    const {queryByType} = render(<UserLocation visible={false} />);
 
     setTimeout(() => {
       const shapeSource = queryByType(ShapeSource);
@@ -61,22 +56,22 @@ describe("UserLocation", () => {
     });
   });
 
-  test("renders with CustomChild when provided", done => {
+  test('renders with CustomChild when provided', done => {
     const circleLayerProps = {
-      key: "testUserLocationCircle",
-      id: "testUserLocationCircle",
+      key: 'testUserLocationCircle',
+      id: 'testUserLocationCircle',
       style: {
         circleRadius: 5,
-        circleColor: "#ccc",
+        circleColor: '#ccc',
         circleOpacity: 1,
-        circlePitchAlignment: "map"
-      }
+        circlePitchAlignment: 'map',
+      },
     };
 
-    const { queryByType, queryAllByType } = render(
+    const {queryByType, queryAllByType} = render(
       <UserLocation>
         <CircleLayer {...circleLayerProps} />
-      </UserLocation>
+      </UserLocation>,
     );
 
     setTimeout(() => {
@@ -92,7 +87,7 @@ describe("UserLocation", () => {
     });
   });
 
-  test("calls onUpdate callback when new location is received", () => {
+  test('calls onUpdate callback when new location is received', () => {
     const onUpdateCallback = jest.fn();
 
     render(<UserLocation onUpdate={onUpdateCallback} />);
@@ -104,22 +99,22 @@ describe("UserLocation", () => {
         heading: 251.5358428955078,
         latitude: 51.5462244,
         longitude: 4.1036916,
-        speed: 0.08543474227190018
+        speed: 0.08543474227190018,
       },
-      timestamp: 1573730357879
+      timestamp: 1573730357879,
     });
 
     expect(onUpdateCallback).toHaveBeenCalled();
   });
 
-  test("calls onPress callback when location icon is pressed", () => {
+  test('calls onPress callback when location icon is pressed', () => {
     const onPressCallback = jest.fn();
 
-    const { queryByType } = render(<UserLocation onPress={onPressCallback} />);
+    const {queryByType} = render(<UserLocation onPress={onPressCallback} />);
 
     const shapeSource = queryByType(ShapeSource);
-    fireEvent(shapeSource, "onPress");
-    fireEvent(shapeSource, "onPress");
+    fireEvent(shapeSource, 'onPress');
+    fireEvent(shapeSource, 'onPress');
     expect(onPressCallback).toHaveBeenCalledTimes(2);
   });
 });

--- a/example/.eslintrc.js
+++ b/example/.eslintrc.js
@@ -1,4 +1,0 @@
-module.exports = {
-  root: true,
-  extends: '@react-native-community',
-};

--- a/example/__tests__/App-test.js
+++ b/example/__tests__/App-test.js
@@ -4,10 +4,11 @@
 
 import 'react-native';
 import React from 'react';
-import App from '../App';
+import renderer from 'react-test-renderer';
+
+import App from '../App'; // eslint-disable-line import/no-unresolved
 
 // Note: test renderer must be required after react-native.
-import renderer from 'react-test-renderer';
 
 it('renders correctly', () => {
   renderer.create(<App />);

--- a/example/index.js
+++ b/example/index.js
@@ -3,6 +3,7 @@
  */
 
 import {AppRegistry} from 'react-native';
+
 import App from './src/App';
 import {name as appName} from './app.json';
 

--- a/example/package.json
+++ b/example/package.json
@@ -44,7 +44,7 @@
     "@babel/runtime": "^7.6.2",
     "@react-native-community/eslint-config": "^0.0.5",
     "babel-jest": "^24.9.0",
-    "eslint": "^6.4.0",
+    "eslint": "^6.8.0",
     "jest": "^24.9.0",
     "jetifier": "^1.6.4",
     "metro-react-native-babel-preset": "^0.56.0",

--- a/example/scripts/set_access_token.js
+++ b/example/scripts/set_access_token.js
@@ -7,5 +7,6 @@ if (!accessToken) {
   process.exit(1);
 }
 
+// eslint-disable-next-line no-new-wrappers
 const fileContents = `{ "accessToken": "${new String(accessToken).trim()}" }`;
 fs.writeFileSync(path.join('./', 'env.json'), fileContents);

--- a/example/scripts/watch_rngl.js
+++ b/example/scripts/watch_rngl.js
@@ -1,12 +1,18 @@
 const path = require('path');
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 const fs = require('fs-extra');
 
 const RNGL_DIR = path.join('..');
-const RNGL_EXAMPLE_DIR = path.join('node_modules', '@react-native-mapbox-gl', 'maps');
+const RNGL_EXAMPLE_DIR = path.join(
+  'node_modules',
+  '@react-native-mapbox-gl',
+  'maps',
+);
 
 function copyFile(source, dest) {
   return new Promise((resolve, reject) => {
-    fs.copy(source, dest, (err) => {
+    fs.copy(source, dest, err => {
       if (err) {
         return reject(err);
       }
@@ -15,25 +21,43 @@ function copyFile(source, dest) {
   });
 }
 
-async function main () {
+async function main() {
   try {
     console.log('Copying javascript');
-    await copyFile(path.join(RNGL_EXAMPLE_DIR, 'javascript'), path.join(RNGL_DIR, 'javascript'));
+    await copyFile(
+      path.join(RNGL_EXAMPLE_DIR, 'javascript'),
+      path.join(RNGL_DIR, 'javascript'),
+    );
 
     console.log('Copying typescript');
-    await copyFile(path.join(RNGL_EXAMPLE_DIR, 'index.d.ts'), path.join(RNGL_DIR, 'index.d.ts'));
+    await copyFile(
+      path.join(RNGL_EXAMPLE_DIR, 'index.d.ts'),
+      path.join(RNGL_DIR, 'index.d.ts'),
+    );
 
     console.log('Copying java');
-    await copyFile(path.join(RNGL_EXAMPLE_DIR, 'android', 'rctmgl', 'src'), path.join(RNGL_DIR, 'android', 'rctmgl', 'src'));
+    await copyFile(
+      path.join(RNGL_EXAMPLE_DIR, 'android', 'rctmgl', 'src'),
+      path.join(RNGL_DIR, 'android', 'rctmgl', 'src'),
+    );
 
     console.log('Copying gradle file');
-    await copyFile(path.join(RNGL_EXAMPLE_DIR, 'android', 'rctmgl', 'build.gradle'), path.join(RNGL_DIR, 'android', 'rctmgl', 'build.gradle'));
+    await copyFile(
+      path.join(RNGL_EXAMPLE_DIR, 'android', 'rctmgl', 'build.gradle'),
+      path.join(RNGL_DIR, 'android', 'rctmgl', 'build.gradle'),
+    );
 
     console.log('Copying objc');
-    await copyFile(path.join(RNGL_EXAMPLE_DIR, 'ios', 'RCTMGL'), path.join(RNGL_DIR, 'ios', 'RCTMGL'));
+    await copyFile(
+      path.join(RNGL_EXAMPLE_DIR, 'ios', 'RCTMGL'),
+      path.join(RNGL_DIR, 'ios', 'RCTMGL'),
+    );
 
     console.log('Copying xcode project');
-    await copyFile(path.join(RNGL_EXAMPLE_DIR, 'ios', 'RCTMGL.xcodeproj'), path.join(RNGL_DIR, 'ios', 'RCTMGL.xcodeproj'));
+    await copyFile(
+      path.join(RNGL_EXAMPLE_DIR, 'ios', 'RCTMGL.xcodeproj'),
+      path.join(RNGL_DIR, 'ios', 'RCTMGL.xcodeproj'),
+    );
   } catch (e) {
     console.log(e);
   }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -75,8 +75,7 @@ class App extends React.Component {
       return (
         <SafeAreaView
           style={[sheet.matchParent, {backgroundColor: colors.primary.blue}]}
-          forceInset={{top: 'always'}}
-        >
+          forceInset={{top: 'always'}}>
           <View style={sheet.matchParent}>
             <Text style={styles.noPermissionsText}>
               You need to accept location permissions in order to use this

--- a/example/src/examples/ChangeLayerColor.js
+++ b/example/src/examples/ChangeLayerColor.js
@@ -34,8 +34,7 @@ class ChangeLayerColor extends React.Component {
         <MapboxGL.MapView
           ref={c => (this._map = c)}
           onPress={this.onPress}
-          style={{flex: 1}}
-        >
+          style={{flex: 1}}>
           <MapboxGL.Camera defaultSettings={defaultCamera} />
           {!!fillColor && <MapboxGL.FillLayer id="water" style={{fillColor}} />}
         </MapboxGL.MapView>

--- a/example/src/examples/ChoroplethLayerByZoomLevel.js
+++ b/example/src/examples/ChoroplethLayerByZoomLevel.js
@@ -74,8 +74,7 @@ class ChoroplethLayerByZoomLevel extends React.PureComponent {
       <Page {...this.props}>
         <MapboxGL.MapView
           styleURL={MapboxGL.StyleURL.Light}
-          style={sheet.matchParent}
-        >
+          style={sheet.matchParent}>
           <MapboxGL.Camera
             centerCoordinate={[-98, 38.88]}
             zoomLevel={3}
@@ -84,8 +83,7 @@ class ChoroplethLayerByZoomLevel extends React.PureComponent {
 
           <MapboxGL.VectorSource
             id="population"
-            url={'mapbox://mapbox.660ui7x6'}
-          >
+            url={'mapbox://mapbox.660ui7x6'}>
             <MapboxGL.FillLayer
               id="state-population"
               sourceLayerID="state_county_population_2014_cen"

--- a/example/src/examples/CreateOfflineRegion.js
+++ b/example/src/examples/CreateOfflineRegion.js
@@ -145,8 +145,7 @@ class CreateOfflineRegion extends React.Component {
           ref={c => (this._map = c)}
           onPress={this.onPress}
           onDidFinishLoadingMap={this.onDidFinishLoadingStyle}
-          style={sheet.matchParent}
-        >
+          style={sheet.matchParent}>
           <MapboxGL.Camera zoomLevel={10} centerCoordinate={CENTER_COORD} />
         </MapboxGL.MapView>
 

--- a/example/src/examples/CustomIcon.js
+++ b/example/src/examples/CustomIcon.js
@@ -55,8 +55,7 @@ class CustomIcon extends React.Component {
         <MapboxGL.MapView
           ref={c => (this._map = c)}
           onPress={this.onPress}
-          style={sheet.matchParent}
-        >
+          style={sheet.matchParent}>
           <MapboxGL.Camera
             zoomLevel={9}
             centerCoordinate={[-73.970895, 40.723279]}
@@ -66,8 +65,7 @@ class CustomIcon extends React.Component {
             id="symbolLocationSource"
             hitbox={{width: 20, height: 20}}
             onPress={this.onSourceLayerPress}
-            shape={this.state.featureCollection}
-          >
+            shape={this.state.featureCollection}>
             <MapboxGL.SymbolLayer
               id="symbolLocationSymbols"
               minZoomLevel={1}

--- a/example/src/examples/CustomVectorSource.js
+++ b/example/src/examples/CustomVectorSource.js
@@ -58,8 +58,7 @@ class CustomVectorSource extends React.PureComponent {
             url={VECTOR_SOURCE_URL}
             ref={source => {
               this._vectorSource = source;
-            }}
-          >
+            }}>
             <MapboxGL.FillLayer
               id="customSourceFill"
               sourceLayerID="react-native-example"

--- a/example/src/examples/DataDrivenCircleColors.js
+++ b/example/src/examples/DataDrivenCircleColors.js
@@ -44,8 +44,7 @@ class DataDrivenCircleColors extends React.PureComponent {
       <Page {...this.props}>
         <MapboxGL.MapView
           styleURL={MapboxGL.StyleURL.Light}
-          style={sheet.matchParent}
-        >
+          style={sheet.matchParent}>
           <MapboxGL.Camera
             zoomLevel={10}
             pitch={45}
@@ -54,8 +53,7 @@ class DataDrivenCircleColors extends React.PureComponent {
 
           <MapboxGL.VectorSource
             id="population"
-            url={'mapbox://examples.8fgz4egr'}
-          >
+            url={'mapbox://examples.8fgz4egr'}>
             <MapboxGL.CircleLayer
               id="sf2010CircleFill"
               sourceLayerID="sf2010"

--- a/example/src/examples/DriveTheLine.js
+++ b/example/src/examples/DriveTheLine.js
@@ -166,8 +166,7 @@ class DriveTheLine extends React.Component {
     return (
       <MapboxGL.ShapeSource
         id="origin"
-        shape={MapboxGL.geoUtils.makePoint(SF_OFFICE_COORDINATE)}
-      >
+        shape={MapboxGL.geoUtils.makePoint(SF_OFFICE_COORDINATE)}>
         <MapboxGL.Animated.CircleLayer id="originInnerCircle" style={style} />
       </MapboxGL.ShapeSource>
     );
@@ -196,8 +195,7 @@ class DriveTheLine extends React.Component {
         <MapboxGL.MapView
           ref={c => (this._map = c)}
           style={sheet.matchParent}
-          styleURL={MapboxGL.StyleURL.Dark}
-        >
+          styleURL={MapboxGL.StyleURL.Dark}>
           <MapboxGL.Camera
             zoomLevel={11}
             centerCoordinate={[-122.452652, 37.762963]}
@@ -211,8 +209,7 @@ class DriveTheLine extends React.Component {
 
           <MapboxGL.ShapeSource
             id="destination"
-            shape={MapboxGL.geoUtils.makePoint(SF_ZOO_COORDINATE)}
-          >
+            shape={MapboxGL.geoUtils.makePoint(SF_ZOO_COORDINATE)}>
             <MapboxGL.CircleLayer
               id="destinationInnerCircle"
               style={layerStyles.destination}

--- a/example/src/examples/EarthQuakes.js
+++ b/example/src/examples/EarthQuakes.js
@@ -54,8 +54,7 @@ class EarthQuakes extends React.Component {
       <Page {...this.props}>
         <MapboxGL.MapView
           style={sheet.matchParent}
-          styleURL={MapboxGL.StyleURL.Dark}
-        >
+          styleURL={MapboxGL.StyleURL.Dark}>
           <MapboxGL.Camera
             zoomLevel={6}
             pitch={45}
@@ -67,8 +66,7 @@ class EarthQuakes extends React.Component {
             cluster
             clusterRadius={50}
             clusterMaxZoom={14}
-            url="https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson"
-          >
+            url="https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson">
             <MapboxGL.SymbolLayer
               id="pointCount"
               style={layerStyles.clusterCount}

--- a/example/src/examples/FitBounds.js
+++ b/example/src/examples/FitBounds.js
@@ -47,13 +47,11 @@ class FitBounds extends React.Component {
       <TabBarPage
         {...this.props}
         options={this._bounds}
-        onOptionPress={this.onFitBounds}
-      >
+        onOptionPress={this.onFitBounds}>
         <MapboxGL.MapView
           contentInset={10}
           styleURL={MapboxGL.StyleURL.Satellite}
-          style={sheet.matchParent}
-        >
+          style={sheet.matchParent}>
           <MapboxGL.Camera
             bounds={this.state.bounds}
             animationDuration={this.state.animationDuration}

--- a/example/src/examples/FlyTo.js
+++ b/example/src/examples/FlyTo.js
@@ -73,8 +73,7 @@ class FlyTo extends React.Component {
       <TabBarPage
         {...this.props}
         options={this._flyToOptions}
-        onOptionPress={this.onFlyToPress}
-      >
+        onOptionPress={this.onFlyToPress}>
         <MapboxGL.MapView style={sheet.matchParent}>
           <MapboxGL.Camera
             zoomLevel={16}

--- a/example/src/examples/GeoJSONSource.js
+++ b/example/src/examples/GeoJSONSource.js
@@ -30,8 +30,7 @@ class GeoJSONSource extends React.Component {
         <MapboxGL.MapView
           ref={ref => (this.map = ref)}
           style={sheet.matchParent}
-          styleURL={MapboxGL.StyleURL.Dark}
-        >
+          styleURL={MapboxGL.StyleURL.Dark}>
           <MapboxGL.Camera
             zoomLevel={2}
             centerCoordinate={[-35.15165038, 40.6235728]}

--- a/example/src/examples/GetCenter.js
+++ b/example/src/examples/GetCenter.js
@@ -45,8 +45,7 @@ class GetCenter extends React.Component {
           onRegionDidChange={this.onRegionDidChange}
           ref={c => (this._map = c)}
           onPress={this.onPress}
-          style={{flex: 1}}
-        >
+          style={{flex: 1}}>
           <MapboxGL.Camera
             zoomLevel={9}
             centerCoordinate={[-73.970895, 40.723279]}

--- a/example/src/examples/GetZoom.js
+++ b/example/src/examples/GetZoom.js
@@ -33,8 +33,7 @@ class GetZoom extends React.Component {
           onRegionDidChange={this.onRegionDidChange}
           ref={c => (this._map = c)}
           onPress={this.onPress}
-          style={{flex: 1}}
-        >
+          style={{flex: 1}}>
           <MapboxGL.Camera
             zoomLevel={9}
             centerCoordinate={[-73.970895, 40.723279]}

--- a/example/src/examples/Heatmap.js
+++ b/example/src/examples/Heatmap.js
@@ -23,8 +23,7 @@ class Heatmap extends React.Component {
 
           <MapboxGL.ShapeSource
             id="earthquakes"
-            url="https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"
-          >
+            url="https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson">
             <MapboxGL.HeatmapLayer
               id="earthquakes"
               sourceID="earthquakes"

--- a/example/src/examples/ImageOverlay.js
+++ b/example/src/examples/ImageOverlay.js
@@ -64,8 +64,7 @@ class ImageOverlay extends React.Component {
         <MapboxGL.MapView
           ref={ref => (this.map = ref)}
           style={sheet.matchParent}
-          styleURL={MapboxGL.StyleURL.Dark}
-        >
+          styleURL={MapboxGL.StyleURL.Dark}>
           <MapboxGL.Camera
             zoomLevel={5.2}
             centerCoordinate={[-75.789, 41.874]}
@@ -75,8 +74,7 @@ class ImageOverlay extends React.Component {
             key="d"
             id="radarSource"
             coordinates={coordQuad}
-            url={frames[this.state.radarFrameIndex]}
-          >
+            url={frames[this.state.radarFrameIndex]}>
             <MapboxGL.RasterLayer id="radarLayer" />
           </MapboxGL.Animated.ImageSource>
         </MapboxGL.MapView>

--- a/example/src/examples/IndoorBuilding.js
+++ b/example/src/examples/IndoorBuilding.js
@@ -54,8 +54,7 @@ class IndoorBuilding extends React.Component {
       <Page {...this.props}>
         <MapboxGL.MapView
           ref={ref => (this.map = ref)}
-          style={sheet.matchParent}
-        >
+          style={sheet.matchParent}>
           <MapboxGL.Camera
             zoomLevel={16}
             pitch={40}
@@ -67,8 +66,7 @@ class IndoorBuilding extends React.Component {
 
           <MapboxGL.ShapeSource
             id="indoorBuildingSource"
-            shape={indoorMapGeoJSON}
-          >
+            shape={indoorMapGeoJSON}>
             <MapboxGL.FillExtrusionLayer
               id="building3d"
               style={layerStyles.building}

--- a/example/src/examples/PointInMapView.js
+++ b/example/src/examples/PointInMapView.js
@@ -43,8 +43,7 @@ class PointInMapView extends React.Component {
         <MapboxGL.MapView
           ref={c => (this._map = c)}
           onPress={this.onPress}
-          style={{flex: 1}}
-        >
+          style={{flex: 1}}>
           <MapboxGL.Camera
             zoomLevel={9}
             centerCoordinate={[-73.970895, 40.723279]}

--- a/example/src/examples/QueryAtPoint.js
+++ b/example/src/examples/QueryAtPoint.js
@@ -65,8 +65,7 @@ class QueryAtPoint extends React.Component {
           ref={c => (this._map = c)}
           onPress={this.onPress}
           style={sheet.matchParent}
-          styleURL={MapboxGL.StyleURL.Light}
-        >
+          styleURL={MapboxGL.StyleURL.Light}>
           <MapboxGL.Camera
             zoomLevel={9}
             centerCoordinate={[-73.970895, 40.723279]}
@@ -79,8 +78,7 @@ class QueryAtPoint extends React.Component {
           {this.state.selectedGeoJSON ? (
             <MapboxGL.ShapeSource
               id="selectedNYC"
-              shape={this.state.selectedGeoJSON}
-            >
+              shape={this.state.selectedGeoJSON}>
               <MapboxGL.FillLayer
                 id="selectedNYCFill"
                 style={styles.selectedNeighborhood}

--- a/example/src/examples/QueryWithRect.js
+++ b/example/src/examples/QueryWithRect.js
@@ -85,8 +85,7 @@ class QueryWithRect extends React.Component {
           ref={c => (this._map = c)}
           onPress={this.onPress}
           style={sheet.matchParent}
-          styleURL={MapboxGL.StyleURL.Light}
-        >
+          styleURL={MapboxGL.StyleURL.Light}>
           <MapboxGL.Camera
             zoomLevel={9}
             centerCoordinate={[-73.970895, 40.723279]}
@@ -99,8 +98,7 @@ class QueryWithRect extends React.Component {
           {this.state.selectedGeoJSON ? (
             <MapboxGL.ShapeSource
               id="selectedNYC"
-              shape={this.state.selectedGeoJSON}
-            >
+              shape={this.state.selectedGeoJSON}>
               <MapboxGL.FillLayer
                 id="selectedNYCFill"
                 style={styles.selectedNeighborhood}

--- a/example/src/examples/RestrictMapBounds.js
+++ b/example/src/examples/RestrictMapBounds.js
@@ -23,8 +23,7 @@ const RestrictMapBounds = props => (
   <Page {...props}>
     <MapboxGL.MapView
       style={sheet.matchParent}
-      styleURL={MapboxGL.StyleURL.SatelliteStreet}
-    >
+      styleURL={MapboxGL.StyleURL.SatelliteStreet}>
       <MapboxGL.Camera
         maxBounds={bounds}
         zoomLevel={15}

--- a/example/src/examples/SetHeading.js
+++ b/example/src/examples/SetHeading.js
@@ -46,12 +46,10 @@ class SetHeading extends React.Component {
       <TabBarPage
         {...this.props}
         options={this._bearingOptions}
-        onOptionPress={this.onHeadingChange}
-      >
+        onOptionPress={this.onHeadingChange}>
         <MapboxGL.MapView
           ref={ref => (this.map = ref)}
-          style={sheet.matchParent}
-        >
+          style={sheet.matchParent}>
           <MapboxGL.Camera {...this.state} followUserLocation />
           <MapboxGL.UserLocation />
         </MapboxGL.MapView>

--- a/example/src/examples/SetPitch.js
+++ b/example/src/examples/SetPitch.js
@@ -46,8 +46,7 @@ class SetPitch extends React.Component {
       <TabBarPage
         {...this.props}
         options={this._pitchOptions}
-        onOptionPress={this.onUpdatePitch}
-      >
+        onOptionPress={this.onUpdatePitch}>
         <MapboxGL.MapView style={sheet.matchParent}>
           <MapboxGL.Camera {...this.state} followUserLocation />
           <MapboxGL.UserLocation />

--- a/example/src/examples/SetUserLocationVerticalAlignment.js
+++ b/example/src/examples/SetUserLocationVerticalAlignment.js
@@ -40,8 +40,7 @@ class SetUserLocationVerticalAlignment extends React.Component {
       <TabBarPage
         {...this.props}
         options={this._alignmentOptions}
-        onOptionPress={this.onAlignmentChange}
-      >
+        onOptionPress={this.onAlignmentChange}>
         <MapboxGL.MapView style={sheet.matchParent}>
           <MapboxGL.Camera followUserLocation />
           <MapboxGL.UserLocation />

--- a/example/src/examples/SetUserTrackingModes.js
+++ b/example/src/examples/SetUserTrackingModes.js
@@ -80,8 +80,7 @@ class SetUserTrackingModes extends React.Component {
         scrollable
         initialIndex={3}
         options={this._trackingOptions}
-        onOptionPress={this.onTrackingChange}
-      >
+        onOptionPress={this.onTrackingChange}>
         <MapboxGL.MapView style={sheet.matchParent}>
           <MapboxGL.UserLocation visible={this.state.showUserLocation} />
 

--- a/example/src/examples/ShapeSourceIcon.js
+++ b/example/src/examples/ShapeSourceIcon.js
@@ -78,8 +78,7 @@ class ShapeSourceIcon extends React.Component {
           <MapboxGL.Images images={{example: exampleIcon, assets: ['pin']}} />
           <MapboxGL.ShapeSource
             id="exampleShapeSource"
-            shape={featureCollection}
-          >
+            shape={featureCollection}>
             <MapboxGL.SymbolLayer id="exampleIconName" style={styles.icon} />
           </MapboxGL.ShapeSource>
         </MapboxGL.MapView>

--- a/example/src/examples/ShowAndHideLayer.js
+++ b/example/src/examples/ShowAndHideLayer.js
@@ -33,8 +33,7 @@ class ShowAndHideLayer extends React.Component {
         <MapboxGL.MapView
           ref={c => (this._map = c)}
           onPress={this.onPress}
-          style={{flex: 1}}
-        >
+          style={{flex: 1}}>
           <MapboxGL.Camera defaultSettings={defaultCamera} />
           <MapboxGL.FillLayer id="building" style={{visibility}} />
           <MapboxGL.LineLayer id="building-outline" style={{visibility}} />

--- a/example/src/examples/ShowMap.js
+++ b/example/src/examples/ShowMap.js
@@ -55,12 +55,10 @@ class ShowMap extends React.Component {
         {...this.props}
         scrollable
         options={this._mapOptions}
-        onOptionPress={this.onMapChange}
-      >
+        onOptionPress={this.onMapChange}>
         <MapboxGL.MapView
           styleURL={this.state.styleURL}
-          style={sheet.matchParent}
-        >
+          style={sheet.matchParent}>
           <MapboxGL.Camera followZoomLevel={12} followUserLocation />
 
           <MapboxGL.UserLocation onPress={this.onUserMarkerPress} />

--- a/example/src/examples/ShowPointAnnotation.js
+++ b/example/src/examples/ShowPointAnnotation.js
@@ -106,8 +106,7 @@ class ShowPointAnnotation extends React.Component {
           key={id}
           id={id}
           coordinate={coordinate}
-          title={title}
-        >
+          title={title}>
           <View style={styles.annotationContainer} />
           <MapboxGL.Callout title="This is a sample" />
         </MapboxGL.PointAnnotation>,
@@ -124,8 +123,7 @@ class ShowPointAnnotation extends React.Component {
           ref={c => (this._map = c)}
           onPress={this.onPress}
           onDidFinishLoadingMap={this.onDidFinishLoadingMap}
-          style={sheet.matchParent}
-        >
+          style={sheet.matchParent}>
           <MapboxGL.Camera
             zoomLevel={16}
             centerCoordinate={this.state.coordinates[0]}

--- a/example/src/examples/ShowRegionDidChange.js
+++ b/example/src/examples/ShowRegionDidChange.js
@@ -131,15 +131,13 @@ class ShowRegionDidChange extends React.Component {
       <TabBarPage
         {...this.props}
         options={this._tabOptions}
-        onOptionPress={this.onOptionPress}
-      >
+        onOptionPress={this.onOptionPress}>
         <MapboxGL.MapView
           ref={c => (this.map = c)}
           style={sheet.matchParent}
           onRegionWillChange={this.onRegionWillChange}
           onRegionIsChanging={this.onRegionIsChanging}
-          onRegionDidChange={this.onRegionDidChange}
-        >
+          onRegionDidChange={this.onRegionDidChange}>
           <MapboxGL.Camera {...this.state.cameraConfig} />
         </MapboxGL.MapView>
         {this.renderRegionChange()}

--- a/example/src/examples/SourceLayerVisibility.js
+++ b/example/src/examples/SourceLayerVisibility.js
@@ -37,8 +37,7 @@ class SourceLayerVisibility extends React.Component {
         <MapboxGL.MapView
           ref={c => (this._map = c)}
           onPress={this.onPress}
-          style={{flex: 1}}
-        >
+          style={{flex: 1}}>
           <MapboxGL.Camera defaultSettings={defaultCamera} />
         </MapboxGL.MapView>
         <Bubble onPress={this.onPress}>

--- a/example/src/examples/TwoByTwo.js
+++ b/example/src/examples/TwoByTwo.js
@@ -33,8 +33,7 @@ class TwoByTwo extends React.Component {
         onSetCameraComplete={this.onUpdateZoomLevel}
         ref={ref => (this.map = ref)}
         style={sheet.matchParent}
-        styleURL={styleURL}
-      >
+        styleURL={styleURL}>
         <MapboxGL.ShapeSource id="smileyFaceSource" shape={smileyFaceGeoJSON}>
           <MapboxGL.FillLayer id="smileyFaceFill" style={layerStyle} />
         </MapboxGL.ShapeSource>

--- a/example/src/examples/YoYo.js
+++ b/example/src/examples/YoYo.js
@@ -60,8 +60,7 @@ class YoYo extends React.Component {
         <MapboxGL.MapView
           ref={ref => (this.map = ref)}
           style={sheet.matchParent}
-          styleURL={MapboxGL.StyleURL.Dark}
-        >
+          styleURL={MapboxGL.StyleURL.Dark}>
           <MapboxGL.Camera
             zoomLevel={this.state.zoomLevel}
             centerCoordinate={SF_OFFICE_COORDINATE}

--- a/example/src/examples/common/PulseCircleLayer.js
+++ b/example/src/examples/common/PulseCircleLayer.js
@@ -119,8 +119,7 @@ class PulseCircleLayer extends React.Component {
     return (
       <MapboxGL.Animated.ShapeSource
         id="pulseCircleSource"
-        shape={this.props.shape}
-      >
+        shape={this.props.shape}>
         <MapboxGL.Animated.CircleLayer
           id="pulseOuterCircle"
           style={outerCircleStyle}

--- a/example/src/utils/config.js
+++ b/example/src/utils/config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import env from '../../env.json';
 
 class Config {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "lint-staged": {
     "linters": {
       "*.js": [
-        "eslint ./javascript/**/*.js  ./example/src/**/*.js ./__tests__/**/*.js --fix",
+        "yarn lint",
         "git add"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "unittest": "jest --coverage --verbose",
     "unittest:single": "jest --testNamePattern",
     "format": "npm run lint -- --fix",
-    "lint": "./node_modules/eslint/bin/eslint.js ./javascript/** ./example/src/** ./__tests__/**"
+    "lint": "eslint . --ignore-pattern 'example' --ignore-pattern 'scripts' --fix && cd example/ && eslint . --ignore-pattern 'scripts' --fix"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.8",
@@ -56,7 +56,7 @@
     "documentation": "12.1.2",
     "ejs": "^2.5.7",
     "ejs-lint": "^0.3.0",
-    "eslint": "^6.0.0",
+    "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-config-strict-react": "9.0.2",


### PR DESCRIPTION
### Problem
There were different setups for `/examples` and the root directories linting:
* There were quite some linting errors when trying to commit anything, I'm assuming, that everyone is currently creating PRs with the `no-verify` flag, which isn't ideal
* Eslint version weren't synced 
* Running `eslint` from `root` and from `example` would result in errors or different results for `example` (ie different linting errors/ warnings)
* Pre-commit hook was using another linting command as well

### Solution
* update `eslint` to version `6.8.0`
* `example/` uses same `eslintrc` as root directory (deleted the one in `example/`, which will cause `eslint` to go up one directory to find a viable `eslintrc`)
* edit `yarn/ npm lint` script within `package.json`
* edit pre-commit hook to use `package.json` lint script

### Considerations
* node_modules need to be installed in `example/` in order to not get false positive errors (but that was also the case beforehand, so ok I guess 🤷‍♂ )
* we have quite some lint warnings, however I would want to deal with those in a follow-up PR
* I needed to disable some errors because fixing those errors would be outside the scope of this PR which is solely focusing on cleaning up the linting pipeline


Looking forward to a review.
Thanks in advance