### PR TITLE
build: Increase android sdk version to 8.6.1

### DIFF
--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     // Mapbox SDK
 
     implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.9.0'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:8.6.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:8.6.1'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:0.7.0'
 
     // Dependencies

--- a/scripts/autogenerate.js
+++ b/scripts/autogenerate.js
@@ -18,7 +18,7 @@ if (!styleSpecJSON) {
 }
 
 const layers = [];
-const androidVersion = '8.6.0';
+const androidVersion = '8.6.1';
 const iosVersion = '5.5.0';
 
 const TMPL_PATH = path.join(__dirname, 'templates');


### PR DESCRIPTION
Increased the android sdk version to `8.6.1` as we have increased crash reports and that release seems to have fixed a native crash from `8.6.0`.

Would love to get your opinion on this guys.

Might be related to:
#626 
#625
#622 
#613 