### PR TITLE
test(circle-layer): add basic tests

### DIFF
--- a/__tests__/components/CircleLayer.test.js
+++ b/__tests__/components/CircleLayer.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import {render} from 'react-native-testing-library';
+
+import CircleLayer from '../../javascript/components/CircleLayer';
+
+describe('Callout', () => {
+  test('renders correctly with default props', () => {
+    const {queryByTestId} = render(<CircleLayer />);
+    const circleLayer = queryByTestId('rctmglCircleLayer');
+    const {props} = circleLayer;
+
+    expect(props.sourceID).toStrictEqual('DefaultSourceID');
+  });
+
+  test('renders correctly with custom props', () => {
+    const customProps = {
+      id: 'customId',
+      sourceID: 'customSourceId',
+      sourceLayerID: 'customSourceLayerId',
+      aboveLayerID: 'customAboveLayerId',
+      belowLayerID: 'customBelowLayerId',
+      layerIndex: 0,
+      filter: ['==', 'arbitraryFilter', true],
+      minZoomLevel: 3,
+      maxZoomLevel: 8,
+      style: {visibility: 'none'},
+    };
+
+    const {queryByTestId} = render(<CircleLayer {...customProps} />);
+    const circleLayer = queryByTestId('rctmglCircleLayer');
+    const {props} = circleLayer;
+
+    expect(props.id).toStrictEqual(customProps.id);
+    expect(props.sourceID).toStrictEqual(customProps.sourceID);
+    expect(props.sourceLayerID).toStrictEqual(customProps.sourceLayerID);
+    expect(props.aboveLayerID).toStrictEqual(customProps.aboveLayerID);
+    expect(props.belowLayerID).toStrictEqual(customProps.belowLayerID);
+    expect(props.layerIndex).toStrictEqual(customProps.layerIndex);
+    expect(props.filter).toStrictEqual(customProps.filter);
+    expect(props.minZoomLevel).toStrictEqual(customProps.minZoomLevel);
+    expect(props.maxZoomLevel).toStrictEqual(customProps.maxZoomLevel);
+    expect(props.reactStyle).toStrictEqual({
+      visibility: {
+        styletype: 'constant',
+        stylevalue: {type: 'string', value: customProps.style.visibility},
+      },
+    });
+  });
+});

--- a/__tests__/components/CircleLayer.test.js
+++ b/__tests__/components/CircleLayer.test.js
@@ -3,7 +3,7 @@ import {render} from 'react-native-testing-library';
 
 import CircleLayer from '../../javascript/components/CircleLayer';
 
-describe('Callout', () => {
+describe('CircleLayer', () => {
   test('renders correctly with default props', () => {
     const {queryByTestId} = render(<CircleLayer />);
     const circleLayer = queryByTestId('rctmglCircleLayer');

--- a/javascript/components/CircleLayer.js
+++ b/javascript/components/CircleLayer.js
@@ -79,15 +79,11 @@ class CircleLayer extends AbstractLayer {
   };
 
   render() {
-    const props = {
-      ...this.baseProps,
-      sourceLayerID: this.props.sourceLayerID,
-    };
     return (
       <RCTMGLCircleLayer
         testID="rctmglCircleLayer"
         ref="nativeLayer"
-        {...props}
+        {...this.baseProps}
       />
     );
   }

--- a/javascript/components/CircleLayer.js
+++ b/javascript/components/CircleLayer.js
@@ -83,7 +83,13 @@ class CircleLayer extends AbstractLayer {
       ...this.baseProps,
       sourceLayerID: this.props.sourceLayerID,
     };
-    return <RCTMGLCircleLayer ref="nativeLayer" {...props} />;
+    return (
+      <RCTMGLCircleLayer
+        testID="rctmglCircleLayer"
+        ref="nativeLayer"
+        {...props}
+      />
+    );
   }
 }
 


### PR DESCRIPTION
This is another small component test PR.

**Note:**
The last [commit](https://github.com/react-native-mapbox-gl/maps/commit/3ba775d48f8f5539397f7db14bfba8e23eaac9cb) contains one additional change in the component itself. 
I removed the local props declaration & spread of `sourceLayerID` from `this.props.sourceLayerID`, because – at least as far as I understand the code – `AbstractLayer` the component `CircleLayer` extends, has the method  `get baseProps()` which is already taking care of that. Or am I missing something here?
Counting on your eagle 👀 on this, dear reviewers!