### PR TITLE
feat(TS): add 'null' as argument type for setAccessToken

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,7 +111,7 @@ export type OnPressEvent = {
 declare namespace MapboxGL {
   function removeCustomHeader(headerName: string): void;
   function addCustomHeader(headerName: string, headerValue: string): void;
-  function setAccessToken(accessToken: string): void;
+  function setAccessToken(accessToken: string | null): void;
   function getAccessToken(): Promise<void>;
   function setTelemetryEnabled(telemetryEnabled: boolean): void;
   function setConnected(connected: boolean): void;


### PR DESCRIPTION
Based on feedback from #293.

NB: https://github.com/react-native-mapbox-gl/maps/blob/a60ae1509b6c3f7f417476ac066fc64f4d6920fe/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java#L339

Will throw a null pointer exception when trying to `setTelemetryEnabled` without setting an accessToken.
```sh
java.lang.NullPointerException: Attempt to invoke interface method 'void com.mapbox.mapboxsdk.maps.TelemetryDefinition.setUserTelemetryRequestState(boolean)' on a null object reference
```

Follow-up ticket could be to remove the necessity to call `setAccessToken` when not using mapbox api at all.
Currently it's coupled with getting an instance:
https://github.com/react-native-mapbox-gl/maps/blob/a60ae1509b6c3f7f417476ac066fc64f4d6920fe/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java#L287-L295


