### PR TITLE
fix(callout): make title property required

### DIFF
--- a/docs/Callout.md
+++ b/docs/Callout.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| title | `string` | `none` | `false` | String that get's displayed in the default callout. |
+| title | `string` | `none` | `true` | String that get's displayed in the default callout. |
 | style | `any` | `none` | `false` | Style property for the Animated.View wrapper, apply animations to this |
 | containerStyle | `any` | `none` | `false` | Style property for the native RCTMGLCallout container, set at your own risk. |
 | contentStyle | `any` | `none` | `false` | Style property for the content bubble. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -159,7 +159,7 @@
     "props": [
       {
         "name": "title",
-        "required": false,
+        "required": true,
         "type": "string",
         "default": "none",
         "description": "String that get's displayed in the default callout."

--- a/index.d.ts
+++ b/index.d.ts
@@ -652,7 +652,7 @@ export interface PointAnnotationProps {
 }
 
 export interface CalloutProps extends Omit<ViewProps, 'style'> {
-  title?: string;
+  title: string;
   style?: StyleProp<WithExpression<ViewStyle>>;
   containerStyle?: StyleProp<WithExpression<ViewStyle>>;
   contentStyle?: StyleProp<WithExpression<ViewStyle>>;

--- a/javascript/components/Callout.js
+++ b/javascript/components/Callout.js
@@ -58,7 +58,7 @@ class Callout extends React.PureComponent {
     /**
      * String that get's displayed in the default callout.
      */
-    title: PropTypes.string,
+    title: PropTypes.string.isRequired,
 
     /**
      * Style property for the Animated.View wrapper, apply animations to this


### PR DESCRIPTION
Follow-up PR to #755 
The `Callout` component's purpose is to show a textual hint, which is passed as property titel. Therefore it should be mandatory.
