### PR TITLE
add invalidatePack method

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -220,6 +220,43 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void invalidatePack(final String name, final Promise promise) {
+        activateFileSource();
+
+        final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);
+
+        offlineManager.listOfflineRegions(new OfflineManager.ListOfflineRegionsCallback() {
+            @Override
+            public void onList(OfflineRegion[] offlineRegions) {
+                OfflineRegion region = getRegionByName(name, offlineRegions);
+
+                if (region == null) {
+                    promise.resolve(null);
+                    Log.w(REACT_CLASS, "invalidateRegion - Unknown offline region");
+                    return;
+                }
+
+                region.invalidate(new OfflineRegion.OfflineRegionInvalidateCallback() {
+                    @Override
+                    public void onInvalidate() {
+                        promise.resolve(null);
+                    }
+
+                    @Override
+                    public void onError(String error) {
+                        promise.reject("invalidateRegion", error);
+                    }
+                });
+            }
+
+            @Override
+            public void onError(String error) {
+                promise.reject("invalidateRegion", error);
+            }
+        });
+    }
+
+    @ReactMethod
     public void deletePack(final String name, final Promise promise) {
         activateFileSource();
 

--- a/docs/OfflineManager.md
+++ b/docs/OfflineManager.md
@@ -31,6 +31,22 @@ await MapboxGL.offlineManager.createPack({
 ```
 
 
+#### invalidatePack(name)
+
+Invalidates the specified offline pack. This method checks that the tiles in the specified offline pack match those from the server. Local tiles that do not match the latest version on the server are updated.This is more efficient than deleting the offline pack and downloading it again. If the data stored locally matches that on the server, new data will not be downloaded.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `name` | `String` | `Yes` | Name of the offline pack. |
+
+
+
+```javascript
+await MapboxGL.offlineManager.invalidatePack('packName')
+```
+
+
 #### deletePack(name)
 
 Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5578,6 +5578,29 @@
         }
       },
       {
+        "name": "invalidatePack",
+        "description": "Invalidates the specified offline pack. This method checks that the tiles in the specified offline pack match those from the server. Local tiles that do not match the latest version on the server are updated.This is more efficient than deleting the offline pack and downloading it again. If the data stored locally matches that on the server, new data will not be downloaded.",
+        "params": [
+          {
+            "name": "name",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.invalidatePack('packName')"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
         "name": "deletePack",
         "description": "Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.",
         "params": [

--- a/ios/RCTMGL/MGLOfflineModule.m
+++ b/ios/RCTMGL/MGLOfflineModule.m
@@ -192,6 +192,25 @@ RCT_EXPORT_METHOD(getPackStatus:(NSString *)name
     resolve([self _makeRegionStatusPayload:name pack:pack]);
 }
 
+RCT_EXPORT_METHOD(invalidatePack:(NSString *)name
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    MGLOfflinePack *pack = [self _getPackFromName:name];
+
+    if (pack == nil) {
+        resolve(nil);
+        return;
+    }
+    [[MGLOfflineStorage sharedOfflineStorage] invalidatePack:pack  withCompletionHandler:^(NSError *error) {
+        if (error != nil) {
+            reject(@"invalidatePack", error.description, error);
+            return;
+        }
+        resolve(nil);
+    }];
+}
+
 RCT_EXPORT_METHOD(deletePack:(NSString *)name
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -68,6 +68,30 @@ class OfflineManager {
   }
 
   /**
+   * Invalidates the specified offline pack. This method checks that the tiles in the specified offline pack match those from the server. Local tiles that do not match the latest version on the server are updated.
+   *
+   * This is more efficient than deleting the offline pack and downloading it again. If the data stored locally matches that on the server, new data will not be downloaded.
+   *
+   * @example
+   * await MapboxGL.offlineManager.invalidatePack('packName')
+   *
+   * @param  {String}  name  Name of the offline pack.
+   * @return {void}
+   */
+  async invalidatePack(name) {
+    if (!name) {
+      return;
+    }
+
+    await this._initialize();
+
+    const offlinePack = this._offlinePacks[name];
+    if (offlinePack) {
+      await MapboxGLOfflineManager.invalidatePack(name);
+    }
+  }
+
+  /**
    * Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.
    *
    * @example


### PR DESCRIPTION
This adds the invalidatePack method that is available in both the iOS and Android SDKs. Tested and working as expected in my app.

I didn't add it to the Examples project because, like invalidateAmbientCache, it is difficult to demonstrate it working without the vector tile service changing its tiles.