### PR TITLE
Fix android iconImage with literal string

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
@@ -844,9 +844,11 @@ public class RCTMGLStyleFactory {
 
     public static void setFillPattern(FillLayer layer, RCTMGLStyleValue styleValue) {
       if (styleValue.isExpression()) {
-        layer.setProperties(PropertyFactory.fillPattern(styleValue.getExpression()));
-      } else if (styleValue.isImageStringValue()) {
-        layer.setProperties(PropertyFactory.fillPattern(styleValue.getImageStringValue()));
+        if (styleValue.isImageStringValue()) {
+          layer.setProperties(PropertyFactory.fillPattern(styleValue.getImageStringValue()));
+        } else {
+          layer.setProperties(PropertyFactory.fillPattern(styleValue.getExpression()));
+        }
       } else {
         layer.setProperties(PropertyFactory.fillPattern(styleValue.getImageURI()));
       }
@@ -1034,9 +1036,11 @@ public class RCTMGLStyleFactory {
 
     public static void setLinePattern(LineLayer layer, RCTMGLStyleValue styleValue) {
       if (styleValue.isExpression()) {
-        layer.setProperties(PropertyFactory.linePattern(styleValue.getExpression()));
-      } else if (styleValue.isImageStringValue()) {
-        layer.setProperties(PropertyFactory.linePattern(styleValue.getImageStringValue()));
+        if (styleValue.isImageStringValue()) {
+          layer.setProperties(PropertyFactory.linePattern(styleValue.getImageStringValue()));
+        } else {
+          layer.setProperties(PropertyFactory.linePattern(styleValue.getExpression()));
+        }
       } else {
         layer.setProperties(PropertyFactory.linePattern(styleValue.getImageURI()));
       }
@@ -1156,9 +1160,11 @@ public class RCTMGLStyleFactory {
 
     public static void setIconImage(SymbolLayer layer, RCTMGLStyleValue styleValue) {
       if (styleValue.isExpression()) {
-        layer.setProperties(PropertyFactory.iconImage(styleValue.getExpression()));
-      } else if (styleValue.isImageStringValue()) {
-        layer.setProperties(PropertyFactory.iconImage(styleValue.getImageStringValue()));
+        if (styleValue.isImageStringValue()) {
+          layer.setProperties(PropertyFactory.iconImage(styleValue.getImageStringValue()));
+        } else {
+          layer.setProperties(PropertyFactory.iconImage(styleValue.getExpression()));
+        }
       } else {
         layer.setProperties(PropertyFactory.iconImage(styleValue.getImageURI()));
       }
@@ -1886,9 +1892,11 @@ public class RCTMGLStyleFactory {
 
     public static void setFillExtrusionPattern(FillExtrusionLayer layer, RCTMGLStyleValue styleValue) {
       if (styleValue.isExpression()) {
-        layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getExpression()));
-      } else if (styleValue.isImageStringValue()) {
-        layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getImageStringValue()));
+        if (styleValue.isImageStringValue()) {
+          layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getImageStringValue()));
+        } else {
+          layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getExpression()));
+        }
       } else {
         layer.setProperties(PropertyFactory.fillExtrusionPattern(styleValue.getImageURI()));
       }
@@ -2156,9 +2164,11 @@ public class RCTMGLStyleFactory {
 
     public static void setBackgroundPattern(BackgroundLayer layer, RCTMGLStyleValue styleValue) {
       if (styleValue.isExpression()) {
-        layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getExpression()));
-      } else if (styleValue.isImageStringValue()) {
-        layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getImageStringValue()));
+        if (styleValue.isImageStringValue()) {
+          layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getImageStringValue()));
+        } else {
+          layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getExpression()));
+        }
       } else {
         layer.setProperties(PropertyFactory.backgroundPattern(styleValue.getImageURI()));
       }

--- a/scripts/templates/RCTMGLStyleFactory.java.ejs
+++ b/scripts/templates/RCTMGLStyleFactory.java.ejs
@@ -76,9 +76,11 @@ public class RCTMGLStyleFactory {
       layer.setProperties(PropertyFactory.visibility(styleValue.getString(VALUE_KEY)));
       <%_ } else if (prop.type === 'resolvedImage') { _%>
       if (styleValue.isExpression()) {
-        layer.setProperties(PropertyFactory.<%= prop.name %>(styleValue.getExpression()));
-      } else if (styleValue.isImageStringValue()) {
-        layer.setProperties(PropertyFactory.<%= prop.name %>(styleValue.getImageStringValue()));
+        if (styleValue.isImageStringValue()) {
+          layer.setProperties(PropertyFactory.<%= prop.name %>(styleValue.getImageStringValue()));
+        } else {
+          layer.setProperties(PropertyFactory.<%= prop.name %>(styleValue.getExpression()));
+        }
       } else {
         layer.setProperties(PropertyFactory.<%= prop.name %>(<%- androidGetConfigType(androidInputType(prop.type, prop.value), prop) -%>));
       }


### PR DESCRIPTION
The last attmempt was not correct. 

Fixes:
```sh
E/Mbgl: {er.alert_client}[JNI]: Error setting property: icon-image expected a literal expression
```