### PR TITLE
Fix `getCoordinateFromView()` calculation on Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -684,6 +684,10 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
 
     }
 
+    private float getDisplayDensity() {
+        return mContext.getResources().getDisplayMetrics().density;
+    }
+
     public void setReactStyleURL(String styleURL) {
         mStyleURL = styleURL;
 
@@ -777,7 +781,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         if (position.hasKey("bottom")) {
             mAttributionGravity |= Gravity.BOTTOM;
         }
-        float density = mContext.getResources().getDisplayMetrics().density;
+        float density = getDisplayDensity();
         mAttributionMargin = new int[]{
             position.hasKey("left") ? (int) density * position.getInt("left") : 0,
             position.hasKey("top") ? (int) density * position.getInt("top") : 0,
@@ -845,6 +849,9 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     }
 
     public void getCoordinateFromView(String callbackID, PointF pointInView) {
+        float density = getDisplayDensity();
+        pointInView.x *= density;
+        pointInView.y *= density;
 
         LatLng mapCoordinate = mMap.getProjection().fromScreenLocation(pointInView);
         WritableMap payload = new WritableNativeMap();


### PR DESCRIPTION
Android: Add private `getDisplayDensity()` function for getting display density and use density to multiple the point in view's x/y coords.

Has been tested two different Android devices with different densities and it now works the same way as iOS does.

Closes #576  