### PR TITLE
Revert "fix(callout): make title property required"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -681,7 +681,7 @@ export interface PointAnnotationProps {
 }
 
 export interface CalloutProps extends Omit<ViewProps, 'style'> {
-  title: string;
+  title?: string;
   style?: StyleProp<WithExpression<ViewStyle>>;
   containerStyle?: StyleProp<WithExpression<ViewStyle>>;
   contentStyle?: StyleProp<WithExpression<ViewStyle>>;


### PR DESCRIPTION
Reverts react-native-mapbox-gl/maps#755

As @mfazekas correctly pointed out, if the `Callout` component is provided with a child, the title property is in fact not required, so it needs to remain optional.

Sorry for the extra work.
