### PR TITLE
Fix icon images and null check

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/images/RCTMGLImages.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/images/RCTMGLImages.java
@@ -66,7 +66,7 @@ public class RCTMGLImages extends AbstractMapFeature {
     }
 
     private void removeImages(RCTMGLMapView mapView) {
-        mapView.getMapboxMap().getStyle(new Style.OnStyleLoaded() {
+        mapView.getStyle(new Style.OnStyleLoaded() {
             @Override
             public void onStyleLoaded(@NonNull Style style) {
                 if (hasImages()) {
@@ -128,7 +128,7 @@ public class RCTMGLImages extends AbstractMapFeature {
         // Wait for style before adding the source to the map
         // only then we can pre-load required images / placeholders into the style
         // before we add the ShapeSource to the map
-        mapView.getMapboxMap().getStyle(new Style.OnStyleLoaded() {
+        mapView.getStyle(new Style.OnStyleLoaded() {
             @Override
             public void onStyleLoaded(@NonNull Style style) {
                 MapboxMap map = mapView.getMapboxMap();

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -974,6 +974,14 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         return mDestroyed;
     }
 
+    public void getStyle(Style.OnStyleLoaded onStyleLoaded) {
+        if (mMap == null) {
+            return;
+        }
+
+        mMap.getStyle(onStyleLoaded);
+    }
+
     private void updateUISettings() {
         if (mMap == null) {
             return;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
@@ -845,6 +845,8 @@ public class RCTMGLStyleFactory {
     public static void setFillPattern(FillLayer layer, RCTMGLStyleValue styleValue) {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.fillPattern(styleValue.getExpression()));
+      } else if (styleValue.isImageStringValue()) {
+        layer.setProperties(PropertyFactory.fillPattern(styleValue.getImageStringValue()));
       } else {
         layer.setProperties(PropertyFactory.fillPattern(styleValue.getImageURI()));
       }
@@ -1033,6 +1035,8 @@ public class RCTMGLStyleFactory {
     public static void setLinePattern(LineLayer layer, RCTMGLStyleValue styleValue) {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.linePattern(styleValue.getExpression()));
+      } else if (styleValue.isImageStringValue()) {
+        layer.setProperties(PropertyFactory.linePattern(styleValue.getImageStringValue()));
       } else {
         layer.setProperties(PropertyFactory.linePattern(styleValue.getImageURI()));
       }
@@ -1153,6 +1157,8 @@ public class RCTMGLStyleFactory {
     public static void setIconImage(SymbolLayer layer, RCTMGLStyleValue styleValue) {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.iconImage(styleValue.getExpression()));
+      } else if (styleValue.isImageStringValue()) {
+        layer.setProperties(PropertyFactory.iconImage(styleValue.getImageStringValue()));
       } else {
         layer.setProperties(PropertyFactory.iconImage(styleValue.getImageURI()));
       }
@@ -1881,6 +1887,8 @@ public class RCTMGLStyleFactory {
     public static void setFillExtrusionPattern(FillExtrusionLayer layer, RCTMGLStyleValue styleValue) {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getExpression()));
+      } else if (styleValue.isImageStringValue()) {
+        layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getImageStringValue()));
       } else {
         layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getImageURI()));
       }
@@ -2149,6 +2157,8 @@ public class RCTMGLStyleFactory {
     public static void setBackgroundPattern(BackgroundLayer layer, RCTMGLStyleValue styleValue) {
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getExpression()));
+      } else if (styleValue.isImageStringValue()) {
+        layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getImageStringValue()));
       } else {
         layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getImageURI()));
       }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleValue.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleValue.java
@@ -171,6 +171,14 @@ public class RCTMGLStyleValue {
         return isAddImage;
     }
 
+    public Boolean isImageStringValue() {
+        return "string".equals(mPayload.getString("type"));
+    }
+
+    public String getImageStringValue() {
+        return mPayload.getString("value");
+    }
+
     public String getImageURI() {
         return imageURI;
     }

--- a/scripts/templates/RCTMGLStyleFactory.java.ejs
+++ b/scripts/templates/RCTMGLStyleFactory.java.ejs
@@ -74,6 +74,14 @@ public class RCTMGLStyleFactory {
       layer.set<%- pascelCase(prop.name) -%>(<%- androidGetConfigType(androidInputType(prop.type, prop.value), prop) -%>);
       <%_ } else if (prop.name === 'visibility') { _%>
       layer.setProperties(PropertyFactory.visibility(styleValue.getString(VALUE_KEY)));
+      <%_ } else if (prop.type === 'resolvedImage') { _%>
+      if (styleValue.isExpression()) {
+        layer.setProperties(PropertyFactory.<%= prop.name %>(styleValue.getExpression()));
+      } else if (styleValue.isImageStringValue()) {
+        layer.setProperties(PropertyFactory.<%= prop.name %>(styleValue.getImageStringValue()));
+      } else {
+        layer.setProperties(PropertyFactory.<%= prop.name %>(<%- androidGetConfigType(androidInputType(prop.type, prop.value), prop) -%>));
+      }
       <%_ } else { _%>
       if (styleValue.isExpression()) {
         layer.setProperties(PropertyFactory.<%= prop.name %>(styleValue.getExpression()));


### PR DESCRIPTION
Fixes: #792 

Another issue is that on android, if iconImage is a literal, not an expression, then the icon is not rendered

```jsx
<SymbolLayer style={{iconImage: 'an-icon'}} />
```

will log an error
`icon-image: expected a literal expression issue`
to work around that if iconImage is just a string we'll use `iconImage(str)` instead of `iconImage(Expression.literal(str))`