### PR TITLE
Allow to be consumed without use_frameworks!

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -34,13 +34,14 @@ target 'RNMapboxGLExample' do
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
   pod 'react-native-mapbox-gl', :path => '../node_modules/@react-native-mapbox-gl/maps'
 
-
   target 'RNMapboxGLExampleTests' do
     inherit! :search_paths
     # Pods for testing
   end
 
-  use_frameworks!
+  pod 'NoUseFrameworks-MapboxMobileEvents',  :podspec => '../node_modules/@react-native-mapbox-gl/maps/ios/NoUseFrameworks-MapboxMobileEvents/NoUseFrameworks-MapboxMobileEvents.podspec.json'
+  # use_frameworks!
+
   use_native_modules!
 end
 

--- a/ios/NoUseFrameworks-MapboxMobileEvents/NoUseFrameworks-MapboxMobileEvents.podspec.json
+++ b/ios/NoUseFrameworks-MapboxMobileEvents/NoUseFrameworks-MapboxMobileEvents.podspec.json
@@ -1,0 +1,27 @@
+{
+  "name": "NoUseFrameworks-MapboxMobileEvents",
+  "version": "0.10.2",
+  "summary": "Mapbox Mobile Events",
+  "description": "This is a workaround that allows consumption of Mapbox-iOS-SDK without use_frameworks!. Mapbox Mobile Events collects usage information to help Mapbox improve its products.",
+  "homepage": "https://github.com/react-native-mapbox-gl/maps/pull/714",
+  "license": {
+    "type": "ISC",
+    "file": "LICENSE.md"
+  },
+  "authors": {
+    "Mapbox": "mobile@mapbox.com"
+  },
+  "screenshots": "https://docs.mapbox.com/ios/api/maps/5.7.0/img/screenshot.png",
+  "social_media_url": "https://twitter.com/mapbox",
+  "source": {
+    "http": "https://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-ios-sdk-5.7.0-dynamic-with-events.zip",
+    "flatten": true
+  },
+  "platforms": {
+    "ios": "9.0"
+  },
+  "requires_arc": true,
+  "vendored_frameworks":  "dynamic/MapboxMobileEvents.framework",
+  "module_name": "MapboxMobileEvents",
+  "preserve_paths": "**/*.bcsymbolmap"
+}


### PR DESCRIPTION
This is a possible workaround for `use_frameworks!`

If you don't want `use_frameworks!` in your podfile use the `pod 'NoUseFrameworks-MapboxMobileEvents' ...` line bellow:

```ruby
    pod 'NoUseFrameworks-MapboxMobileEvents',  :podspec => '../node_modules/@react-native-mapbox-gl/maps/ios/NoUseFrameworks-MapboxMobileEvents/NoUseFrameworks-MapboxMobileEvents.podspec.json'
  # use_frameworks!
```

Note: you can test this PR with this in your packages.json

"@react-native-mapbox-gl/maps": "mfazekas/maps-1#allow-no-use-frameworks"

See https://github.com/mapbox/mapbox-gl-native-ios/issues/154