### PR TITLE
Default to non use_frameworks! version

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,15 +32,19 @@ target 'RNMapboxGLExample' do
   pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
-  pod 'react-native-mapbox-gl', :path => '../../'
+
+  # default version
+  # pod 'react-native-mapbox-gl', :path => '../../'
+
+  # use frameworks version
+  pod 'react-native-mapbox-gl/DynamicLibrary', :path => '../../'
+  ENV["REACT_NATIVE_MAPBOX_GL_USE_FRAMEWORKS"] = "YES"
+  use_frameworks!
 
   target 'RNMapboxGLExampleTests' do
     inherit! :search_paths
     # Pods for testing
   end
-
-  pod 'NoUseFrameworks-MapboxMobileEvents',  :podspec => '../../ios/NoUseFrameworks-MapboxMobileEvents/NoUseFrameworks-MapboxMobileEvents.podspec.json'
-  # use_frameworks!
 
   use_native_modules!
 end

--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -8,11 +8,24 @@ Pod::Spec.new do |s|
   s.version		= package['version']
   s.authors		= { "Nick Italiano" => "ni6@njit.edu" }
   s.homepage    	= "https://github.com/@react-native-mapbox-gl/maps#readme"
+  s.source      	= { :git => "https://github.com/@react-native-mapbox-gl/maps.git" }
   s.license     	= "MIT"
   s.platform    	= :ios, "8.0"
-  s.source      	= { :git => "https://github.com/@react-native-mapbox-gl/maps.git" }
-  s.source_files	= "ios/RCTMGL/**/*.{h,m}"
 
   s.dependency 'Mapbox-iOS-SDK', '~> 5.7'
   s.dependency 'React'
+
+  s.subspec 'DynamicLibrary' do |sp|
+    sp.source_files	= "ios/RCTMGL/**/*.{h,m}"
+  end
+
+  if ENV["REACT_NATIVE_MAPBOX_GL_USE_FRAMEWORKS"]
+    s.default_subspecs= ['DynamicLibrary']
+  else
+    s.subspec 'StaticLibraryFixer' do |sp|
+      s.dependency '@react-native-mapbox-gl-mapbox-static', '~> 5.7'
+    end
+
+    s.default_subspecs= ['DynamicLibrary', 'StaticLibraryFixer']
+  end
 end


### PR DESCRIPTION
This defaults to non use_frameworks! version so autolink just works.

To use the `use_frameworks!` variant:

```ruby
pod 'react-native-mapbox-gl/DynamicLibrary', :path => '../node_modules/@react-native-mapbox-gl/maps'


use_frameworks!
```