### PR TITLE
Fix types for styleURL

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -748,7 +748,7 @@ export interface ImageSourceProps extends ViewProps {
 
 export interface OfflineCreatePackOptions {
   name?: string;
-  styleURL?: MapboxGL.StyleURL;
+  styleURL?: string;
   bounds?: [GeoJSON.Position, GeoJSON.Position];
   minZoom?: number;
   maxZoom?: number;
@@ -762,7 +762,7 @@ export interface SnapshotOptions {
   zoomLevel?: number;
   pitch?: number;
   heading?: number;
-  styleURL?: MapboxGL.StyleURL;
+  styleURL?: string;
   writeToDisk?: boolean;
 }
 


### PR DESCRIPTION
This is just a simple change to offline manager types that I ran into an issue with in our project.

Commits:
* Change offline pack `styleURL` type to `string`, as is the case with `MapViewProps`
This is for consistency, and to avoid type errors.