### PR TITLE
Allow to customize used framework version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
     - brew cleanup
     podfile: example/ios/Podfile
 before_install:
+- nvm use 10.18.1 
 - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1
 - export PATH=$HOME/.yarn/bin:$PATH
 install:

--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -2,6 +2,9 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
+
+REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION = ENV["REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION"] || '~> 5.8'
+
 Pod::Spec.new do |s|
   s.name		= "react-native-mapbox-gl"
   s.summary		= "React Native Component for Mapbox GL"
@@ -12,7 +15,7 @@ Pod::Spec.new do |s|
   s.license     	= "MIT"
   s.platform    	= :ios, "8.0"
 
-  s.dependency 'Mapbox-iOS-SDK', '~> 5.8'
+  s.dependency 'Mapbox-iOS-SDK', REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION
   s.dependency 'React'
 
   s.subspec 'DynamicLibrary' do |sp|
@@ -23,7 +26,7 @@ Pod::Spec.new do |s|
     s.default_subspecs= ['DynamicLibrary']
   else
     s.subspec 'StaticLibraryFixer' do |sp|
-      s.dependency '@react-native-mapbox-gl-mapbox-static', '~> 5.8'
+      s.dependency '@react-native-mapbox-gl-mapbox-static', REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION
     end
 
     s.default_subspecs= ['DynamicLibrary', 'StaticLibraryFixer']

--- a/scripts/autogenerate.js
+++ b/scripts/autogenerate.js
@@ -21,7 +21,7 @@ function readIosVersion() {
     'react-native-mapbox-gl.podspec',
   );
   const lines = fs.readFileSync(podspecPath, 'utf8').split('\n');
-  const mapboxLineRegex = /^\s+s\.dependency\s+'Mapbox-iOS-SDK', '~>\s+(\d+\.\d+)'$/;
+  const mapboxLineRegex = /^REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION\s*=\s*.+'~>\s+(\d+\.\d+)'$/;
   const mapboxLine = lines.filter(i => mapboxLineRegex.exec(i))[0];
   return `${mapboxLineRegex.exec(mapboxLine)[1]}.0`;
 }


### PR DESCRIPTION
REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION="~> 5.7" pod install

```
REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION="~> 5.6.0" pod install --repo-update
```

or add
```
ENV['REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION'] = '~> 5.6.0'
```
to your podfile before 
```
use_native_modules!
```