### PR TITLE
ShapeShource#onPress e.nativeEvent is now deprecated, use e.features

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,7 +66,7 @@ module.exports = {
     quotes: [2, "single"],
     "eol-last": [0],
     "no-continue": [1],
-    "class-methods-use-this": [1],
+    "class-methods-use-this": [0],
     "no-bitwise": [1],
     "prefer-destructuring": [1],
     "consistent-return": [1],

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -576,7 +576,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         PointF screenPoint = mMap.getProjection().toScreenLocation(point);
         List<RCTSource> touchableSources = getAllTouchableSources();
 
-        Map<String, Feature> hits = new HashMap<>();
+        Map<String, List<Feature>> hits = new HashMap<>();
         List<RCTSource> hitTouchableSources = new ArrayList<>();
         for (RCTSource touchableSource : touchableSources) {
             Map<String, Double> hitbox = touchableSource.getTouchHitbox();
@@ -593,7 +593,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
 
             List<Feature> features = mMap.queryRenderedFeatures(hitboxF, touchableSource.getLayerIDs());
             if (features.size() > 0) {
-                hits.put(touchableSource.getID(), features.get(0));
+                hits.put(touchableSource.getID(), features);
                 hitTouchableSources.add(touchableSource);
             }
         }
@@ -601,7 +601,11 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         if (hits.size() > 0) {
             RCTSource source = getTouchableSourceWithHighestZIndex(hitTouchableSources);
             if (source != null && source.hasPressListener()) {
-                source.onPress(hits.get(source.getID()));
+                source.onPress(new RCTSource.OnPressEvent(
+                        hits.get(source.getID()),
+                        point,
+                        screenPoint
+                        ));
                 return true;
             }
         }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLImageSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLImageSource.java
@@ -38,7 +38,7 @@ public class RCTMGLImageSource extends RCTSource<ImageSource> {
     }
 
     @Override
-    public void onPress(Feature feature) {
+    public void onPress(OnPressEvent feature) {
         // ignore, we cannot query raster layers
     }
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLRasterSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLRasterSource.java
@@ -39,7 +39,7 @@ public class RCTMGLRasterSource extends RCTMGLTileSource<RasterSource> {
     }
 
     @Override
-    public void onPress(Feature feature) {
+    public void onPress(OnPressEvent feature) {
         // ignore, cannot query raster layers
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
@@ -115,8 +115,8 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
         mTolerance = tolerance;
     }
 
-    public void onPress(Feature feature) {
-        mManager.handleEvent(FeatureClickEvent.makeShapeSourceEvent(this, feature));
+    public void onPress(OnPressEvent event) {
+        mManager.handleEvent(FeatureClickEvent.makeShapeSourceEvent(this, event));
     }
 
     private GeoJsonOptions getOptions() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLVectorSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLVectorSource.java
@@ -27,8 +27,8 @@ public class RCTMGLVectorSource extends RCTMGLTileSource<VectorSource> {
         mManager = manager;
     }
 
-    public void onPress(Feature feature) {
-        mManager.handleEvent(FeatureClickEvent.makeVectorSourceEvent(this, feature));
+    public void onPress(OnPressEvent event) {
+        mManager.handleEvent(FeatureClickEvent.makeVectorSourceEvent(this, event));
     }
 
     @Override

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTSource.java
@@ -2,11 +2,14 @@ package com.mapbox.rctmgl.components.styles.sources;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+
+import android.graphics.PointF;
 import android.view.View;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.mapbox.geojson.Feature;
+import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.sources.Source;
@@ -214,7 +217,20 @@ public abstract class RCTSource<T extends Source> extends AbstractMapFeature {
     }
 
     public abstract T makeSource();
-    public abstract void onPress(Feature feature);
+
+    static public class OnPressEvent {
+        public List<Feature> features;
+        public LatLng latLng;
+        public PointF screenPoint;
+
+        public OnPressEvent(@NonNull List<Feature> features, @NonNull LatLng latLng, @NonNull PointF screenPoint) {
+            this.features = features;
+            this.latLng = latLng;
+            this.screenPoint = screenPoint;
+        }
+    }
+
+    public abstract void onPress(OnPressEvent event);
 
     public static boolean isDefaultSource(String sourceID) {
         return DEFAULT_ID.equals(sourceID);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/FeatureClickEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/FeatureClickEvent.java
@@ -1,12 +1,20 @@
 package com.mapbox.rctmgl.events;
 
+import android.graphics.PointF;
 import android.view.View;
 
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.mapbox.geojson.Feature;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.rctmgl.components.styles.sources.RCTSource;
 import com.mapbox.rctmgl.events.constants.EventKeys;
 import com.mapbox.rctmgl.events.constants.EventTypes;
+import com.mapbox.rctmgl.utils.ConvertUtils;
 import com.mapbox.rctmgl.utils.GeoJSONUtils;
+
+import java.util.List;
 
 /**
  * Created by nickitaliano on 11/7/17.
@@ -14,12 +22,16 @@ import com.mapbox.rctmgl.utils.GeoJSONUtils;
 
 public class FeatureClickEvent extends AbstractEvent {
     private String mEventKey;
-    private Feature mFeature;
+    private List<Feature> mFeatures;
+    private LatLng mLatLng;
+    private PointF mPoint;
 
-    public FeatureClickEvent(View view, String eventKey, String eventType, Feature feature) {
+    public FeatureClickEvent(View view, String eventKey, String eventType, List<Feature> features, LatLng latLng, PointF point) {
         super(view, eventType);
-        mFeature = feature;
+        mFeatures = features;
         mEventKey = eventKey;
+        mLatLng = latLng;
+        mPoint = point;
     }
 
     @Override
@@ -29,21 +41,39 @@ public class FeatureClickEvent extends AbstractEvent {
 
     @Override
     public WritableMap getPayload() {
-        return GeoJSONUtils.fromFeature(mFeature);
+        WritableMap map = Arguments.createMap();
+        WritableArray features = Arguments.createArray();
+
+        for(Feature feature : mFeatures) {
+            features.pushMap(GeoJSONUtils.fromFeature(feature));
+        }
+        map.putArray("features", features);
+
+        WritableMap coordinates = Arguments.createMap();
+        coordinates.putDouble("latitude", mLatLng.getLatitude());
+        coordinates.putDouble("longitude", mLatLng.getLongitude());
+        map.putMap("coordinates", coordinates);
+
+        WritableMap point = Arguments.createMap();
+        point.putDouble("x", mPoint.x);
+        point.putDouble("y", mPoint.y);
+        map.putMap("point", point);
+
+        return map;
     }
 
-    public static FeatureClickEvent makeShapeSourceEvent(View view, Feature feature) {
+    public static FeatureClickEvent makeShapeSourceEvent(View view, RCTSource.OnPressEvent event) {
         return new FeatureClickEvent(view, EventKeys.SHAPE_SOURCE_LAYER_CLICK,
-                EventTypes.SHAPE_SOURCE_LAYER_CLICK, feature);
+                EventTypes.SHAPE_SOURCE_LAYER_CLICK, event.features, event.latLng, event.screenPoint);
     }
 
-    public static FeatureClickEvent makeVectorSourceEvent(View view, Feature feature) {
+    public static FeatureClickEvent makeVectorSourceEvent(View view, RCTSource.OnPressEvent event) {
         return new FeatureClickEvent(view, EventKeys.VECTOR_SOURCE_LAYER_CLICK,
-                EventTypes.VECTOR_SOURCE_LAYER_CLICK, feature);
+                EventTypes.VECTOR_SOURCE_LAYER_CLICK, event.features, event.latLng, event.screenPoint);
     }
 
-    public static FeatureClickEvent makeRasterSourceEvent(View view, Feature feature) {
+    public static FeatureClickEvent makeRasterSourceEvent(View view, RCTSource.OnPressEvent event) {
         return new FeatureClickEvent(view, EventKeys.RASTER_SOURCE_LAYER_CLICK,
-                EventTypes.RASTER_SOURCE_LAYER_CLICK, feature);
+                EventTypes.RASTER_SOURCE_LAYER_CLICK, event.features, event.latLng, event.screenPoint);
     }
 }

--- a/docs/ShapeSource.md
+++ b/docs/ShapeSource.md
@@ -19,4 +19,15 @@
 | &nbsp;&nbsp;width | `number` | `none` | `true` | FIX ME NO DESCRIPTION |
 | &nbsp;&nbsp;height | `number` | `none` | `true` | FIX ME NO DESCRIPTION |
 
+### methods
+#### onPress(event)
+
+
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `event` | `n/a` | `Yes` | undefined |
+
+
 

--- a/docs/VectorSource.md
+++ b/docs/VectorSource.md
@@ -35,4 +35,14 @@ vectorSource.features(['id1', 'id2'])
 ```
 
 
+#### onPress(event)
+
+
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `event` | `n/a` | `Yes` | undefined |
+
+
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3425,7 +3425,20 @@
   "ShapeSource": {
     "description": "ShapeSource is a map content source that supplies vector shapes to be shown on the map.\nThe shape may be a url or a GeoJSON object",
     "displayName": "ShapeSource",
-    "methods": [],
+    "methods": [
+      {
+        "name": "onPress",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "event",
+            "type": null
+          }
+        ],
+        "returns": null
+      }
+    ],
     "props": [
       {
         "name": "id",
@@ -3499,14 +3512,38 @@
         "params": [
           {
             "name": "event",
-            "description": "event with geojson feature as payload",
+            "description": null,
             "type": {
-              "name": "NativeSyntheticEvent",
+              "name": "Object"
+            },
+            "optional": false
+          },
+          {
+            "name": "event.features",
+            "description": "the geojson features that have hit by the press (might be multiple)",
+            "type": {
+              "name": "Array",
               "elements": [
                 {
-                  "name": "GeoJSONFeatureEvent"
+                  "name": "Object"
                 }
               ]
+            },
+            "optional": false
+          },
+          {
+            "name": "event.coordinates",
+            "description": "the coordinates of the click",
+            "type": {
+              "name": "Object"
+            },
+            "optional": false
+          },
+          {
+            "name": "event.point",
+            "description": "the point of the click",
+            "type": {
+              "name": "Object"
             },
             "optional": false
           }
@@ -5079,6 +5116,18 @@
         "examples": [
           "\nvectorSource.features(['id1', 'id2'])\n\n"
         ]
+      },
+      {
+        "name": "onPress",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "event",
+            "type": null
+          }
+        ],
+        "returns": null
       }
     ],
     "props": [
@@ -5141,7 +5190,46 @@
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "Source press listener, gets called when a user presses one of the children layers only\nif that layer has a higher z-index than another source layers"
+        "description": "Source press listener, gets called when a user presses one of the children layers only\nif that layer has a higher z-index than another source layers",
+        "params": [
+          {
+            "name": "event",
+            "description": null,
+            "type": {
+              "name": "Object"
+            },
+            "optional": false
+          },
+          {
+            "name": "event.features",
+            "description": "the geojson features that have hit by the press (might be multiple)",
+            "type": {
+              "name": "Array",
+              "elements": [
+                {
+                  "name": "Object"
+                }
+              ]
+            },
+            "optional": false
+          },
+          {
+            "name": "event.coordinates",
+            "description": "the coordinates of the click",
+            "type": {
+              "name": "Object"
+            },
+            "optional": false
+          },
+          {
+            "name": "event.point",
+            "description": "the point of the click",
+            "type": {
+              "name": "Object"
+            },
+            "optional": false
+          }
+        ]
       },
       {
         "name": "hitbox",

--- a/example/src/examples/CustomIcon.js
+++ b/example/src/examples/CustomIcon.js
@@ -45,9 +45,13 @@ class CustomIcon extends React.Component {
     });
   }
 
-  onSourceLayerPress(e) {
-    const feature = e.nativeEvent.payload;
-    console.log('You pressed a layer here is your feature', feature); // eslint-disable-line
+  onSourceLayerPress({features, coordinates, point}) {
+    console.log(
+      'You pressed a layer here are your features:',
+      features,
+      coordinates,
+      point,
+    );
   }
 
   render() {

--- a/example/src/examples/CustomVectorSource.js
+++ b/example/src/examples/CustomVectorSource.js
@@ -58,6 +58,12 @@ class CustomVectorSource extends React.PureComponent {
             url={VECTOR_SOURCE_URL}
             ref={source => {
               this._vectorSource = source;
+            }}
+            onPress={(e) => {
+              console.log(
+                `VectorSource onPress: ${e.features}`,
+                e.features,
+              );
             }}>
             <MapboxGL.FillLayer
               id="customSourceFill"

--- a/javascript/utils/deprecation.js
+++ b/javascript/utils/deprecation.js
@@ -1,0 +1,25 @@
+/**
+ * Copy properties from origObject to newObject, which not exists in newObject, 
+ * calls onDeprecatedCalled callback in case a copied property is invoked.
+ */
+// eslint-disable-next-line class-methods-use-this
+export function copyPropertiesAsDeprecated(
+  origObject,
+  newObject,
+  onDeprecatedCalled,
+  accessors = {},
+) {
+  const result = newObject;
+  for (const [key, value] of Object.entries(origObject)) {
+    if (!newObject[key]) {
+      // eslint-disable-next-line fp/no-mutating-methods
+      Object.defineProperty(result, key, {
+        get() {
+          onDeprecatedCalled(key);
+          return accessors[key] ? accessors[key](value) : value;
+        },
+      });
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Currently in ShapeSource/VectorSource onPress returns a single feature, we also cannot get location of press.
```es6
onPress(e) {
    const feature = e.nativeEvent.payload;
    ...
}
```

With the new version the above works, but deprecated, and you can now access all the features that were at the point of click via: `features`  (the old `payload` only contained the first feature) There is also additional coordinates and point describing the location of the press
```es6
onPress({features, coordinates, point}) {
    ...
}
```



Fixes: #611 