### PR TITLE
refactor(location-manager): #start, #pause, #dispose

### DIFF
--- a/__tests__/components/UserLocation.test.js
+++ b/__tests__/components/UserLocation.test.js
@@ -143,7 +143,7 @@ describe('UserLocation', () => {
     beforeEach(() => {
       ul = new UserLocation();
       jest.spyOn(locationManager, 'start').mockImplementation(jest.fn());
-      jest.spyOn(locationManager, 'dispose').mockImplementation(jest.fn());
+      jest.spyOn(locationManager, 'stop').mockImplementation(jest.fn());
       jest
         .spyOn(locationManager, 'getLastKnownLocation')
         .mockImplementation(() => position);
@@ -187,7 +187,7 @@ describe('UserLocation', () => {
         expect(ul.setState).toHaveBeenCalledWith({
           coordinates: lastKnownLocation,
         });
-        expect(locationManager.dispose).not.toHaveBeenCalled();
+        expect(locationManager.stop).not.toHaveBeenCalled();
       });
 
       test('called with "running" false', async () => {
@@ -202,7 +202,7 @@ describe('UserLocation', () => {
         expect(ul.locationManagerRunning).toStrictEqual(false);
         // only once from start
         expect(locationManager.start).toHaveBeenCalledTimes(1);
-        expect(locationManager.dispose).toHaveBeenCalledTimes(1);
+        expect(locationManager.stop).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/example/src/examples/SetDisplacement.js
+++ b/example/src/examples/SetDisplacement.js
@@ -21,7 +21,7 @@ class SetDisplacement extends React.Component {
   }
 
   componentWillUnmount() {
-    MapboxGL.locationManager.dispose();
+    MapboxGL.locationManager.stop();
   }
 
   onDisplacementChange = index => {

--- a/example/src/examples/SetHeading.js
+++ b/example/src/examples/SetHeading.js
@@ -34,7 +34,7 @@ class SetHeading extends React.Component {
   }
 
   componentWillUnmount() {
-    MapboxGL.locationManager.dispose();
+    MapboxGL.locationManager.stop();
   }
 
   onHeadingChange(index, heading) {

--- a/example/src/examples/SetPitch.js
+++ b/example/src/examples/SetPitch.js
@@ -34,7 +34,7 @@ class SetPitch extends React.Component {
   }
 
   componentWillUnmount() {
-    MapboxGL.locationManager.dispose();
+    MapboxGL.locationManager.stop();
   }
 
   onUpdatePitch(index, pitch) {

--- a/example/src/examples/ShowMap.js
+++ b/example/src/examples/ShowMap.js
@@ -38,7 +38,7 @@ class ShowMap extends React.Component {
   }
 
   componentWillUnmount() {
-    MapboxGL.locationManager.dispose();
+    MapboxGL.locationManager.stop();
   }
 
   onMapChange(index, styleURL) {

--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -164,7 +164,7 @@ class UserLocation extends React.Component {
           });
         }
       } else if (!running) {
-        locationManager.dispose();
+        locationManager.stop();
       }
     }
   };

--- a/javascript/modules/location/locationManager.js
+++ b/javascript/modules/location/locationManager.js
@@ -12,7 +12,6 @@ class LocationManager {
     this._listeners = [];
     this._lastKnownLocation = null;
     this._isListening = false;
-    this._isPaused = false;
     this.onUpdate = this.onUpdate.bind(this);
   }
 
@@ -45,12 +44,6 @@ class LocationManager {
   }
 
   start(displacement = 0) {
-    if (this._isPaused) {
-      MapboxGLLocationManager.start(displacement);
-      this._isPaused = false;
-      return;
-    }
-
     if (!this._isListening) {
       MapboxGLLocationManager.start(displacement);
 
@@ -63,14 +56,7 @@ class LocationManager {
     }
   }
 
-  pause() {
-    if (!this._isPaused && this._isListening) {
-      MapboxGLLocationManager.pause();
-      this._isListening = false;
-    }
-  }
-
-  dispose() {
+  stop() {
     MapboxGLLocationManager.stop();
 
     if (this._isListening) {


### PR DESCRIPTION
Replaced confusing set of three methods with just two
.start - starts locationManager service
.stop - stops locationManager service

.stop internally calls `dispose`, however stop is more sementic in our
usecases

remove .pause