### PR TITLE
fix(mapview): replace short-circuit with ternary

### DIFF
--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -767,7 +767,7 @@ class MapView extends NativeBridgeComponent(React.Component) {
       <View
         onLayout={this._onLayout}
         style={this.props.style}
-        testID={!mapView && this.props.testID}
+        testID={mapView ? null : this.props.testID}
       >
         {mapView}
       </View>


### PR DESCRIPTION
This commit https://github.com/react-native-mapbox-gl/maps/commit/6a15169a426393abf915f2184dd6d0144dfaac6f introduced `testID` to the MapView component. 

Unfortunately it will crash when `mapView` is actually present, which would result in `false` within the check `!mapView && this.props.testID`, thus returning `false` to `testID`, which does only accept `String`.

Testable via example app `Map` => `Show Map` View.

Feedback/ review welcome