### PR TITLE
Fix `getPointInView()` calculation on Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -837,6 +837,9 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     public void getPointInView(String callbackID, LatLng mapCoordinate) {
 
         PointF pointInView = mMap.getProjection().toScreenLocation(mapCoordinate);
+        float density = getDisplayDensity();
+        pointInView.x /= density;
+        pointInView.y /= density;
         WritableMap payload = new WritableNativeMap();
 
         WritableArray array = new WritableNativeArray();


### PR DESCRIPTION
The `getCoordinateFromView` method got fixed recently in this PR https://github.com/react-native-mapbox-gl/maps/pull/619, but the `getPointInView()` had the same problem (only in the opposite direction).

This PR should fix this, but I've only tested on my phone. The fact it did work on my phone and that it is so simple (just do the inverse operation to the one added to `getCoordinateFromView`) gives me confidence it is correct, but feel free to test it further.