### PR TITLE
[iOS] Fix case of nil id in RCTMGLMapTouchEvent

### DIFF
--- a/ios/RCTMGL/RCTMGLMapTouchEvent.m
+++ b/ios/RCTMGL/RCTMGLMapTouchEvent.m
@@ -17,11 +17,13 @@
 {
     MGLPointFeature *feature = [[MGLPointFeature alloc] init];
     feature.coordinate = _coordinate;
-    feature.attributes = @{
-                            @"id": _id,
-                            @"screenPointX": [NSNumber numberWithDouble:_screenPoint.x],
-                            @"screenPointY":[NSNumber numberWithDouble:_screenPoint.y]
-                         };
+    NSMutableDictionary *attributes = [NSMutableDictionary new];
+    [attributes setValue:[NSNumber numberWithDouble:_screenPoint.x] forKey:@"screenPointX"];
+    [attributes setValue:[NSNumber numberWithDouble:_screenPoint.y] forKey:@"screenPointY"];
+    if (_id) {
+        [attributes setValue:_id forKey:@"id"];
+    }
+    feature.attributes = attributes;
     return [feature geoJSONDictionary];
 }
 


### PR DESCRIPTION
Due to the changes in #835, I got example app crashed when I trigger the event from point.

```
RNMapboxGLExample[15032:67237673] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]'
*** First throw call stack:
(0x19a14096c 0x199e59028 0x19a199500 0x19a1a3350 0x19a027540 0x19a018ca4 0x101128f7c 0x10111e91c 0x1011537c0 0x101133ed4 0x19de13248 0x19de1b9e8 0x19de1916c 0x19de186a0 0x19de0c564 0x19a0bb524 0x19a0b61c4 0x19a0b6774 0x19a0b5f40 0x1a4346534 0x19e241580 0x1007afe14 0x199f34e18)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

This is because the id is nil in case of `_fromPoint`.