### PR TITLE
feat(camera): add verticalAlignment

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCameraManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCameraManager.java
@@ -91,4 +91,9 @@ public class RCTMGLCameraManager extends AbstractEventEmitter<RCTMGLCamera> {
         camera.setMaxZoomLevel(value);
     }
 
+    @ReactProp(name="userLocationVerticalAlignment")
+    public void setUserLocationVerticalAlignment(RCTMGLCamera camera, int userLocationVerticalAlignment) {
+        camera.setReactUserLocationVerticalAlignment(userLocationVerticalAlignment);
+    }
+
 }

--- a/docs/Camera.md
+++ b/docs/Camera.md
@@ -19,6 +19,7 @@
 | &nbsp;&nbsp;&nbsp;&nbsp;paddingTop | `number` | `none` | `false` | Top camera padding for bounds |
 | &nbsp;&nbsp;&nbsp;&nbsp;paddingBottom | `number` | `none` | `false` | Bottom camera padding for bounds |
 | &nbsp;&nbsp;zoomLevel | `number` | `none` | `false` | Zoom level of the map |
+| &nbsp;&nbsp;userLocationVerticalAlignment | `number` | `none` | `false` | The vertical alignment of the user location within in map. This is only enabled while tracking the users location. |
 | centerCoordinate | `array` | `none` | `false` | Center coordinate on map [lng, lat] |
 | heading | `number` | `none` | `false` | Heading on map |
 | pitch | `number` | `none` | `false` | Pitch on map |
@@ -30,6 +31,7 @@
 | &nbsp;&nbsp;paddingTop | `number` | `none` | `false` | Top camera padding for bounds |
 | &nbsp;&nbsp;paddingBottom | `number` | `none` | `false` | Bottom camera padding for bounds |
 | zoomLevel | `number` | `none` | `false` | Zoom level of the map |
+| userLocationVerticalAlignment | `number` | `none` | `false` | The vertical alignment of the user location within in map. This is only enabled while tracking the users location. |
 | minZoomLevel | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | maxZoomLevel | `number` | `none` | `false` | FIX ME NO DESCRIPTION |
 | maxBounds | `shape` | `none` | `false` | Restrict map panning so that the center is within these bounds |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -514,6 +514,13 @@
               "type": "number",
               "default": "none",
               "description": "Zoom level of the map"
+            },
+            {
+              "name": "userLocationVerticalAlignment",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "The vertical alignment of the user location within in map. This is only enabled while tracking the users location."
             }
           ]
         },
@@ -615,6 +622,13 @@
         "type": "number",
         "default": "none",
         "description": "Zoom level of the map"
+      },
+      {
+        "name": "userLocationVerticalAlignment",
+        "required": false,
+        "type": "number",
+        "default": "none",
+        "description": "The vertical alignment of the user location within in map. This is only enabled while tracking the users location."
       },
       {
         "name": "minZoomLevel",

--- a/example/src/examples/SetUserLocationVerticalAlignment.js
+++ b/example/src/examples/SetUserLocationVerticalAlignment.js
@@ -42,7 +42,12 @@ class SetUserLocationVerticalAlignment extends React.Component {
         options={this._alignmentOptions}
         onOptionPress={this.onAlignmentChange}>
         <MapboxGL.MapView style={sheet.matchParent}>
-          <MapboxGL.Camera followUserLocation />
+          <MapboxGL.Camera
+            zoomLevel={16}
+            followUserLocation
+            followUserMode="compass"
+            userLocationVerticalAlignment={this.state.currentAlignmentMode}
+          />
           <MapboxGL.UserLocation />
         </MapboxGL.MapView>
       </TabBarPage>

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -61,6 +61,11 @@ const SettingsPropTypes = {
    * Zoom level of the map
    */
   zoomLevel: PropTypes.number,
+
+  /**
+   * The vertical alignment of the user location within in map. This is only enabled while tracking the users location.
+   */
+  userLocationVerticalAlignment: PropTypes.number,
 };
 
 class Camera extends React.Component {
@@ -140,6 +145,17 @@ class Camera extends React.Component {
   }
 
   _handleCameraChange(currentCamera, nextCamera) {
+    // setting it in here up top for it to take immediate effect
+    // TODO: refactor when other issues are solved
+    if (
+      currentCamera.userLocationVerticalAlignment !==
+      nextCamera.userLocationVerticalAlignment
+    ) {
+      this.refs.camera.setNativeProps({
+        userLocationVerticalAlignment: nextCamera.userLocationVerticalAlignment,
+      });
+    }
+
     const hasCameraChanged = this._hasCameraChanged(currentCamera, nextCamera);
     if (!hasCameraChanged) {
       return;
@@ -547,6 +563,7 @@ class Camera extends React.Component {
         stop={this._createStopConfig(props)}
         maxZoomLevel={this.props.maxZoomLevel}
         minZoomLevel={this.props.minZoomLevel}
+        userLocationVerticalAlignment={this.props.userLocationVerticalAlignment}
         maxBounds={this._getMaxBounds()}
         defaultStop={this._createDefaultCamera()}
         {...callbacks}


### PR DESCRIPTION
This is the attempt to add `verticalAlignment` as a prop to Camera.

It does "work", however with some caveats.

First my general assumptions:
* Vertical Alignment has three settings TOP CENTER BOTTOM
* Vertical Alignment does only make sense when the UserLocation is tracked
* Vertical Alignment is maintained for the chosen UserTrackingMode, even when changed
* Camera rotation is anchored around the verticalAlignment

Current (unfinished) implementation with this PR:
* Vertical Alignment is set to either TOP CENTER or BOTTOM when option is selected 
Check out this example to test it:  example/src/examples/SetUserLocationVerticalAlignment.js

## Problems
### UserTracking Mode is set to NONE after applied vertical Alignment

UserTrackingMode is reset to `NONE` once the verticalAlignment is set. This is due to `moveCamera`, `easeCamera`, `animateCamera` -> all of them eventually call a function called `notifyDeveloperAnimationListeners();`
https://github.com/mapbox/mapbox-gl-native-android/blob/65cf1d1cc7a0d63d9cccc3fc27825d7ee24b3d80/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java#L2422-L2424

Which in turn will eventually call this:
https://github.com/mapbox/mapbox-gl-native-android/blob/daf0430a24b1f761472c90f12ae25a5e081c9ed2/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java#L1592-L1594

Which will set `CameraMode.NONE`, rendering the tracking disabled on our map.

And this will spit us back out here:
https://github.com/react-native-mapbox-gl/maps/blob/3653e4c8cdf13096c43464886820edd535143914/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java#L412-L436

I've managed to simply disable this and hardcode:
`mLocationComponent.setCameraMode(UserTrackingMode.getCameraMode(<MY_USER_TRACKING_MODE>));`

Obviously, that's not a fitting solution :S


### Camera anchor point is not centered around vertically aligned user location
The other issue is, that when using the above mentioned hack to actually keep track of the user location. The camera rotation is still anchored on the center of the map, instead of the newly aligned user location...


Really looking forward to some feedback and recommendations, as I'm stuck on how to proceed with with.


Thanks in advance


Obviously, please _DO NOT MERGE_