### PR TITLE
Fix MarkerView race with reflow

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLMarkerView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLMarkerView.java
@@ -65,7 +65,7 @@ public class RCTMGLMarkerView extends AbstractMapFeature implements MarkerView.O
 
         final RCTMGLMarkerView rctmglMarkerView = this;
 
-        mMapView.getMapAsync(
+        mMapView.getMapWithReflowAsync(
             new OnMapReadyCallback() {
                 @Override
                 public void onMapReady(@NonNull MapboxMap mapboxMap) {

--- a/example/src/examples/MarkerView.js
+++ b/example/src/examples/MarkerView.js
@@ -59,7 +59,9 @@ class ShowMarkerView extends React.Component {
             centerCoordinate={this.state.coordinates[0]}
           />
 
-          <MapboxGL.PointAnnotation coordinate={this.state.coordinates[1]}>
+          <MapboxGL.PointAnnotation
+            coordinate={this.state.coordinates[1]}
+            id="pt-ann">
             <AnnotationContent title={'this is a point annotation'} />
           </MapboxGL.PointAnnotation>
 


### PR DESCRIPTION
When marker view got added before MapView reflow, the marker view got resized to full size of mapview. Now MarkerView's are added only after reflow finished.

https://github.com/react-native-mapbox-gl/maps/blob/b2f418ba5faf254565e5b7ea80de740e0f8c0a91/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java#L461-L470