### PR TITLE
Add point annotation id to event payload

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/PointAnnotationClickEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/PointAnnotationClickEvent.java
@@ -12,18 +12,35 @@ import com.mapbox.rctmgl.components.annotation.RCTMGLPointAnnotation;
 import com.mapbox.rctmgl.events.constants.EventKeys;
 import com.mapbox.rctmgl.events.constants.EventTypes;
 import com.mapbox.rctmgl.utils.ConvertUtils;
+import com.mapbox.rctmgl.utils.GeoJSONUtils;
 
 /**
  * Created by nickitaliano on 10/11/17.
  */
 
 public class PointAnnotationClickEvent extends MapClickEvent {
-    public PointAnnotationClickEvent(View view, @NonNull LatLng latLng, @NonNull PointF screenPoint, String eventType) {
+    private RCTMGLPointAnnotation mView;
+    private LatLng mTouchedLatLng;
+    private PointF mScreenPoint;
+
+    public PointAnnotationClickEvent(RCTMGLPointAnnotation view, @NonNull LatLng latLng, @NonNull PointF screenPoint, String eventType) {
         super(view, latLng, screenPoint, eventType);
+        mView = view;
+        mTouchedLatLng = latLng;
+        mScreenPoint = screenPoint;
     }
 
     @Override
     public String getKey() {
         return getType().equals(EventTypes.ANNOTATION_SELECTED) ? EventKeys.POINT_ANNOTATION_SELECTED : EventKeys.POINT_ANNOTATION_DESELECTED;
+    }
+
+    @Override
+    public WritableMap getPayload() {
+        WritableMap properties = new WritableNativeMap();
+        properties.putString("id", mView.getID());
+        properties.putDouble("screenPointX", mScreenPoint.x);
+        properties.putDouble("screenPointY", mScreenPoint.y);
+        return GeoJSONUtils.toPointFeature(mTouchedLatLng, properties);
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/PointAnnotationDragEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/PointAnnotationDragEvent.java
@@ -12,14 +12,31 @@ import com.mapbox.rctmgl.components.annotation.RCTMGLPointAnnotation;
 import com.mapbox.rctmgl.events.constants.EventKeys;
 import com.mapbox.rctmgl.events.constants.EventTypes;
 import com.mapbox.rctmgl.utils.ConvertUtils;
+import com.mapbox.rctmgl.utils.GeoJSONUtils;
 
 public class PointAnnotationDragEvent extends MapClickEvent {
-    public PointAnnotationDragEvent(View view, @NonNull LatLng latLng, @NonNull PointF screenPoint, String eventType) {
+    RCTMGLPointAnnotation mView;
+    private LatLng mTouchedLatLng;
+    private PointF mScreenPoint;
+
+    public PointAnnotationDragEvent(RCTMGLPointAnnotation view, @NonNull LatLng latLng, @NonNull PointF screenPoint, String eventType) {
         super(view, latLng, screenPoint, eventType);
+        mView = view;
+        mTouchedLatLng = latLng;
+        mScreenPoint = screenPoint;
     }
 
     @Override
     public String getKey() {
         return getType().equals(EventTypes.ANNOTATION_DRAG_START) ? EventKeys.POINT_ANNOTATION_DRAG_START : EventKeys.POINT_ANNOTATION_DRAG_END;
+    }
+
+    @Override
+    public WritableMap getPayload() {
+        WritableMap properties = new WritableNativeMap();
+        properties.putString("id", mView.getID());
+        properties.putDouble("screenPointX", mScreenPoint.x);
+        properties.putDouble("screenPointY", mScreenPoint.y);
+        return GeoJSONUtils.toPointFeature(mTouchedLatLng, properties);
     }
 }

--- a/ios/RCTMGL/RCTMGLMapTouchEvent.h
+++ b/ios/RCTMGL/RCTMGLMapTouchEvent.h
@@ -13,6 +13,7 @@
 
 @interface RCTMGLMapTouchEvent : RCTMGLEvent
 
+@property (nonatomic, copy) NSString *id;
 @property (nonatomic, assign) CLLocationCoordinate2D coordinate;
 @property (nonatomic, assign) CGPoint screenPoint;
 

--- a/ios/RCTMGL/RCTMGLMapTouchEvent.m
+++ b/ios/RCTMGL/RCTMGLMapTouchEvent.m
@@ -18,6 +18,7 @@
     MGLPointFeature *feature = [[MGLPointFeature alloc] init];
     feature.coordinate = _coordinate;
     feature.attributes = @{
+                            @"id": _id,
                             @"screenPointX": [NSNumber numberWithDouble:_screenPoint.x],
                             @"screenPointY":[NSNumber numberWithDouble:_screenPoint.y]
                          };
@@ -38,6 +39,7 @@
 {
     RCTMGLMapTouchEvent *event = [[RCTMGLMapTouchEvent alloc] init];
     event.type = RCT_MAPBOX_ANNOTATION_TAP;
+    event.id = pointAnnotation.id;
     event.coordinate = pointAnnotation.coordinate;
     event.screenPoint = [pointAnnotation.superview convertPoint:pointAnnotation.frame.origin toView:nil];
     return event;


### PR DESCRIPTION
If point annotations are created dynamically, id has to be included in events payload in order to identify them.