### PR TITLE
fix(camera): heading example

### DIFF
--- a/example/src/examples/SetHeading.js
+++ b/example/src/examples/SetHeading.js
@@ -18,6 +18,7 @@ class SetHeading extends React.Component {
       heading: 0,
       zoomLevel: 16,
       animationDuration: 150,
+      followUserLocation: true,
     };
 
     this._bearingOptions = [
@@ -31,6 +32,12 @@ class SetHeading extends React.Component {
 
   componentDidMount() {
     MapboxGL.locationManager.start();
+  }
+
+  componentDidUpdate() {
+    if (this.state.followUserLocation) {
+      this.setState({followUserLocation: false});
+    }
   }
 
   componentWillUnmount() {
@@ -50,7 +57,7 @@ class SetHeading extends React.Component {
         <MapboxGL.MapView
           ref={(ref) => (this.map = ref)}
           style={sheet.matchParent}>
-          <MapboxGL.Camera {...this.state} followUserLocation />
+          <MapboxGL.Camera {...this.state} />
           <MapboxGL.UserLocation />
         </MapboxGL.MapView>
       </TabBarPage>


### PR DESCRIPTION
`followUserLocation` prevents heading from being applied
have it enabled initially to get user location and disable afterwards
heading is now correctly applied when pushing option buttons