### PR TITLE
Add clearAmbientCache and setMaximumAmbientCacheSize methods

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -138,6 +138,44 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
         });
     }
 
+    @ReactMethod
+    public void clearAmbientCache(final Promise promise) {
+        activateFileSource();
+
+        final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
+
+        offlineManager.clearAmbientCache(new OfflineManager.FileSourceCallback() {
+            @Override
+            public void onSuccess() {
+                promise.resolve(null);
+            }
+
+            @Override
+            public void onError(String error) {
+                promise.reject("clearAmbientCache", error);
+            }
+        });
+    }
+
+    @ReactMethod
+    public void setMaximumAmbientCacheSize(int size, final Promise promise) {
+        activateFileSource();
+
+        final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
+
+        offlineManager.setMaximumAmbientCacheSize(size, new OfflineManager.FileSourceCallback() {
+            @Override
+            public void onSuccess() {
+                promise.resolve(null);
+            }
+
+            @Override
+            public void onError(String error) {
+                promise.reject("setMaximumAmbientCacheSize", error);
+            }
+        });
+    }
+
 
     @ReactMethod
     public void resetDatabase(final Promise promise) {

--- a/docs/OfflineManager.md
+++ b/docs/OfflineManager.md
@@ -79,6 +79,38 @@ await MapboxGL.offlineManager.invalidateAmbientCache();
 ```
 
 
+#### clearAmbientCache()
+
+Erases resources from the ambient cache.<br/>This method clears the cache and decreases the amount of space that map resources take up on the device.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+
+
+
+
+```javascript
+await MapboxGL.offlineManager.clearAmbientCache();
+```
+
+
+#### setMaximumAmbientCacheSize(size)
+
+Sets the maximum size of the ambient cache in bytes. Disables the ambient cache if set to 0.<br/>This method may be computationally expensive because it will erase resources from the ambient cache if its size is decreased.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `size` | `Number` | `Yes` | Size of ambient cache. |
+
+
+
+```javascript
+await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);
+```
+
+
 #### resetDatabase()
 
 Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5638,6 +5638,43 @@
         }
       },
       {
+        "name": "clearAmbientCache",
+        "description": "Erases resources from the ambient cache.\nThis method clears the cache and decreases the amount of space that map resources take up on the device.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.clearAmbientCache();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "setMaximumAmbientCacheSize",
+        "description": "Sets the maximum size of the ambient cache in bytes. Disables the ambient cache if set to 0.\nThis method may be computationally expensive because it will erase resources from the ambient cache if its size is decreased.",
+        "params": [
+          {
+            "name": "size",
+            "description": "Size of ambient cache.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
         "name": "resetDatabase",
         "description": "Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.",
         "params": [],

--- a/example/src/examples/CacheManagement.js
+++ b/example/src/examples/CacheManagement.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import MapboxGL, {MapView, Camera} from '@react-native-mapbox-gl/maps';
+import {
+  Alert,
+  StyleSheet,
+  View,
+  TextInput,
+  TouchableOpacity,
+  Text,
+} from 'react-native';
+
+import sheet from '../styles/sheet';
+import {DEFAULT_CENTER_COORDINATE} from '../utils';
+
+import BaseExamplePropTypes from './common/BaseExamplePropTypes';
+import Page from './common/Page';
+
+const styles = StyleSheet.create({
+  controlsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  control: {
+    width: '40%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 16,
+    padding: 8,
+  },
+  button: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 3,
+    backgroundColor: 'blue',
+    padding: 8,
+    width: '100%',
+  },
+  buttonTxt: {
+    color: 'white',
+    textAlign: 'center',
+  },
+  textInput: {
+    width: '100%',
+    borderBottomColor: 'grey',
+    borderBottomWidth: 1,
+    marginBottom: 8,
+    padding: 8,
+  },
+});
+
+class CacheManagement extends React.Component {
+  static propTypes = {
+    ...BaseExamplePropTypes,
+  };
+
+  state = {
+    cacheSize: '',
+  };
+
+  invalidateAmbientCache = async () => {
+    await MapboxGL.offlineManager.invalidateAmbientCache();
+    Alert.alert('Ambient cache successfully invalidated');
+  };
+
+  resetDatabase = async () => {
+    await MapboxGL.offlineManager.resetDatabase();
+    Alert.alert('Database successfully reset');
+  };
+
+  clearAmbientCache = async () => {
+    await MapboxGL.offlineManager.clearAmbientCache();
+    Alert.alert('Ambient cache successfully cleared');
+  };
+
+  setMaximumAmbientCacheSize = async () => {
+    const newMaxSize = parseInt(this.state.cacheSize, 10);
+    await MapboxGL.offlineManager.setMaximumAmbientCacheSize(newMaxSize);
+    Alert.alert(`Max cache size successfully set to ${newMaxSize} bytes`);
+  };
+
+  validateCacheInputValue = (value) => !isNaN(parseInt(value, 10));
+
+  onChangeCacheSize = (cacheSize) => this.setState({cacheSize});
+
+  render() {
+    const validSizeValue = this.validateCacheInputValue(this.state.cacheSize);
+    const buttonStyles = validSizeValue
+      ? styles.button
+      : [styles.button, {backgroundColor: 'grey'}];
+
+    return (
+      <Page {...this.props}>
+        <MapView style={sheet.matchParent}>
+          <Camera zoomLevel={16} centerCoordinate={DEFAULT_CENTER_COORDINATE} />
+        </MapView>
+
+        <View style={styles.controls}>
+          <View style={styles.controlsContainer}>
+            <View style={styles.control}>
+              <TouchableOpacity
+                onPress={this.invalidateAmbientCache}
+                style={styles.button}>
+                <Text style={styles.buttonTxt}>Invalidate cache</Text>
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.control}>
+              <TouchableOpacity
+                onPress={this.resetDatabase}
+                style={styles.button}>
+                <Text style={styles.buttonTxt}>Reset database</Text>
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.control}>
+              <TextInput
+                onChangeText={this.onChangeCacheSize}
+                value={this.state.cacheSize}
+                placeholder="New max"
+                keyboardType="numeric"
+                style={styles.textInput}
+              />
+              <TouchableOpacity
+                onPress={this.setMaximumAmbientCacheSize}
+                style={buttonStyles}
+                disabled={!validSizeValue}>
+                <Text style={styles.buttonTxt}>Set ambient max cache</Text>
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.control}>
+              <TouchableOpacity
+                onPress={this.clearAmbientCache}
+                style={styles.button}>
+                <Text style={styles.buttonTxt}>Clear ambient cache</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Page>
+    );
+  }
+}
+
+export default CacheManagement;

--- a/example/src/scenes/Home.js
+++ b/example/src/scenes/Home.js
@@ -52,6 +52,7 @@ import CompassView from '../examples/CompassView';
 import BugReportTemplate from '../examples/BugReportExample';
 import StyleJson from '../examples/StyleJson';
 import ShapeSourceTS from '../examples/SymbolCircleLayer/ShapeSource';
+import CacheManagement from '../examples/CacheManagement';
 
 const styles = StyleSheet.create({
   header: {
@@ -173,6 +174,7 @@ const Examples = [
     new ExampleItem('Yo Yo Camera', YoYo),
   ]),
   new ExampleItem('Bug Report Template', BugReportPage),
+  new ExampleItem('Cache management', CacheManagement),
 ];
 
 function ExampleGroupComponent({items, navigation, showBack}) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -273,6 +273,9 @@ declare namespace MapboxGL {
     deletePack(name: string): Promise<void>;
     getPacks(): Promise<Array<OfflinePack>>;
     getPack(name: string): Promise<OfflinePack | undefined>;
+    invalidateAmbientCache(): Promise<void>;
+    clearAmbientCache(): Promise<void>;
+    setMaximumAmbientCacheSize(size: number): Promise<void>;
     resetDatabase(): Promise<void>;
     setTileCountLimit(limit: number): void;
     setProgressEventThrottle(throttleValue: number): void;

--- a/ios/RCTMGL/MGLOfflineModule.m
+++ b/ios/RCTMGL/MGLOfflineModule.m
@@ -165,6 +165,31 @@ RCT_EXPORT_METHOD(invalidateAmbientCache:(RCTPromiseResolveBlock)resolve rejecte
     }];
 }
 
+RCT_EXPORT_METHOD(clearAmbientCache:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [[MGLOfflineStorage sharedOfflineStorage] clearAmbientCacheWithCompletionHandler:^(NSError *error) {
+        if (error != nil) {
+            reject(@"clearAmbientCache", error.description, error);
+            return;
+        }
+        resolve(nil);
+    }];
+}
+
+RCT_EXPORT_METHOD(setMaximumAmbientCacheSize:(NSUInteger)cacheSize
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [[MGLOfflineStorage sharedOfflineStorage] setMaximumAmbientCacheSize:cacheSize withCompletionHandler:^(NSError *error) {
+        if (error != nil) {
+            reject(@"setMaximumAmbientCacheSize", error.description, error);
+            return;
+        }
+        resolve(nil);
+    }];
+    
+}
+
 RCT_EXPORT_METHOD(resetDatabase:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     [[MGLOfflineStorage sharedOfflineStorage] resetDatabaseWithCompletionHandler:^(NSError *error) {

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -131,6 +131,35 @@ class OfflineManager {
   }
 
   /**
+   * Erases resources from the ambient cache.
+   * This method clears the cache and decreases the amount of space that map resources take up on the device.
+   *
+   * @example
+   * await MapboxGL.offlineManager.clearAmbientCache();
+   *
+   * @return {void}
+   */
+  async clearAmbientCache() {
+    await this._initialize();
+    await MapboxGLOfflineManager.clearAmbientCache();
+  }
+
+  /**
+   * Sets the maximum size of the ambient cache in bytes. Disables the ambient cache if set to 0.
+   * This method may be computationally expensive because it will erase resources from the ambient cache if its size is decreased.
+   *
+   * @example
+   * await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);
+   *
+   * @param  {Number}  size  Size of ambient cache.
+   * @return {void}
+   */
+  async setMaximumAmbientCacheSize(size) {
+    await this._initialize();
+    await MapboxGLOfflineManager.setMaximumAmbientCacheSize(size);
+  }
+
+  /**
    * Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.
    *
    * @example


### PR DESCRIPTION
#902 

This PR provides two additional methods to control mapbox cache `clearAmbientCache` and `setMaximumAmbientCacheSize`.  Also, this PR includes a new page 'Cache Management' in the example app, where those methods can be easily tested. In addition to them, I have included two others: `invalidateAmbientCache` and `resetDatabase`, which have been implemented earlier #899. 
<img width="464" alt="Screenshot 2020-06-19 at 12 34 48" src="https://user-images.githubusercontent.com/10786814/85120388-daa7f680-b22b-11ea-8f6e-b61cc5510457.png">
