### PR TITLE
fix(user-location): stop locationManager on unmount

### DIFF
--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -140,6 +140,8 @@ class UserLocation extends React.Component {
             coordinates: this._getCoordinatesFromLocation(lastKnownLocation),
           });
         }
+      } else if (!running) {
+        locationManager.dispose();
       }
     }
   };


### PR DESCRIPTION
UserLocation component wouldn't stop `locationManager` on unmounts.

On unmounts, we call `await this.setLocationManager({running: false});`

https://github.com/react-native-mapbox-gl/maps/blob/c8fbd5bf344a7a11545f0cabc6fce9f63a73cf58/javascript/components/UserLocation.js#L130-L147

I went for an `else if` to be very specific about when it's supposed to stop.

This resolves #663 

Looking forward to a review
Thanks in advance
