### PR TITLE
Use nativeAssets prop instead of Images#images#assets

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/DownloadMapImageTask.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/DownloadMapImageTask.java
@@ -149,9 +149,9 @@ public class DownloadMapImageTask extends AsyncTask<Map.Entry<String, ImageEntry
 
     private BitmapFactory.Options getBitmapOptions(DisplayMetrics metrics, Double scale) {
         BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inScreenDensity = metrics.densityDpi;
+        options.inTargetDensity = metrics.densityDpi;
         if (scale != ImageEntry.defaultScale) {
-            options.inScreenDensity = metrics.densityDpi;
-            options.inTargetDensity = metrics.densityDpi;
             options.inDensity = (int) ((double) DisplayMetrics.DENSITY_DEFAULT * scale);
         }
         return options;

--- a/docs/Images.md
+++ b/docs/Images.md
@@ -5,7 +5,8 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| images | `object` | `none` | `false` | Specifies the external images in key-value pairs required for the shape source.<br/>If you have an asset under Image.xcassets on iOS and the drawables directory on android<br/>you can specify an array of string names with assets as the key `{ assets: ['pin'] }`. |
+| images | `object` | `none` | `false` | Specifies the external images in key-value pairs required for the shape source.<br/>Keys are names - see iconImage expressions, values can be either urls-s objects <br/>with format {uri: 'http://...'}` or `require('image.png')` or `import 'image.png'` |
+| nativeAssetImages | `array` | `none` | `false` | If you have an asset under Image.xcassets on iOS and the drawables directory on android<br/>you can specify an array of string names with assets as the key `['pin']`. |
 | onImageMissing | `func` | `none` | `false` | Gets called when a Layer is trying to render an image whose key is not present in<br/>any of the `Images` component of the Map. |
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1821,7 +1821,19 @@
         "required": false,
         "type": "object",
         "default": "none",
-        "description": "Specifies the external images in key-value pairs required for the shape source.\nIf you have an asset under Image.xcassets on iOS and the drawables directory on android\nyou can specify an array of string names with assets as the key `{ assets: ['pin'] }`."
+        "description": "Specifies the external images in key-value pairs required for the shape source.\nKeys are names - see iconImage expressions, values can be either urls-s objects \nwith format {uri: 'http://...'}` or `require('image.png')` or `import 'image.png'`"
+      },
+      {
+        "name": "nativeAssetImages",
+        "required": false,
+        "type": {
+          "name": "array",
+          "value": {
+            "type": "string"
+          }
+        },
+        "default": "none",
+        "description": "If you have an asset under Image.xcassets on iOS and the drawables directory on android\nyou can specify an array of string names with assets as the key `['pin']`."
       },
       {
         "name": "onImageMissing",

--- a/example/src/examples/ShapeSourceIcon.js
+++ b/example/src/examples/ShapeSourceIcon.js
@@ -82,7 +82,6 @@ class ShapeSourceIcon extends React.Component {
   state = {
     images: {
       example: exampleIcon,
-      assets: ['pin'],
     },
   };
 
@@ -97,6 +96,7 @@ class ShapeSourceIcon extends React.Component {
             centerCoordinate={[-117.20611157485, 52.180961084261]}
           />
           <MapboxGL.Images
+            nativeAssetImages={['pin']}
             images={images}
             onImageMissing={imageKey =>
               this.setState({

--- a/javascript/components/Images.js
+++ b/javascript/components/Images.js
@@ -32,10 +32,16 @@ class Images extends React.Component {
 
     /**
      * Specifies the external images in key-value pairs required for the shape source.
-     * If you have an asset under Image.xcassets on iOS and the drawables directory on android
-     * you can specify an array of string names with assets as the key `{ assets: ['pin'] }`.
+     * Keys are names - see iconImage expressions, values can be either urls-s objects 
+     * with format {uri: 'http://...'}` or `require('image.png')` or `import 'image.png'`
      */
     images: PropTypes.object,
+
+    /**
+     * If you have an asset under Image.xcassets on iOS and the drawables directory on android
+     * you can specify an array of string names with assets as the key `['pin']`.
+     */
+    nativeAssetImages: PropTypes.arrayOf(PropTypes.string),
 
     /**
      * Gets called when a Layer is trying to render an image whose key is not present in
@@ -56,6 +62,9 @@ class Images extends React.Component {
     for (const imageName of imageNames) {
       const value = this.props.images[imageName];
       if (imageName === ShapeSource.NATIVE_ASSETS_KEY && Array.isArray(value)) {
+        console.warn(
+          `Use of ${ShapeSource.NATIVE_ASSETS_KEY} in Images#images is deprecated please use Images#nativeAssetImages`,
+        );
         nativeImages = value;
       } else if (_isUrlOrPath(value)) {
         images[imageName] = value;
@@ -65,6 +74,10 @@ class Images extends React.Component {
           images[imageName] = res;
         }
       }
+    }
+
+    if (this.props.nativeAssetImages) {
+      nativeImages = this.props.nativeAssetImages;
     }
 
     return {


### PR DESCRIPTION
Deprecate `Images#images#assets` for `Images#nativeAssetImages`

Before:
```jsx
<Images
   images={{
      assets: ['pin'],
      foo: {uri: 'http:///....png'}
   }}
/>
```

After:
```jsx
<Images
   nativeAssetImages={['pin']}
   images={{
      foo: {uri: 'http:///....png'}
   }}
/>
```