### PR TITLE
RFC: AnimatedRouteCoordinatesArray and AnimatedExtractCoordinateFromArray

### DIFF
--- a/__tests__/interface.test.js
+++ b/__tests__/interface.test.js
@@ -82,6 +82,8 @@ describe('Public Interface', () => {
       'AnimatedPoint',
       'AnimatedCoordinatesArray',
       'AnimatedShape',
+      'AnimatedExtractCoordinateFromArray',
+      'AnimatedRouteCoordinatesArray',
     ];
     actualKeys.forEach(key => expect(expectedKeys).toContain(key));
   });

--- a/__tests__/utils/animated/AnimatedCoordinatesArray.test.js
+++ b/__tests__/utils/animated/AnimatedCoordinatesArray.test.js
@@ -75,7 +75,10 @@ describe('AnimatedShapeSource', () => {
 
   test('testAddingCoords', () => {
     AnimatedShapeSource.__skipSetNativeProps_FOR_TESTS_ONLY = false;
-    const coordinates = new AnimatedCoordinatesArray([[1, 1], [10, 10]]);
+    const coordinates = new AnimatedCoordinatesArray([
+      [1, 1],
+      [10, 10],
+    ]);
 
     let shapeSourceRef;
     // eslint-disable-next-line no-unused-vars
@@ -90,7 +93,11 @@ describe('AnimatedShapeSource', () => {
 
     coordinates
       .timing({
-        toValue: [[21, 21], [30, 30], [50, 50]],
+        toValue: [
+          [21, 21],
+          [30, 30],
+          [50, 50],
+        ],
         duration: 20,
         easing: Easing.linear,
         useNativeDriver: false,
@@ -109,7 +116,7 @@ describe('AnimatedShapeSource', () => {
           coordinates: [
             [1 + (i + 1) * 4, 1 + (i + 1) * 4],
             [10 + (i + 1) * 4, 10 + (i + 1) * 4],
-            [10 + (i + 1) * 8, 10 + (i + 1) * 8]
+            [10 + (i + 1) * 8, 10 + (i + 1) * 8],
           ],
         }),
       });

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -32,6 +32,8 @@ import MarkerView from './components/MarkerView';
 import AnimatedMapPoint from './utils/animated/AnimatedPoint';
 import AnimatedShape from './utils/animated/AnimatedShape';
 import AnimatedCoordinatesArray from './utils/animated/AnimatedCoordinatesArray';
+import AnimatedExtractCoordinateFromArray from './utils/animated/AnimatedExtractCoordinateFromArray';
+import AnimatedRouteCoordinatesArray from './utils/animated/AnimatedRouteCoordinatesArray';
 
 const MapboxGL = {...NativeModules.MGLModule};
 
@@ -99,6 +101,8 @@ MapboxGL.snapshotManager = snapshotManager;
 // utils
 MapboxGL.AnimatedPoint = AnimatedMapPoint;
 MapboxGL.AnimatedCoordinatesArray = AnimatedCoordinatesArray;
+MapboxGL.AnimatedExtractCoordinateFromArray = AnimatedExtractCoordinateFromArray;
+MapboxGL.AnimatedRouteCoordinatesArray = AnimatedRouteCoordinatesArray;
 MapboxGL.AnimatedShape = AnimatedShape;
 
 // animated
@@ -118,7 +122,9 @@ const Animated = {
 
   // values
   CoordinatesArray: AnimatedCoordinatesArray,
+  RouteCoordinatesArray: AnimatedRouteCoordinatesArray,
   Shape: AnimatedShape,
+  ExtractCoordinateFromArray : AnimatedExtractCoordinateFromArray, 
 };
 
 MapboxGL.Animated = Animated;

--- a/javascript/utils/animated/AnimatedCoordinatesArray.js
+++ b/javascript/utils/animated/AnimatedCoordinatesArray.js
@@ -14,106 +14,119 @@ if (__DEV__) {
 }
 
 class AnimatedCoordinatesArray extends AnimatedWithChildren {
-  constructor(coordinatesArray) {
+  constructor(...args) {
     super();
 
-    this.coordinatesArray = coordinatesArray.map(coord => [...coord]);
-
-    // progressValue is a 0->1 value describing the animation
-    this.progressValue = new Animated.Value(0.0);
-    this.progressValue.__addChild(this);
+    this.state = this.onInitialState(...args);
   }
 
   /**
-   * @typedef {Object} CoordinatesAnimator
+   * Subclasses can override to calculate initial state
    *
-   * @property {function} calculate - Calculate new coordinates based on progres: a nubmer
-   *   between 0-1 specifying where the animation is, and origCoords the starting coordinates.
+   * @param {*} args - to value from animate
+   * @returns {object} - the state object
    */
-
+  onInitialState(coordinatesArray) {
+    return {coords: coordinatesArray.map(coord => [coord[0], coord[1]])};
+  }
 
   /**
-   * Subclasses can override to implement different animations.
+   * Subclasses can override getValue to calculate value from state.
+   * Value is typically coordinates array, but can be anything
+   *
+   * @param {object} state - either state from initialState and/or from calculate
+   * @returns {object}
+   */
+  onGetValue(state) {
+    return state.coords;
+  }
+
+  /**
+   * Calculates state based on startingState and progress, returns a new state
+   *
+   * @param {object} state - state object from initialState and/or from calculate
+   * @param {number} progress - value between 0 and 1
+   * @returns {object} next state
+   */
+  onCalculate(state, progress) {
+    const {coords, targetCoords} = state;
+    const newF = progress;
+    const origF = 1.0 - newF;
+    
+
+    // common
+    const commonLen = Math.min(coords.length, targetCoords.length);
+    const common = coords
+      .slice(0, commonLen)
+      .map((origCoord, i) => [
+        origCoord[0] * origF + targetCoords[i][0] * newF,
+        origCoord[1] * origF + targetCoords[i][1] * newF,
+      ]);
+
+    if (targetCoords.length > coords.length) {
+      // only in new (adding)
+      const addingOrig =
+        coords.length > 0 ? coords[coords.length - 1] : targetCoords[0];
+      const adding = targetCoords
+        .slice(commonLen, targetCoords.length)
+        .map(newCoord => [
+          addingOrig[0] * origF + newCoord[0] * newF,
+          addingOrig[1] * origF + newCoord[1] * newF,
+        ]);
+      return {coords: [...common, ...adding], targetCoords};
+    }
+
+    if (coords.length > targetCoords.length) {
+      // only in orig (dissapearing)
+      const dissapearingNew =
+        targetCoords.length > 0
+          ? targetCoords[targetCoords.length - 1]
+          : coords[0];
+      const dissapearing = coords
+        .slice(commonLen, coords.length)
+        .map(origCoord => [
+          origCoord[0] * origF + dissapearingNew[0] * newF,
+          origCoord[1] * origF + dissapearingNew[1] * newF,
+        ]);
+      return {coords: [...common, ...dissapearing], targetCoords};
+    }
+
+    return {coords: common, targetCoords};
+  }
+
+  /**
+   * Subclasses can override to start a new animation
    *
    * @param {*} toValue - to value from animate
    * @param {*} actCoords - the current coordinates array to start from
-   * @returns {CoordinatesAnimator}
+   * @returns {object} The state
    */
-  createCoordinatesAnimator(toValue, actCoords) {
-    const newCoords = toValue.map(coord => [...coord]);
+  onStart(state, toValue) {
+    const targetCoords = toValue.map(coord => [coord[0], coord[1]]);
     return {
-      coords: newCoords,
-      calculate(progress, origCoords) {
-        const newF = progress;
-        const origF = 1.0 - newF;
-        const nextCoords = this.coords;
-
-        // common
-        const commonLen = Math.min(origCoords.length, newCoords.length);
-        const common = origCoords
-          .slice(0, commonLen)
-          .map((origCoord, i) => [
-            origCoord[0] * origF + newCoords[i][0] * newF,
-            origCoord[1] * origF + newCoords[i][1] * newF,
-          ]);
-
-        if (nextCoords.length > origCoords.length) {
-          // only in new (adding)
-          const addingOrig =
-            origCoords.length > 0
-              ? origCoords[origCoords.length - 1]
-              : nextCoords[0];
-          const adding = nextCoords
-            .slice(commonLen, nextCoords.length)
-            .map(newCoord => [
-              addingOrig[0] * origF + newCoord[0] * newF,
-              addingOrig[1] * origF + newCoord[1] * newF,
-            ]);
-          return [...common, ...adding];
-        }
-
-        if (origCoords.length > nextCoords.length) {
-          // only in orig (dissapearing)
-          const dissapearingNew =
-            nextCoords.length > 0
-              ? nextCoords[nextCoords.length - 1]
-              : origCoords[0];
-          const dissapearing = origCoords
-            .slice(commonLen, origCoords.length)
-            .map(origCoord => [
-              origCoord[0] * origF + dissapearingNew[0] * newF,
-              origCoord[1] * origF + dissapearingNew[1] * newF,
-            ]);
-          return [...common, ...dissapearing];
-        }
-
-        return common;
-      },
+      ...state,
+      targetCoords,
     };
   }
 
-  animate(progressAnimation, config) {
+  animate(progressValue, progressAnimation, config) {
     const {toValue} = config;
 
     const onAnimationStart = animation => {
-      if (this.coordAnimator) {
+      if (this.animation) {
         // there was a started but not finsihed animation
         const actProgress = this.progressValue.__getValue();
         this.animation.stop();
-        this.progressValue.setValue(0.0);
-        this.coordinatesArray = this.coordAnimator.calculate(
-          actProgress,
-          this.coordinatesArray,
-        );
-        this.coordAnimator = null;
+        this.state = this.onCalculate(this.state, actProgress);
+        this.progressValue.__removeChild(this);
+        this.progressValue = null;
         this.animation = null;
       }
 
+      this.progressValue = progressValue;
+      this.progressValue.__addChild(this);
       this.animation = animation;
-      this.coordAnimator = this.createCoordinatesAnimator(
-        toValue,
-        this.coordinatesArray,
-      );
+      this.state = this.onStart(this.state, toValue);
     };
 
     const origAnimationStart = progressAnimation.start;
@@ -121,38 +134,43 @@ class AnimatedCoordinatesArray extends AnimatedWithChildren {
     newAnimation.start = function start(...args) {
       onAnimationStart(progressAnimation);
       origAnimationStart(...args);
-    }
+    };
     return newAnimation;
   }
 
   timing(config) {
+    const progressValue = new Animated.Value(0.0);
     return this.animate(
-      Animated.timing(this.progressValue, {...config, toValue: 1.0}),
+      progressValue,
+      Animated.timing(progressValue, {...config, toValue: 1.0}),
       config,
     );
   }
 
   spring(config) {
+    const progressValue = new Animated.Value(0.0);
     return this.animate(
-      Animated.spring(this.progressValue, {...config, toValue: 1.0}),
+      progressValue,
+      Animated.spring(progressValue, {...config, toValue: 1.0}),
       config,
     );
   }
 
   decay(config) {
+    const progressValue = new Animated.Value(0.0);
     return this.animate(
+      progressValue,
       Animated.decay(this.progressValue, {...config, toValue: 1.0}),
       config,
     );
   }
 
   __getValue() {
-    if (!this.coordAnimator) {
-      return this.coordinatesArray.map(coord => [coord[0], coord[1]]);
+    if (!this.progressValue) {
+      return this.onGetValue(this.state);
     }
-    return this.coordAnimator.calculate(
-      this.progressValue.__getValue(),
-      this.coordinatesArray,
+    return this.onGetValue(
+      this.onCalculate(this.state, this.progressValue.__getValue()),
     );
   }
 }

--- a/javascript/utils/animated/AnimatedExtractCoordinateFromArray.js
+++ b/javascript/utils/animated/AnimatedExtractCoordinateFromArray.js
@@ -1,0 +1,43 @@
+import {Animated} from 'react-native';
+
+// see
+// https://github.com/facebook/react-native/blob/master/Libraries/Animated/src/nodes/AnimatedWithChildren.js
+const AnimatedWithChildren = Object.getPrototypeOf(Animated.ValueXY);
+if (__DEV__) {
+  if (AnimatedWithChildren.name !== 'AnimatedWithChildren') {
+    console.error(
+      'AnimatedCoordinatesArray could not obtain AnimatedWithChildren base class',
+    );
+  }
+}
+
+export default class AnimatedExtractCoordinateFromArray extends AnimatedWithChildren {
+  _array = null;
+
+  _index = 0;
+
+  constructor(array, index) {
+    super();
+    this._array = array;
+    this._index = index;
+  }
+
+  __getValue() {
+    const actArray = this._array.__getValue();
+    let index = this._index;
+
+    if (index < 0) {
+      index += actArray.length;
+    }
+    return actArray[index];
+  }
+
+  __attach() {
+    this._array.__addChild(this);
+  }
+
+  __detach() {
+    this._array.__removeChild(this);
+    super.__detach();
+  }
+}

--- a/javascript/utils/animated/AnimatedRouteCoordinatesArray.js
+++ b/javascript/utils/animated/AnimatedRouteCoordinatesArray.js
@@ -1,0 +1,122 @@
+import {lineString, point, convertDistance as convertDistanceFn, convertLength as convertLengthFn} from '@turf/helpers';
+import distance from '@turf/distance';
+import nearestPointOnLine from '@turf/nearest-point-on-line';
+import length from '@turf/length';
+
+import AnimatedCoordinatesArray from './AnimatedCoordinatesArray';
+
+const convertLength = convertLengthFn || convertDistanceFn;
+
+export default class AnimatedRouteCoordinatesArray extends AnimatedCoordinatesArray {
+
+  /**
+   * Calculate initial state
+   *
+   * @param {*} args - to value from animate
+   * @returns {object} - the state object
+   */
+  onInitialState(coordinatesArray) {
+    return { fullRoute: coordinatesArray.map(coord => [coord[0], coord[1]]), end: { from: 0 } };
+  }
+
+  /**
+   * Calculate value from state.
+   *  
+   * @param {object} state - either state from initialState and/or from calculate 
+   * @returns {object}  
+   */
+  onGetValue(state) {
+    return state.actRoute || state.fullRoute;
+  }
+
+  /**
+   * Calculates state based on startingState and progress, returns a new state
+   * 
+   * @param {object} state - state object from initialState and/or from calculate
+   * @param {number} progress - value between 0 and 1
+   * @returns {object} next state
+   */
+  onCalculate(state, progress) {
+    const {fullRoute, end} = state;
+    const currentEnd = end.from * (1.0 - progress) + progress * end.to;
+
+    let prevsum = 0;
+    let actsum = 0;
+    let i = fullRoute.length - 1;
+    while (actsum < currentEnd && i > 0) {
+      prevsum = actsum;
+      actsum += distance(
+        point(fullRoute[i]),
+        point(fullRoute[i - 1]),
+        this.distconf,
+      );
+      i -= 1;
+    }
+    if (actsum <= currentEnd) {
+      let actRoute = [...fullRoute.slice(0, i + 1)];
+      return {fullRoute, end: {...end, current: currentEnd}, actRoute};
+    }
+    const r = (currentEnd - prevsum) / (actsum - prevsum);
+    const or = 1.0 - r;
+
+    let actRoute = [
+      ...fullRoute.slice(0, i + 1),
+      [
+        fullRoute[i][0] * r + fullRoute[i + 1][0] * or,
+        fullRoute[i][1] * r + fullRoute[i + 1][1] * or,
+      ],
+    ];
+    return {fullRoute, end: {...end, current: currentEnd}, actRoute};
+  }
+
+  /**
+   * Subclasses can override to start a new animation
+   *
+   * @param {*} toValue - to value from animate
+   * @param {*} actCoords - the current coordinates array to start from
+   * @returns {object} The state
+   */
+  onStart(state, toValue) {
+    const {fullRoute, end} = state;
+    let toDist;
+    if (! toValue.end) {
+      console.error("RouteCoordinatesArray: toValue should have end with either along or point");
+    }
+    if (toValue.end.along != null) {
+      let {units} = toValue;
+      const ls = lineString(fullRoute);
+      toDist = convertLength(toValue.end.along, units);
+      toDist = length(ls) - toDist;
+    }
+    if (toDist != null) {
+      if (toValue.end.point) {
+        console.warn(
+          'RouteCoordinatesArray: toValue.end: has both along and point, point is ignored',
+        );
+      }
+    } else if (toValue.end.point) {
+      const ls = lineString(fullRoute);
+
+      const nearest = nearestPointOnLine(ls, toValue.end.point);
+      toDist = length(ls) - nearest.properties.location;
+    } else {
+      console.warn(
+        'RouteCoordinatesArray: toValue.end: should have either along or point',
+      );
+    }
+
+    let result = {
+      fullRoute,
+      end: {
+        ...end,
+        from: (end.current != null) ? end.current : end.from,
+        to: toDist,
+      }
+    };
+    return result;
+  }
+
+  get originalRoute() {
+    return this.state.fullRoute;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "@mapbox/geo-viewport": ">= 0.4.0",
     "@turf/along": ">= 4.0.0 <7.0.0",
     "@turf/distance": ">= 4.0.0 <7.0.0",
+    "@turf/nearest-point-on-line": ">= 4.0.0 <7.0.0",
     "@turf/helpers": ">= 4.6.0 <7.0.0",
+    "@turf/length": ">= 4.6.0 <7.0.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The question is if we want those to be part of the library.
I see those options:
- add those to the library as in this PR
- add those to a separate library like `@react-native-mapbox/maps-animations`
- add those as examples as they are simple

Added 2 new animated classes:
* AnimatedRouteCoordinatesArray - like animated coordinates array but instead of morphing points its animates the array as a route, eating the end of route.
* AnimatedExtractCoordinateFromArray - allows to extract a single point from an array usefull for showing the current point of the screen

![animated_route_point](https://user-images.githubusercontent.com/52435/76657260-b922d900-6571-11ea-8469-128c82ee34d8.gif)


```es6
route = new Animated.RouteCoordinatesArray([
      ....
    ]);

point = new Animated.ExtractCoordinateFromArray(route, -1);
   ...
this.route
      .timing({
        toValue: {end: {point: currentLocation}},
        duration: 2000,
        easing: Easing.linear,
      })
      .start();

...


<Animated.ShapeSource
            id={'route'}
            shape={
              new Animated.Shape({
                type: 'LineString',
                coordinates: route,
              })
            }>
            <Animated.LineLayer
              id={'lineroute'}
            />
          </Animated.ShapeSource>
          <Animated.ShapeSource
            id="currentLocation"
            shape={
              new Animated.Shape({
                type: 'Point',
                coordinates: point,
              })
            }>
            <Animated.CircleLayer
              id="currentLocationCircle"
            />
          </Animated.ShapeSource>
```
