### PR TITLE
Change compassViewPosition propType from string to number

### DIFF
--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -18,7 +18,7 @@
 | attributionPosition | `union` | `none` | `false` | Adds attribution offset, e.g. `{top: 8, left: 8}` will put attribution button in top-left corner of the map |
 | logoEnabled | `bool` | `true` | `false` | Enable/Disable the logo on the map. |
 | compassEnabled | `bool` | `none` | `false` | Enable/Disable the compass from appearing on the map |
-| compassViewPosition | `string` | `none` | `false` | Change corner of map the compass starts at. (iOS only) 0: TopLeft, 1: TopRight, 2: BottomLeft, 3: BottomRight |
+| compassViewPosition | `number` | `none` | `false` | Change corner of map the compass starts at. (iOS only) 0: TopLeft, 1: TopRight, 2: BottomLeft, 3: BottomRight |
 | compassViewMargins | `object` | `none` | `false` | Add margins to the compass with x and y values |
 | surfaceView | `bool` | `false` | `false` | [Android only] Enable/Disable use of GLSurfaceView insted of TextureView. |
 | onPress | `func` | `none` | `false` | Map press listener, gets called when a user presses the map |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2742,7 +2742,7 @@
       {
         "name": "compassViewPosition",
         "required": false,
-        "type": "string",
+        "type": "number",
         "default": "none",
         "description": "Change corner of map the compass starts at. (iOS only) 0: TopLeft, 1: TopRight, 2: BottomLeft, 3: BottomRight"
       },

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -128,7 +128,7 @@ class MapView extends NativeBridgeComponent(React.Component) {
     /**
      * Change corner of map the compass starts at. (iOS only) 0: TopLeft, 1: TopRight, 2: BottomLeft, 3: BottomRight
      */
-    compassViewPosition: PropTypes.string,
+    compassViewPosition: PropTypes.number,
 
     /**
      * Add margins to the compass with x and y values


### PR DESCRIPTION
This simple change fixes the `propType` defined for `MapView`'s `compassViewPosition` prop.

It had been set to `string`, but should be `number`. The [corresponding TypeScript type](https://github.com/react-native-mapbox-gl/maps/blob/master/index.d.ts#L334) is already correct so this is the only change required.