### PR TITLE
Use debounce.clear instead of _.debounce.cancel

### DIFF
--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -289,8 +289,8 @@ class MapView extends NativeBridgeComponent(React.Component) {
   }
 
   componentWillUnmount() {
-    this._onDebouncedRegionWillChange.cancel();
-    this._onDebouncedRegionDidChange.cancel();
+    this._onDebouncedRegionWillChange.clear();
+    this._onDebouncedRegionDidChange.clear();
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
As we've replaced underscore aka `_.debounce` with deounce `cancel` is now `clear`