### PR TITLE
Add Logger

### DIFF
--- a/__tests__/interface.test.js
+++ b/__tests__/interface.test.js
@@ -84,6 +84,7 @@ describe('Public Interface', () => {
       'AnimatedShape',
       'AnimatedExtractCoordinateFromArray',
       'AnimatedRouteCoordinatesArray',
+      'Logger',
     ];
     actualKeys.forEach((key) => expect(expectedKeys).toContain(key));
   });

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/RCTMGLPackage.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/RCTMGLPackage.java
@@ -32,6 +32,7 @@ import com.mapbox.rctmgl.components.styles.sources.RCTMGLRasterSourceManager;
 import com.mapbox.rctmgl.components.styles.sources.RCTMGLShapeSourceManager;
 import com.mapbox.rctmgl.components.styles.sources.RCTMGLVectorSourceManager;
 import com.mapbox.rctmgl.modules.RCTMGLLocationModule;
+import com.mapbox.rctmgl.modules.RCTMGLLogging;
 import com.mapbox.rctmgl.modules.RCTMGLModule;
 import com.mapbox.rctmgl.modules.RCTMGLOfflineModule;
 import com.mapbox.rctmgl.modules.RCTMGLSnapshotModule;
@@ -50,6 +51,7 @@ public class RCTMGLPackage implements ReactPackage {
         modules.add(new RCTMGLOfflineModule(reactApplicationContext));
         modules.add(new RCTMGLSnapshotModule(reactApplicationContext));
         modules.add(new RCTMGLLocationModule(reactApplicationContext));
+        modules.add(new RCTMGLLogging(reactApplicationContext));
 
         return modules;
     }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLogging.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLogging.java
@@ -1,0 +1,130 @@
+package com.mapbox.rctmgl.modules;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.mapbox.mapboxsdk.log.Logger;
+import com.mapbox.mapboxsdk.log.LoggerDefinition;
+import android.util.Log;
+
+@ReactModule(name = RCTMGLLogging.REACT_CLASS)
+public class RCTMGLLogging extends ReactContextBaseJavaModule {
+    public static final String REACT_CLASS = "RCTMGLLogging";
+    private ReactApplicationContext mReactContext;
+
+    public RCTMGLLogging(ReactApplicationContext reactApplicationContext) {
+        super(reactApplicationContext);
+        mReactContext = reactApplicationContext;
+
+        Logger.setVerbosity(Logger.WARN);
+        Logger.setLoggerDefinition(new LoggerDefinition() {
+            @Override
+            public void v(String tag, String msg) {
+                Log.v(tag, msg);
+                onLog("verbose", tag, msg, null);
+            }
+
+            @Override
+            public void v(String tag, String msg, Throwable tr) {
+                Log.v(tag, msg, tr);
+                onLog("verbose", tag, msg, tr);
+            }
+
+            @Override
+            public void d(String tag, String msg) {
+                Log.d(tag, msg);
+                onLog("debug", tag, msg, null);
+            }
+
+            @Override
+            public void d(String tag, String msg, Throwable tr) {
+                Log.d(tag, msg, tr);
+                onLog("debug",tag,msg,tr);
+            }
+
+            @Override
+            public void i(String tag, String msg) {
+                Log.i(tag, msg);
+                onLog("info", tag, msg, null);
+            }
+
+            @Override
+            public void i(String tag, String msg, Throwable tr) {
+                Log.i(tag, msg, tr);
+                onLog("info", tag, msg, tr);
+            }
+
+            @Override
+            public void w(String tag, String msg) {
+                Log.w(tag, msg);
+                onLog("warning", tag, msg, null);
+            }
+
+            @Override
+            public void w(String tag, String msg, Throwable tr) {
+                Log.w(tag, msg, tr);
+                onLog("warning", tag, msg, tr);
+            }
+
+            @Override
+            public void e(String tag, String msg) {
+                Log.e(tag, msg);
+                onLog("error", tag, msg, null);
+            }
+
+            @Override
+            public void e(String tag, String msg, Throwable tr) {
+                Log.e(tag, msg, tr);
+                onLog("error", tag, msg, tr);
+            }
+        });
+    }
+
+    @Override
+    public String getName() {
+        return REACT_CLASS;
+    }
+
+    @ReactMethod
+    public void setLogLevel(String level) {
+        @Logger.LogLevel int logLevel = Logger.NONE;
+        switch(level)
+        {
+            case "error":
+                logLevel = Logger.ERROR;
+                break;
+            case "warning":
+                logLevel = Logger.WARN;
+                break;
+            case "info":
+                logLevel = Logger.INFO;
+                break;
+            case "debug":
+                logLevel = Logger.DEBUG;
+                break;
+            case "verbose":
+                logLevel = Logger.VERBOSE;
+                break;
+            default:
+                logLevel = Logger.NONE;
+                break;
+        }
+        Logger.setVerbosity(logLevel);
+    }
+
+    public void onLog(String level, String tag, String msg, Throwable tr) {
+        WritableMap event = Arguments.createMap();
+        event.putString("message", msg);
+        event.putString("tag", tag);
+        event.putString("level", level);
+
+        mReactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit("LogEvent", event);
+    }
+
+}

--- a/ios/RCTMGL/RCTMGLLogging.h
+++ b/ios/RCTMGL/RCTMGLLogging.h
@@ -1,0 +1,18 @@
+#ifndef RCTMGLLogging_h
+#define RCTMGLLogging_h
+
+#import <Foundation/Foundation.h>
+#import <React/RCTEventEmitter.h>
+
+
+@class MGLLoggingConfiguration;
+
+@interface RCTMGLLogging : RCTEventEmitter <RCTBridgeModule>
+
+@property (nonatomic, nonnull) MGLLoggingConfiguration*  loggingConfiguration;
+
+- (void)setLoggingLevel:(nonnull NSString*) logLevel;
+
+@end
+
+#endif /* RCTMGLLogging_h */

--- a/ios/RCTMGL/RCTMGLLogging.m
+++ b/ios/RCTMGL/RCTMGLLogging.m
@@ -1,0 +1,114 @@
+#import "RCTMGLLogging.h"
+
+@import Mapbox;
+
+@implementation RCTMGLLogging
+
++ (id)allocWithZone:(NSZone *)zone {
+    static RCTMGLLogging *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [super allocWithZone:zone];
+    });
+    return sharedInstance;
+}
+
+-(id)init {
+    if ( self = [super init] ) {
+        self.loggingConfiguration = [MGLLoggingConfiguration sharedConfiguration];
+        [self.loggingConfiguration  setLoggingLevel:MGLLoggingLevelWarning];
+        __weak typeof(self) weakSelf = self;
+        self.loggingConfiguration.handler = ^(MGLLoggingLevel loggingLevel, NSString *filePath, NSUInteger line, NSString *message) {
+            [weakSelf sendLogWithLevel:loggingLevel filePath: filePath line: line message: message];
+        };
+    }
+    return self;
+}
+
+RCT_EXPORT_MODULE();
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"LogEvent"];
+}
+
+- (void)sendLogWithLevel:(MGLLoggingLevel)loggingLevel filePath:(NSString*)filePath line:(NSUInteger)line message:(NSString*)message
+{
+    NSString* level = @"n/a";
+    switch (loggingLevel) {
+    case MGLLoggingLevelInfo:
+        level = @"info";
+        break;
+    case MGLLoggingLevelError:
+        level = @"error";
+        break;
+#if MGL_LOGGING_ENABLE_DEBUG
+    case MGLLoggingLevelDebug:
+        level = @"debug";
+        break;
+#endif
+    case MGLLoggingLevelWarning:
+        level = @"warning";
+        break;
+    case MGLLoggingLevelNone:
+        level = @"none";
+        break;
+    case MGLLoggingLevelFault:
+        level = @"fault";
+        break;
+    case MGLLoggingLevelVerbose:
+        level = @"verbose";
+        break;
+    }
+
+    NSString* type = nil;
+    if ([message hasPrefix:@"Failed to load glyph range"]) {
+        type = @"missing_font";
+    }
+
+    NSMutableDictionary* body = [@{
+        @"level": level,
+        @"message": message,
+        @"filePath": filePath,
+        @"line": @(line)
+    } mutableCopy];
+
+    if (type != nil) {
+        body[@"type"] = type;
+    }
+    [self sendEventWithName:@"LogEvent" body:body];
+}
+
+RCT_EXPORT_METHOD(setLogLevel: (nonnull NSString*)logLevel)
+{
+    MGLLoggingLevel mglLogLevel = MGLLoggingLevelNone;
+    if ([logLevel isEqualToString:@"none"]) {
+        mglLogLevel = MGLLoggingLevelNone;
+    } else if ([logLevel isEqualToString:@"debug"]) {
+        mglLogLevel = MGLLoggingLevelInfo;
+    } else if ([logLevel isEqualToString:@"fault"]) {
+        mglLogLevel = MGLLoggingLevelFault;
+    } else if ([logLevel isEqualToString:@"error"]) {
+        mglLogLevel = MGLLoggingLevelError;
+    } else if ([logLevel isEqualToString:@"warning"]) {
+        mglLogLevel = MGLLoggingLevelWarning;
+    } else if ([logLevel isEqualToString:@"info"]) {
+        mglLogLevel = MGLLoggingLevelInfo;
+    } else if ([logLevel isEqualToString:@"debug"]) {
+#if MGL_LOGGING_ENABLE_DEBUG
+        mglLogLevel = MGLLoggingLevelDebug;
+#else
+        mglLogLevel = MGLLoggingLevelVerbose;
+#endif
+    } else if ([logLevel isEqualToString:@"verbose"]) {
+        mglLogLevel = MGLLoggingLevelVerbose;
+    }
+    self.loggingConfiguration.loggingLevel = mglLogLevel;
+}
+
+@end

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -16,6 +16,7 @@
 
 @class CameraUpdateQueue;
 @class RCTMGLImages;
+@class RCTMGLLogging;
 
 @protocol RCTMGLMapViewCamera<NSObject>
 - (void)initialLayout;
@@ -27,6 +28,7 @@ typedef void (^StyleLoadedBlock) (MGLStyle* __nonnull style);
 
 @interface RCTMGLMapView : MGLMapView<RCTInvalidating>
 
+@property (nonatomic, strong, nonnull) RCTMGLLogging* logging;
 @property (nonatomic, strong) CameraUpdateQueue *cameraUpdateQueue;
 @property (nonatomic, weak) id<RCTMGLMapViewCamera> reactCamera;
 @property (nonatomic, strong) NSMutableArray<id<RCTComponent>> *reactSubviews;

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -13,6 +13,7 @@
 #import "RCTMGLImages.h"
 #import "UIView+React.h"
 #import "RCTMGLNativeUserLocation.h"
+#import "RCTMGLLogging.h"
 
 @implementation RCTMGLMapView
 {
@@ -37,6 +38,7 @@ static double const M2PI = M_PI * 2;
         _reactSubviews = [[NSMutableArray alloc] init];
         _layerWaiters = [[NSMutableDictionary alloc] init];
         _styleWaiters = [[NSMutableArray alloc] init];
+        _logging = [[RCTMGLLogging alloc] init];
     }
     return self;
 }

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -17,6 +17,7 @@ import {
   viewPropTypes,
 } from '../utils';
 import {getFilter} from '../utils/filterUtils';
+import Logger from '../utils/Logger';
 
 import NativeBridgeComponent from './NativeBridgeComponent';
 
@@ -264,6 +265,9 @@ class MapView extends NativeBridgeComponent(React.Component) {
   constructor(props) {
     super(props, NATIVE_MODULE_NAME);
 
+    this.logger = Logger.sharedInstance();
+    this.logger.start();
+
     this.state = {
       isReady: null,
       region: null,
@@ -297,6 +301,7 @@ class MapView extends NativeBridgeComponent(React.Component) {
   componentWillUnmount() {
     this._onDebouncedRegionWillChange.clear();
     this._onDebouncedRegionDidChange.clear();
+    this.logger.stop();
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -35,6 +35,7 @@ import AnimatedShape from './utils/animated/AnimatedShape';
 import AnimatedCoordinatesArray from './utils/animated/AnimatedCoordinatesArray';
 import AnimatedExtractCoordinateFromArray from './utils/animated/AnimatedExtractCoordinateFromArray';
 import AnimatedRouteCoordinatesArray from './utils/animated/AnimatedRouteCoordinatesArray';
+import Logger from './utils/Logger';
 
 const MapboxGL = {...NativeModules.MGLModule};
 
@@ -108,6 +109,7 @@ MapboxGL.AnimatedCoordinatesArray = AnimatedCoordinatesArray;
 MapboxGL.AnimatedExtractCoordinateFromArray = AnimatedExtractCoordinateFromArray;
 MapboxGL.AnimatedRouteCoordinatesArray = AnimatedRouteCoordinatesArray;
 MapboxGL.AnimatedShape = AnimatedShape;
+MapboxGL.Logger = Logger;
 
 const {LineJoin} = MapboxGL;
 
@@ -141,6 +143,7 @@ export {
   AnimatedShape,
   Animated,
   LineJoin,
+  Logger,
 };
 
 export default MapboxGL;

--- a/javascript/utils/Logger.js
+++ b/javascript/utils/Logger.js
@@ -1,0 +1,114 @@
+import {NativeEventEmitter, NativeModules} from 'react-native';
+const {MGLLogging} = NativeModules;
+
+class Logger {
+  static instance = null;
+
+  static sharedInstance() {
+    if (this.instance === null) {
+      this.instance = new Logger();
+    }
+    return this.instance;
+  }
+
+  constructor() {
+    this.loggerEmitter = new NativeEventEmitter(MGLLogging);
+    this.startedCount = 0;
+    this.logCallback = null;
+  }
+
+  /**
+   * Set custom logger function.
+   * @param {Logger~logCallback} logCallback - callback taking a log object as param. If callback return falsy value then
+   * default logging will take place.
+   */
+  static setLogCallback(logCallback) {
+    this.sharedInstance().setLogCallback(logCallback);
+  }
+
+  /**
+   * Set custom logger function.
+   * @param {Logger~logCallback} logCallback - callback taking a log object as param. If callback return falsy value then
+   * default logging will take place.
+   */
+  setLogCallback(logCallback) {
+    this.logCallback = logCallback;
+  }
+
+  /**
+   * This callback is displayed as part of the Requester class.
+   * @callback Logger~logCallback
+   * @param {object} log
+   * @param {string} log.message - the message of the log
+   * @param {string} log.level - log level
+   * @param {string} log.tag - optional tag used on android
+   */
+
+  /**
+   * setLogLevel
+   * @param {LogLevel} level
+   */
+  static setLogLevel(level) {
+    MGLLogging.setLogLevel(level);
+  }
+
+  /**
+   * @type {('error'|'warning'|'info'|'debug'|'verobse')} LogLevel - Supported log levels
+   */
+
+  start() {
+    if (this.startedCount === 0) {
+      this.subscribe();
+    }
+    this.startedCount += 1;
+  }
+
+  stop() {
+    this.startedCount -= 1;
+    if (this.startedCount === 0) {
+      this.unsubscribe();
+    }
+  }
+
+  subscribe() {
+    this.subscription = this.loggerEmitter.addListener('LogEvent', (log) => {
+      this.onLog(log);
+    });
+  }
+
+  unsubscribe() {
+    this.subscription.remove();
+    this.subscription = null;
+  }
+
+  effectiveLevel(log) {
+    let {level, message, tag} = log;
+
+    if (level === 'warning') {
+      if (
+        tag === 'Mbgl-HttpRequest' &&
+        message.startsWith('Request failed due to a permanent error: Canceled')
+      ) {
+        // this seems to happening too much to show a warning every time
+        return 'info';
+      }
+    }
+    return level;
+  }
+
+  onLog(log) {
+    if (!this.logCallback || !this.logCallback(log)) {
+      let {message} = log;
+      let level = this.effectiveLevel(log);
+      if (level === 'error') {
+        console.error('Mapbox error', message, log);
+      } else if (level === 'warning') {
+        console.warn('Mapbox warning', message, log);
+      } else {
+        console.log(`Mapbox [${level}]`, message, log);
+      }
+    }
+  }
+}
+
+export default Logger;


### PR DESCRIPTION
Add Logging component so we can show errors from Mapbox in react native.
For example in current versions when a font is not found, some of annotations will not be rendered without any clue what's happened.

See #839,  #774

With this change we get a redbox error:

![kép](https://user-images.githubusercontent.com/52435/80737965-9abe7000-8b14-11ea-8cf7-e30cdc64a476.png)

![kép](https://user-images.githubusercontent.com/52435/80738978-0ce38480-8b16-11ea-9846-d36c2f674387.png)



There is also an api for this:

```
import {Logger} from '@react-native-mapbox-gl/maps';
...

Logger.setLogLevel('verbose');
Logger.setLogCallback((log) => {
      console.log('Mapbox log:', log);
      return true;
    });
```

## Changelog

* Set default Mapbox logging verbosity to warning. (Change it using `Logger.setLogLevel('verbose')`)
* Error/Warn mapbox log messages are treated as redbox/yellowbox errors/warnings. (Override it using `Logger.setLoggerCallback(log => { return true })`