### PR TITLE
[iOS] fix camera with stops and add type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -398,6 +398,23 @@ export interface CameraProps extends CameraSettings, ViewProps {
   ) => void;
 }
 
+export interface CameraStopSettings {
+  centerCoordinate?: GeoJSON.Position;
+  heading?: number;
+  pitch?: number;
+  bounds?: {
+    ne: GeoJSON.Position;
+    sw: GeoJSON.Position;
+    paddingLeft?: number;
+    paddingRight?: number;
+    paddingTop?: number;
+    paddingBottom?: number;
+  };
+  zoomLevel?: number;
+  animationDuration?: number;
+  animationMode?: 'flyTo' | 'easeTo' | 'moveTo';
+}
+
 export interface CameraSettings {
   centerCoordinate?: GeoJSON.Position;
   heading?: number;
@@ -412,6 +429,7 @@ export interface CameraSettings {
   };
   zoomLevel?: number;
   animationDuration?: number;
+  stops?: CameraStopSettings[];
 }
 
 export interface UserLocationProps {

--- a/index.d.ts
+++ b/index.d.ts
@@ -398,23 +398,6 @@ export interface CameraProps extends CameraSettings, ViewProps {
   ) => void;
 }
 
-export interface CameraStopSettings {
-  centerCoordinate?: GeoJSON.Position;
-  heading?: number;
-  pitch?: number;
-  bounds?: {
-    ne: GeoJSON.Position;
-    sw: GeoJSON.Position;
-    paddingLeft?: number;
-    paddingRight?: number;
-    paddingTop?: number;
-    paddingBottom?: number;
-  };
-  zoomLevel?: number;
-  animationDuration?: number;
-  animationMode?: 'flyTo' | 'easeTo' | 'moveTo';
-}
-
 export interface CameraSettings {
   centerCoordinate?: GeoJSON.Position;
   heading?: number;
@@ -429,7 +412,8 @@ export interface CameraSettings {
   };
   zoomLevel?: number;
   animationDuration?: number;
-  stops?: CameraStopSettings[];
+  animationMode?: 'flyTo' | 'easeTo' | 'moveTo';
+  stops?: CameraSettings[];
 }
 
 export interface UserLocationProps {

--- a/ios/RCTMGL/RCTMGLCamera.m
+++ b/ios/RCTMGL/RCTMGLCamera.m
@@ -120,8 +120,14 @@
     if (_map != nil && _map.userTrackingMode != MGLUserTrackingModeNone) {
         _map.userTrackingMode = MGLUserTrackingModeNone;
     }
-    
-    [cameraUpdateQueue enqueue:[CameraStop fromDictionary:_stop]];
+    if (_stop[@"stops"]) {
+        NSArray* stops = _stop[@"stops"];
+        for (NSDictionary* stop in stops) {
+            [cameraUpdateQueue enqueue:[CameraStop fromDictionary:stop]];
+        }
+    } else {
+        [cameraUpdateQueue enqueue:[CameraStop fromDictionary:_stop]];
+    }
     [cameraUpdateQueue execute:_map];
 }
 


### PR DESCRIPTION
I am working on iOS and found out that camera not working when passing `stops`.
```
this.camera.setCamera({
  stops: [
    { pitch: 45, animationDuration: 200 },
    { heading: 180, animationDuration: 300 },
  ]
})
```
So, this PR just fix the issue on iOS only. I will check Android later when start working on it.