### PR TITLE
Adding Java 8 compatibility options

### DIFF
--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -15,6 +15,11 @@ android {
         versionName "1.0"
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
Noticed, that when trying to run `detox` test builds it would fail with:
```shell
> Task :@react-native-mapbox-gl_maps:mergeExtDexDebugAndroidTest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':@react-native-mapbox-gl_maps:mergeExtDexDebugAndroidTest'.
> Could not resolve all files for configuration ':@react-native-mapbox-gl_maps:debugAndroidTestRuntimeClasspath'.
   > Failed to transform retrofit-2.7.1.jar (com.squareup.retrofit2:retrofit:2.7.1) to match attributes {artifactType=android-dex, dexing-enable-desugaring=false, dexing-is-debuggable=true, dexing-min-sdk=23, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for DexingNoClasspathTransform: /Users/user/.gradle/caches/modules-2/files-2.1/com.squareup.retrofit2/retrofit/2.7.1/ab61c867c73bdf57224bcc40525f42fea72960a0/retrofit-2.7.1.jar.
         > Error while dexing.
           The dependency contains Java 8 bytecode. Please enable desugaring by adding the following to build.gradle
           android {
               compileOptions {
                   sourceCompatibility 1.8
                   targetCompatibility 1.8
               }
           }
           See https://developer.android.com/studio/write/java8-support.html for details. Alternatively, increase the minSdkVersion to 26 or above.

   > Failed to transform okhttp-3.14.4.jar (com.squareup.okhttp3:okhttp:3.14.4) to match attributes {artifactType=android-dex, dexing-enable-desugaring=false, dexing-is-debuggable=true, dexing-min-sdk=23, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for DexingNoClasspathTransform: /Users/user/.gradle/caches/modules-2/files-2.1/com.squareup.okhttp3/okhttp/3.14.4/4f6f76315e70d9af39a1125dc6ff7145e26e3040/okhttp-3.14.4.jar.
         > Error while dexing.
```

See [this ticket](https://github.com/FormidableLabs/react-native-app-auth/issues/455) in another project for reference.

Notice, that increasing the `minSdkVersion` to `24` did not help in my project - I had to go up to `26`, however I can't do that as we need to support `Android 7`