### PR TITLE
Adds named export for library functions

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -111,4 +111,33 @@ MapboxGL.Animated = {
   BackgroundLayer: Animated.createAnimatedComponent(BackgroundLayer),
 };
 
+export {
+  MapView,
+  Light,
+  PointAnnotation,
+  Callout,
+  UserLocation,
+  Camera,
+  Annotation,
+  MarkerView,
+  VectorSource,
+  ShapeSource,
+  RasterSource,
+  ImageSource,
+  Images,
+  FillLayer,
+  FillExtrusionLayer,
+  HeatmapLayer,
+  LineLayer,
+  CircleLayer,
+  SymbolLayer,
+  RasterLayer,
+  BackgroundLayer,
+  locationManager,
+  offlineManager,
+  snapshotManager,
+  geoUtils,
+  AnimatedMapPoint,
+};
+
 export default MapboxGL;


### PR DESCRIPTION
This PR adds named export for main library components in order to let us do for example `import {MapView, UserLocation} from '@react-native-mapbox-gl/maps';`