### PR TITLE
test(mapView): add testId when rendered outside of android and ios

### DIFF
--- a/__tests__/components/MapView.test.js
+++ b/__tests__/components/MapView.test.js
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import {render} from 'react-native-testing-library';
+
+import MapView from '../../javascript/components/MapView';
+
+describe('MapView', () => {
+  test('renders with testID', () => {
+    const expectedTestId = 'im used for identification in tests';
+
+    const {getByTestId} = render(<MapView testID={expectedTestId} />);
+
+    expect(() => {
+      getByTestId(expectedTestId);
+    }).not.toThrowError();
+  });
+});

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -756,7 +756,7 @@ class MapView extends NativeBridgeComponent(React.Component) {
       <View
         onLayout={this._onLayout}
         style={this.props.style}
-        testID={this.props.testID}
+        testID={!mapView && this.props.testID}
       >
         {mapView}
       </View>

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -753,7 +753,11 @@ class MapView extends NativeBridgeComponent(React.Component) {
     }
 
     return (
-      <View onLayout={this._onLayout} style={this.props.style}>
+      <View
+        onLayout={this._onLayout}
+        style={this.props.style}
+        testID={this.props.testID}
+      >
         {mapView}
       </View>
     );


### PR DESCRIPTION
### Purpose:
I was writing a test that needed to validate that a map was rendered into the UI for a specific screen. However, despite having the `testID` prop available to me on the `MapView` component, I wasn't able to use `getByTestId`. It turns out that the `MapView` component doesn't render the `testID` prop if it isn't being rendered on Android or iOS.

### Solution:
- Add `testID` to the props used when `MapView` is rendered outside of Android and iOS.