### PR TITLE
Add mergeOfflineRegions method to enable side-loading tiles

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -301,6 +301,25 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void mergeOfflineRegions(final String path, final Promise promise) {
+        activateFileSource();
+
+        final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
+
+        offlineManager.mergeOfflineRegions(path, new OfflineManager.MergeOfflineRegionsCallback() {
+            @Override
+            public void onMerge(OfflineRegion[] offlineRegions) {
+                promise.resolve(null);
+            }
+
+            @Override
+            public void onError(String error) {
+                promise.reject("mergeOfflineRegions", error);
+            }
+        });
+    }
+
+    @ReactMethod
     public void setTileCountLimit(int tileCountLimit) {
         OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
         offlineManager.setOfflineMapboxTileCountLimit(tileCountLimit);

--- a/docs/OfflineManager.md
+++ b/docs/OfflineManager.md
@@ -95,6 +95,22 @@ const offlinePack = await MapboxGL.offlineManager.getPack();
 ```
 
 
+#### mergeOfflineRegions(path)
+
+Sideloads offline db
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `path` | `String` | `Yes` | Path to offline tile db on file system. |
+
+
+
+```javascript
+await MapboxGL.offlineManager.mergeOfflineRegions(path);
+```
+
+
 #### setTileCountLimit(limit)
 
 Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.<br/>The Mapbox Terms of Service prohibits changing or bypassing this limit without permission from Mapbox.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5250,6 +5250,29 @@
         }
       },
       {
+        "name": "mergeOfflineRegions",
+        "description": "Sideloads offline db",
+        "params": [
+          {
+            "name": "path",
+            "description": "Path to offline tile db on file system.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.mergeOfflineRegions(path);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
         "name": "setTileCountLimit",
         "description": "Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.\nThe Mapbox Terms of Service prohibits changing or bypassing this limit without permission from Mapbox.",
         "params": [

--- a/javascript/modules/offline/OfflinePack.js
+++ b/javascript/modules/offline/OfflinePack.js
@@ -10,7 +10,7 @@ class OfflinePack {
 
   get name() {
     const {metadata} = this;
-    return metadata.name;
+    return metadata && metadata.name;
   }
 
   get bounds() {
@@ -18,7 +18,7 @@ class OfflinePack {
   }
 
   get metadata() {
-    if (!this._metadata) {
+    if (!this._metadata && this.pack.metadata) {
       this._metadata = JSON.parse(this.pack.metadata);
     }
     return this._metadata;

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -133,6 +133,20 @@ class OfflineManager {
   }
 
   /**
+   * Sideloads offline db
+   *
+   * @example
+   * await MapboxGL.offlineManager.mergeOfflineRegions(path);
+   *
+   * @param {String} path Path to offline tile db on file system.
+   * @return {void}
+   */
+  async mergeOfflineRegions(path) {
+    await this._initialize();
+    return MapboxGLOfflineManager.mergeOfflineRegions(path);
+  }
+
+  /**
    * Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.
    * The Mapbox Terms of Service prohibits changing or bypassing this limit without permission from Mapbox.
    *


### PR DESCRIPTION
This adds `mergeOfflineRegions` method to the offline manager. Tested and working on iOS and Android.

I decided to use the name `mergeOfflineRegions` (which is what it's called in the Android SDK) because it made more sense to me than naming it `addContentsOfFile` or `addContentsOfURL` (as it's called in the iOS SDK).

I originally started making an example to demonstrate it in the example app, but since the side-loaded database must be generated using the same version of the Mapbox SDK that the client is using, such an example would break whenever we update either of our iOS or Android SDK versions.

This resolves #574.