### PR TITLE
Pass options argument in makeFeature

### DIFF
--- a/javascript/utils/geoUtils.js
+++ b/javascript/utils/geoUtils.js
@@ -20,8 +20,8 @@ export function makeLatLngBounds(northEastCoordinates, southWestCoordinates) {
   ]);
 }
 
-export function makeFeature(geometry, properties) {
-  return feature(geometry, properties);
+export function makeFeature(geometry, properties, options) {
+  return feature(geometry, properties, options);
 }
 
 export function makeFeatureCollection(features = [], options) {


### PR DESCRIPTION
Is useful to create feature `id` in one single call:

```
MapboxGL.geoUtils.makeFeature(
  {
    type: 'Point',
    coordinates: center,
  },
  {prop: "val"},
  {id: "myId"},
);
```