### PR TITLE
Remove require cycles on Annotation and maps/index

### DIFF
--- a/javascript/components/annotations/Annotation.js
+++ b/javascript/components/annotations/Annotation.js
@@ -2,7 +2,9 @@ import React from 'react';
 import {Easing} from 'react-native';
 import PropTypes from 'prop-types';
 
-import MapboxGL from '../../index'; // eslint-disable-line import/no-cycle
+import SymbolLayer from '../SymbolLayer';
+
+import Animated from '../../utils/animated/Animated';
 import AnimatedMapPoint from '../../utils/animated/AnimatedPoint';
 
 class Annotation extends React.Component {
@@ -101,20 +103,20 @@ class Annotation extends React.Component {
     }
 
     return (
-      <MapboxGL.Animated.ShapeSource
+      <Animated.ShapeSource
         id={this.props.id}
         ref="source"
         onPress={this.onPress}
         shape={this.state.shape}
       >
         {this.symbolStyle && (
-          <MapboxGL.SymbolLayer
+          <SymbolLayer
             id={`${this.props.id}-symbol`}
             style={this.symbolStyle}
           />
         )}
         {this.props.children}
-      </MapboxGL.Animated.ShapeSource>
+      </Animated.ShapeSource>
     );
   }
 }

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -29,6 +29,7 @@ import locationManager from './modules/location/locationManager';
 import offlineManager from './modules/offline/offlineManager';
 import snapshotManager from './modules/snapshot/snapshotManager';
 import MarkerView from './components/MarkerView';
+import Animated from './utils/animated/Animated';
 import AnimatedMapPoint from './utils/animated/AnimatedPoint';
 import AnimatedShape from './utils/animated/AnimatedShape';
 import AnimatedCoordinatesArray from './utils/animated/AnimatedCoordinatesArray';
@@ -98,36 +99,15 @@ MapboxGL.locationManager = locationManager;
 MapboxGL.offlineManager = offlineManager;
 MapboxGL.snapshotManager = snapshotManager;
 
+// animated
+MapboxGL.Animated = Animated;
+
 // utils
 MapboxGL.AnimatedPoint = AnimatedMapPoint;
 MapboxGL.AnimatedCoordinatesArray = AnimatedCoordinatesArray;
 MapboxGL.AnimatedExtractCoordinateFromArray = AnimatedExtractCoordinateFromArray;
 MapboxGL.AnimatedRouteCoordinatesArray = AnimatedRouteCoordinatesArray;
 MapboxGL.AnimatedShape = AnimatedShape;
-
-// animated
-const Animated = {
-  // sources
-  ShapeSource: RNAnimated.createAnimatedComponent(ShapeSource),
-  ImageSource: RNAnimated.createAnimatedComponent(ImageSource),
-
-  // layers
-  FillLayer: RNAnimated.createAnimatedComponent(FillLayer),
-  FillExtrusionLayer: RNAnimated.createAnimatedComponent(FillExtrusionLayer),
-  LineLayer: RNAnimated.createAnimatedComponent(LineLayer),
-  CircleLayer: RNAnimated.createAnimatedComponent(CircleLayer),
-  SymbolLayer: RNAnimated.createAnimatedComponent(SymbolLayer),
-  RasterLayer: RNAnimated.createAnimatedComponent(RasterLayer),
-  BackgroundLayer: RNAnimated.createAnimatedComponent(BackgroundLayer),
-
-  // values
-  CoordinatesArray: AnimatedCoordinatesArray,
-  RouteCoordinatesArray: AnimatedRouteCoordinatesArray,
-  Shape: AnimatedShape,
-  ExtractCoordinateFromArray : AnimatedExtractCoordinateFromArray, 
-};
-
-MapboxGL.Animated = Animated;
 
 const {LineJoin} = MapboxGL;
 

--- a/javascript/utils/animated/Animated.js
+++ b/javascript/utils/animated/Animated.js
@@ -1,14 +1,14 @@
 ﻿import { Animated as RNAnimated } from 'react-native';
 
-import ShapeSource from './../../components/ShapeSource';
-import ImageSource from './../../components/ImageSource';
-import FillLayer from './../../components/FillLayer';
-import FillExtrusionLayer from './../../components/FillExtrusionLayer';
-import LineLayer from './../../components/LineLayer';
-import CircleLayer from './../../components/CircleLayer';
-import SymbolLayer from './../../components/SymbolLayer';
-import RasterLayer from './../../components/RasterLayer';
-import BackgroundLayer from './../../components/BackgroundLayer';
+import ShapeSource from '../../components/ShapeSource';
+import ImageSource from '../../components/ImageSource';
+import FillLayer from '../../components/FillLayer';
+import FillExtrusionLayer from '../../components/FillExtrusionLayer';
+import LineLayer from '../../components/LineLayer';
+import CircleLayer from '../../components/CircleLayer';
+import SymbolLayer from '../../components/SymbolLayer';
+import RasterLayer from '../../components/RasterLayer';
+import BackgroundLayer from '../../components/BackgroundLayer';
 import AnimatedShape from './AnimatedShape';
 import AnimatedCoordinatesArray from './AnimatedCoordinatesArray';
 import AnimatedExtractCoordinateFromArray from './AnimatedExtractCoordinateFromArray';

--- a/javascript/utils/animated/Animated.js
+++ b/javascript/utils/animated/Animated.js
@@ -1,0 +1,38 @@
+﻿import { Animated as RNAnimated } from 'react-native';
+
+import ShapeSource from './../../components/ShapeSource';
+import ImageSource from './../../components/ImageSource';
+import FillLayer from './../../components/FillLayer';
+import FillExtrusionLayer from './../../components/FillExtrusionLayer';
+import LineLayer from './../../components/LineLayer';
+import CircleLayer from './../../components/CircleLayer';
+import SymbolLayer from './../../components/SymbolLayer';
+import RasterLayer from './../../components/RasterLayer';
+import BackgroundLayer from './../../components/BackgroundLayer';
+import AnimatedShape from './AnimatedShape';
+import AnimatedCoordinatesArray from './AnimatedCoordinatesArray';
+import AnimatedExtractCoordinateFromArray from './AnimatedExtractCoordinateFromArray';
+import AnimatedRouteCoordinatesArray from './AnimatedRouteCoordinatesArray';
+
+const Animated = {
+    // sources
+    ShapeSource: RNAnimated.createAnimatedComponent(ShapeSource),
+    ImageSource: RNAnimated.createAnimatedComponent(ImageSource),
+
+    // layers
+    FillLayer: RNAnimated.createAnimatedComponent(FillLayer),
+    FillExtrusionLayer: RNAnimated.createAnimatedComponent(FillExtrusionLayer),
+    LineLayer: RNAnimated.createAnimatedComponent(LineLayer),
+    CircleLayer: RNAnimated.createAnimatedComponent(CircleLayer),
+    SymbolLayer: RNAnimated.createAnimatedComponent(SymbolLayer),
+    RasterLayer: RNAnimated.createAnimatedComponent(RasterLayer),
+    BackgroundLayer: RNAnimated.createAnimatedComponent(BackgroundLayer),
+
+    // values
+    CoordinatesArray: AnimatedCoordinatesArray,
+    RouteCoordinatesArray: AnimatedRouteCoordinatesArray,
+    Shape: AnimatedShape,
+    ExtractCoordinateFromArray: AnimatedExtractCoordinateFromArray,
+};
+
+export default Animated;


### PR DESCRIPTION
Closes: #783

As I reported on https://github.com/react-native-mapbox-gl/maps/issues/783, I actually found that this component was importad on index.js:

https://github.com/react-native-mapbox-gl/maps/blob/424f931f880c84c9989bb3947e4aaddcdd2aec59/javascript/index.js#L11

Meanwhile it is imported back by index.js itself:

https://github.com/react-native-mapbox-gl/maps/blob/424f931f880c84c9989bb3947e4aaddcdd2aec59/javascript/components/annotations/Annotation.js#L5

Roughly, was change the call to the MapboxGL object to import only the Animated component:

https://github.com/react-native-mapbox-gl/maps/blob/424f931f880c84c9989bb3947e4aaddcdd2aec59/javascript/components/annotations/Annotation.js#L103-L118