### PR TITLE
Implement refresh for PointAnnotation on android and fix Images

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotationManager.java
@@ -1,6 +1,9 @@
 package com.mapbox.rctmgl.components.annotation;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -32,6 +35,17 @@ public class RCTMGLPointAnnotationManager extends AbstractEventEmitter<RCTMGLPoi
                 .build();
     }
 
+    //region React Methods
+    public static final int METHOD_REFRESH = 2;
+
+    @Nullable
+    @Override
+    public Map<String, Integer> getCommandsMap() {
+        return MapBuilder.<String, Integer>builder()
+                .put("refresh", METHOD_REFRESH)
+                .build();
+    }
+
     @Override
     public String getName() {
         return REACT_CLASS;
@@ -60,5 +74,14 @@ public class RCTMGLPointAnnotationManager extends AbstractEventEmitter<RCTMGLPoi
     @ReactProp(name="draggable")
     public void setDraggable(RCTMGLPointAnnotation annotation, Boolean draggable) {
         annotation.setDraggable(draggable);
+    }
+
+    @Override
+    public void receiveCommand(RCTMGLPointAnnotation annotation, String command, @Nullable ReadableArray args) {
+        switch (command) {
+            case "refresh":
+                annotation.refresh();
+                break;
+        }
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -14,6 +14,7 @@ import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 
 
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -134,6 +135,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
 
 
     private MarkerViewManager makerViewManager = null;
+    private ViewGroup mOffscreenAnnotationViewContainer = null;
 
     private boolean mAnnotationClicked = false;
 
@@ -1268,6 +1270,23 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         loadedStyle.addImage("MARKER_IMAGE_ID", BitmapFactory.decodeResource(
             this.getResources(), R.drawable.red_marker)
         );
+    }
+
+    /**
+     * PointAnnotations are rendered to a canvas, but react native Image component is
+     * implemented on top of Fresco, and fresco will not load images when their view is
+     * not attached to the window. So we'll have an offscreen view where we add those views
+     * so they can rendered full to canvas.
+     */
+    public ViewGroup offscreenAnnotationViewContainer() {
+        if (mOffscreenAnnotationViewContainer == null) {
+            mOffscreenAnnotationViewContainer = new FrameLayout(getContext());
+            FrameLayout.LayoutParams flParams = new FrameLayout.LayoutParams(0,0);
+            flParams.setMargins(-10000, -10000, -10000,-10000);
+            mOffscreenAnnotationViewContainer.setLayoutParams(flParams);
+            addView(mOffscreenAnnotationViewContainer);
+        }
+        return mOffscreenAnnotationViewContainer;
     }
 
     public MarkerViewManager getMakerViewManager(MapboxMap map) {

--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -19,4 +19,15 @@
 | onDragStart | `func` | `none` | `false` | This callback is fired once this annotation has started being dragged. |
 | onDragEnd | `func` | `none` | `false` | This callback is fired once this annotation has stopped being dragged. |
 
+### methods
+#### refresh()
+
+On android point annotation is rendered offscreen with a canvas into an image.<br/>To rerender the image from the current state of the view call refresh.<br/>Call this for example from Image#onLoad.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+
+
+
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2973,7 +2973,17 @@
   "PointAnnotation": {
     "description": "PointAnnotation represents a one-dimensional shape located at a single geographical coordinate. Consider using ShapeSource and SymbolLayer instead, if you have many points and you have static images, they'll offer much better performance.\nIf you need interctive views please use MarkerView, as with PointAnnotation on android child views are rendered onto a bitmap for better performance.",
     "displayName": "PointAnnotation",
-    "methods": [],
+    "methods": [
+      {
+        "name": "refresh",
+        "docblock": "On android point annotation is rendered offscreen with a canvas into an image.\nTo rerender the image from the current state of the view call refresh.\nCall this for example from Image#onLoad.",
+        "modifiers": [],
+        "params": [],
+        "returns": null,
+        "description": "On android point annotation is rendered offscreen with a canvas into an image.\nTo rerender the image from the current state of the view call refresh.\nCall this for example from Image#onLoad.",
+        "examples": []
+      }
+    ],
     "props": [
       {
         "name": "id",

--- a/example/src/examples/ShowPointAnnotation.js
+++ b/example/src/examples/ShowPointAnnotation.js
@@ -1,5 +1,7 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable fp/no-mutating-methods */
 import React from 'react';
-import {Animated, View, Text, StyleSheet} from 'react-native';
+import {Animated, View, Text, StyleSheet, Image} from 'react-native';
 import MapboxGL from '@react-native-mapbox-gl/maps';
 
 import sheet from '../styles/sheet';
@@ -20,6 +22,7 @@ const styles = StyleSheet.create({
     borderRadius: ANNOTATION_SIZE / 2,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'rgba(0, 0, 0, 0.45)',
+    overflow: 'hidden',
   },
   annotationFill: {
     width: ANNOTATION_SIZE - 3,
@@ -29,6 +32,30 @@ const styles = StyleSheet.create({
     transform: [{scale: 0.6}],
   },
 });
+
+class AnnotationWithRemoteImage extends React.Component {
+  annotationRef = null;
+
+  render() {
+    const {id, coordinate, title} = this.props;
+    return (
+      <MapboxGL.PointAnnotation
+        id={id}
+        coordinate={coordinate}
+        title={title}
+        ref={ref => (this.annotationRef = ref)}>
+        <View style={styles.annotationContainer}>
+          <Image
+            source={{uri: 'https://reactnative.dev/img/tiny_logo.png'}}
+            style={{width: ANNOTATION_SIZE, height: ANNOTATION_SIZE}}
+            onLoad={() => this.annotationRef.refresh()}
+          />
+        </View>
+        <MapboxGL.Callout title="This is a sample" />
+      </MapboxGL.PointAnnotation>
+    );
+  }
+}
 
 class ShowPointAnnotation extends React.Component {
   static propTypes = {
@@ -101,16 +128,27 @@ class ShowPointAnnotation extends React.Component {
         animationStyle.transform = [{scale: this._scaleOut}];
       }
 
-      items.push(
-        <MapboxGL.PointAnnotation
-          key={id}
-          id={id}
-          coordinate={coordinate}
-          title={title}>
-          <View style={styles.annotationContainer} />
-          <MapboxGL.Callout title="This is a sample" />
-        </MapboxGL.PointAnnotation>,
-      );
+      if ((i % 2) === 1) {
+        items.push(
+          <AnnotationWithRemoteImage
+            key={id}
+            id={id}
+            coordinate={coordinate}
+            title={title} />
+        );
+
+      } else {
+        items.push(
+          <MapboxGL.PointAnnotation
+            key={id}
+            id={id}
+            coordinate={coordinate}
+            title={title}>
+            <View style={styles.annotationContainer} />
+            <MapboxGL.Callout title="This is a sample with image" />
+          </MapboxGL.PointAnnotation>,
+        );
+      }
     }
 
     return items;

--- a/javascript/components/PointAnnotation.js
+++ b/javascript/components/PointAnnotation.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {requireNativeComponent, StyleSheet} from 'react-native';
+import {
+  requireNativeComponent,
+  StyleSheet,
+  findNodeHandle,
+  UIManager,
+} from 'react-native';
 
 import {toJSONString, isFunction, viewPropTypes} from '../utils';
 import {makePoint} from '../utils/geoUtils';
@@ -129,6 +134,17 @@ class PointAnnotation extends React.PureComponent {
       return;
     }
     return toJSONString(makePoint(this.props.coordinate));
+  }
+
+  /**
+   * On android point annotation is rendered offscreen with a canvas into an image.
+   * To rerender the image from the current state of the view call refresh.
+   * Call this for example from Image#onLoad.
+   */
+  refresh() {
+    if (Platform.OS === 'android') {
+      UIManager.dispatchViewManagerCommand(findNodeHandle(this), 'refresh', []);
+    }
   }
 
   render() {


### PR DESCRIPTION
Fixes: #469 

Images placed inside PointAnnotation was not rendered an android. On android we render PointAnnotations by rendering the RN Views to an bitmaps and using SymbolLayer to display the map.
There is 2 issue with images
1.) React Native Images are based on Fresco on android, and Fresco is detecting that a view is not attached to a window, and in such cases, it'll not load the image.
2.) Images might take a while to load and we've dont renrender the bitmaps. (Only when layout has changed)

Solutions:
1.) we add the views to an invisible parent view inside the map, so fresco detects that they are still attached
2.) there is a new `PointAnnotation#refresh` that you can call from `Image#onLoad` to request a re-render once the image has loaded

```es6
class AnnotationWithRemoteImage extends React.Component {
  annotationRef = null;

  render() {
    const {id, coordinate, title} = this.props;
    return (
      <MapboxGL.PointAnnotation
        id={id}
        coordinate={coordinate}
        title={title}
        ref={ref => (this.annotationRef = ref)}>
        <View style={styles.annotationContainer}>
          <Image
            source={{uri: 'https://reactnative.dev/img/tiny_logo.png'}}
            style={{width: ANNOTATION_SIZE, height: ANNOTATION_SIZE}}
            onLoad={() => this.annotationRef.refresh()}
          />
        </View>
        <MapboxGL.Callout title="This is a sample" />
      </MapboxGL.PointAnnotation>
    );
  }
}
```