### PR TITLE
add invalidateAmbientCache method

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -122,6 +122,24 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void invalidateAmbientCache(final Promise promise) {
+        activateFileSource();
+        final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
+        offlineManager.invalidateAmbientCache(new OfflineManager.FileSourceCallback() {
+            @Override
+            public void onSuccess() {
+                promise.resolve(null);
+            }
+
+            @Override
+            public void onError(String error) {
+                promise.reject("invalidateAmbientCache", error);
+            }
+        });
+    }
+
+
+    @ReactMethod
     public void resetDatabase(final Promise promise) {
         activateFileSource();
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);

--- a/docs/OfflineManager.md
+++ b/docs/OfflineManager.md
@@ -47,6 +47,22 @@ await MapboxGL.offlineManager.deletePack('packName')
 ```
 
 
+#### invalidateAmbientCache()
+
+Forces a revalidation of the tiles in the ambient cache and downloads a fresh version of the tiles from the tile server.<br/>This is the recommend method for clearing the cache.<br/>This is the most efficient method because tiles in the ambient cache are re-downloaded to remove outdated data from a device.<br/>It does not erase resources from the ambient cache or delete the database, which can be computationally expensive operations that may carry unintended side effects.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+
+
+
+
+```javascript
+await MapboxGL.offlineManager.invalidateAmbientCache();
+```
+
+
 #### resetDatabase()
 
 Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5574,6 +5574,20 @@
         }
       },
       {
+        "name": "invalidateAmbientCache",
+        "description": "Forces a revalidation of the tiles in the ambient cache and downloads a fresh version of the tiles from the tile server.\nThis is the recommend method for clearing the cache.\nThis is the most efficient method because tiles in the ambient cache are re-downloaded to remove outdated data from a device.\nIt does not erase resources from the ambient cache or delete the database, which can be computationally expensive operations that may carry unintended side effects.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.invalidateAmbientCache();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
         "name": "resetDatabase",
         "description": "Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.",
         "params": [],

--- a/ios/RCTMGL/MGLOfflineModule.m
+++ b/ios/RCTMGL/MGLOfflineModule.m
@@ -154,6 +154,17 @@ RCT_EXPORT_METHOD(getPacks:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseR
     });
 }
 
+RCT_EXPORT_METHOD(invalidateAmbientCache:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [[MGLOfflineStorage sharedOfflineStorage] invalidateAmbientCacheWithCompletionHandler:^(NSError *error) {
+        if (error != nil) {
+            reject(@"invalidateAmbientCache", error.description, error);
+            return;
+        }
+        resolve(nil);
+    }];
+}
+
 RCT_EXPORT_METHOD(resetDatabase:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     [[MGLOfflineStorage sharedOfflineStorage] resetDatabaseWithCompletionHandler:^(NSError *error) {

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -91,6 +91,22 @@ class OfflineManager {
   }
 
   /**
+   * Forces a revalidation of the tiles in the ambient cache and downloads a fresh version of the tiles from the tile server.
+   * This is the recommend method for clearing the cache.
+   * This is the most efficient method because tiles in the ambient cache are re-downloaded to remove outdated data from a device.
+   * It does not erase resources from the ambient cache or delete the database, which can be computationally expensive operations that may carry unintended side effects.
+   *
+   * @example
+   * await MapboxGL.offlineManager.invalidateAmbientCache();
+   *
+   * @return {void}
+   */
+  async invalidateAmbientCache() {
+    await this._initialize();
+    await MapboxGLOfflineManager.invalidateAmbientCache();
+  }
+
+  /**
    * Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.
    *
    * @example


### PR DESCRIPTION
This adds the `invalidateAmbientCache` method that is available in both the iOS and Android SDKs. Tested and working as expected in my app.

As a side note, I couldn't get `npm run generate` to work. It keeps failing on generating the docs, with the following error:
```
UnhandledPromiseRejectionWarning: Browserslist: caniuse-lite is outdated. Please run next command `npm update`
```
It appears to be failing on the `npx documentation build ${MODULES_PATH} -f json` command. I tried using different versions of `documentation` without any success. So I added the docs change by hand for now.