### PR TITLE
Expose onDrag callback for iOS and Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotation.java
@@ -236,6 +236,12 @@ public class RCTMGLPointAnnotation extends AbstractMapFeature implements View.On
         mManager.handleEvent(makeDragEvent(EventTypes.ANNOTATION_DRAG_START));
     }
 
+    public void onDrag() {
+        LatLng latLng = mAnnotation.getLatLng();
+        mCoordinate = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
+        mManager.handleEvent(makeDragEvent(EventTypes.ANNOTATION_DRAG));
+    }
+
     public void onDragEnd() {
         LatLng latLng = mAnnotation.getLatLng();
         mCoordinate = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotationManager.java
@@ -31,6 +31,7 @@ public class RCTMGLPointAnnotationManager extends AbstractEventEmitter<RCTMGLPoi
                 .put(EventKeys.POINT_ANNOTATION_SELECTED, "onMapboxPointAnnotationSelected")
                 .put(EventKeys.POINT_ANNOTATION_DESELECTED, "onMapboxPointAnnotationDeselected")
                 .put(EventKeys.POINT_ANNOTATION_DRAG_START, "onMapboxPointAnnotationDragStart")
+                .put(EventKeys.POINT_ANNOTATION_DRAG, "onMapboxPointAnnotationDrag")
                 .put(EventKeys.POINT_ANNOTATION_DRAG_END, "onMapboxPointAnnotationDragEnd")
                 .build();
     }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -505,9 +505,12 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
             }
 
             @Override
-            // Left empty on purpose
             public void onAnnotationDrag(Symbol symbol) {
-
+                final long selectedMarkerID = symbol.getId();
+                RCTMGLPointAnnotation annotation = getPointAnnotationByMarkerID(selectedMarkerID);
+                if (annotation != null) {
+                    annotation.onDrag();
+                }
             }
 
             @Override

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/PointAnnotationDragEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/PointAnnotationDragEvent.java
@@ -28,7 +28,16 @@ public class PointAnnotationDragEvent extends MapClickEvent {
 
     @Override
     public String getKey() {
-        return getType().equals(EventTypes.ANNOTATION_DRAG_START) ? EventKeys.POINT_ANNOTATION_DRAG_START : EventKeys.POINT_ANNOTATION_DRAG_END;
+        String eventType = getType();
+
+        if (eventType.equals(EventTypes.ANNOTATION_DRAG_START)) {
+            return EventKeys.POINT_ANNOTATION_DRAG_START;
+        }
+        if (eventType.equals(EventTypes.ANNOTATION_DRAG_END)) {
+            return EventKeys.POINT_ANNOTATION_DRAG_END;
+        }
+
+        return EventKeys.POINT_ANNOTATION_DRAG;
     }
 
     @Override

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventKeys.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventKeys.java
@@ -19,6 +19,7 @@ public class EventKeys {
     public static final String POINT_ANNOTATION_SELECTED = ns("pointannotation.selected");
     public static final String POINT_ANNOTATION_DESELECTED = ns("pointannotation.deselected");
     public static final String POINT_ANNOTATION_DRAG_START = ns("pointannotation.dragstart");
+    public static final String POINT_ANNOTATION_DRAG = ns("pointannotation.drag");
     public static final String POINT_ANNOTATION_DRAG_END = ns("pointannotation.dragend");
 
     // source events

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventTypes.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/constants/EventTypes.java
@@ -33,6 +33,7 @@ public class EventTypes {
     public static final String ANNOTATION_SELECTED = "annotationselected";
     public static final String ANNOTATION_DESELECTED = "annotationdeselected";
     public static final String ANNOTATION_DRAG_START = "annotationdragstart";
+    public static final String ANNOTATION_DRAG = "annotationdrag";
     public static final String ANNOTATION_DRAG_END = "annotationdragend";
 
     // offline event types

--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -18,6 +18,7 @@
 | onDeselected | `func` | `none` | `false` | This callback is fired once this annotation is deselected. |
 | onDragStart | `func` | `none` | `false` | This callback is fired once this annotation has started being dragged. |
 | onDragEnd | `func` | `none` | `false` | This callback is fired once this annotation has stopped being dragged. |
+| onDrag | `func` | `none` | `false` | This callback is fired during this annotation is being dragged. |
 
 ### methods
 #### refresh()

--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -18,7 +18,7 @@
 | onDeselected | `func` | `none` | `false` | This callback is fired once this annotation is deselected. |
 | onDragStart | `func` | `none` | `false` | This callback is fired once this annotation has started being dragged. |
 | onDragEnd | `func` | `none` | `false` | This callback is fired once this annotation has stopped being dragged. |
-| onDrag | `func` | `none` | `false` | This callback is fired during this annotation is being dragged. |
+| onDrag | `func` | `none` | `false` | This callback is fired while this annotation is being dragged. |
 
 ### methods
 #### refresh()

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3194,7 +3194,7 @@
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "This callback is fired during this annotation is being dragged."
+        "description": "This callback is fired while this annotation is being dragged."
       }
     ],
     "composes": [

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3188,6 +3188,13 @@
         "type": "func",
         "default": "none",
         "description": "This callback is fired once this annotation has stopped being dragged."
+      },
+      {
+        "name": "onDrag",
+        "required": false,
+        "type": "func",
+        "default": "none",
+        "description": "This callback is fired during this annotation is being dragged."
       }
     ],
     "composes": [

--- a/example/src/examples/ShowPointAnnotation.js
+++ b/example/src/examples/ShowPointAnnotation.js
@@ -41,6 +41,10 @@ class AnnotationWithRemoteImage extends React.Component {
         id={id}
         coordinate={coordinate}
         title={title}
+        draggable
+        onDrag={(e) => console.log(e.properties.id, e.geometry.coordinates)}
+        onDragStart={(e) => console.log(e.properties.id, e.geometry.coordinates)}
+        onDragEnd={(e) => console.log(e.properties.id, e.geometry.coordinates)}
         ref={(ref) => (this.annotationRef = ref)}>
         <View style={styles.annotationContainer}>
           <Image

--- a/example/src/examples/ShowPointAnnotation.js
+++ b/example/src/examples/ShowPointAnnotation.js
@@ -42,9 +42,9 @@ class AnnotationWithRemoteImage extends React.Component {
         coordinate={coordinate}
         title={title}
         draggable
-        onDrag={(e) => console.log(e.properties.id, e.geometry.coordinates)}
-        onDragStart={(e) => console.log(e.properties.id, e.geometry.coordinates)}
-        onDragEnd={(e) => console.log(e.properties.id, e.geometry.coordinates)}
+        onDrag={(e) => console.log('onDrag:', e.properties.id, e.geometry.coordinates)}
+        onDragStart={(e) => console.log('onDragStart:', e.properties.id, e.geometry.coordinates)}
+        onDragEnd={(e) => console.log('onDragEnd:', e.properties.id, e.geometry.coordinates)}
         ref={(ref) => (this.annotationRef = ref)}>
         <View style={styles.annotationContainer}>
           <Image

--- a/index.d.ts
+++ b/index.d.ts
@@ -684,6 +684,9 @@ export interface PointAnnotationProps {
   anchor?: Point;
   onSelected?: () => void;
   onDeselected?: () => void;
+  onDragStart?: () => void;
+  onDrag?: () => void;
+  onDragEnd?: () => void;
 }
 
 export interface MarkerViewProps extends PointAnnotationProps {

--- a/index.d.ts
+++ b/index.d.ts
@@ -680,6 +680,7 @@ export interface PointAnnotationProps {
   title?: string;
   snippet?: string;
   selected?: boolean;
+  draggable?: boolean;
   coordinate: GeoJSON.Position;
   anchor?: Point;
   onSelected?: () => void;

--- a/ios/RCTMGL/RCTMGLMapTouchEvent.h
+++ b/ios/RCTMGL/RCTMGLMapTouchEvent.h
@@ -20,5 +20,6 @@
 + (RCTMGLMapTouchEvent*)makeTapEvent:(MGLMapView*)mapView withPoint:(CGPoint)point;
 + (RCTMGLMapTouchEvent*)makeLongPressEvent:(MGLMapView*)mapView withPoint:(CGPoint)point;
 + (RCTMGLMapTouchEvent *)makeAnnotationTapEvent:(RCTMGLPointAnnotation *)pointAnnotation;
++ (RCTMGLMapTouchEvent *)makeAnnotationTapEventOnDrag:(RCTMGLPointAnnotation *)pointAnnotation;
 
 @end

--- a/ios/RCTMGL/RCTMGLMapTouchEvent.m
+++ b/ios/RCTMGL/RCTMGLMapTouchEvent.m
@@ -52,11 +52,24 @@
     return event;
 }
 
++ (RCTMGLMapTouchEvent *)makeAnnotationTapEventOnDrag:(RCTMGLPointAnnotation *)pointAnnotation
+{
+    RCTMGLMapTouchEvent *event = [[RCTMGLMapTouchEvent alloc] init];
+    event.type = RCT_MAPBOX_ANNOTATION_TAP;
+    event.id = pointAnnotation.id;
+    CGPoint screenPoint = [pointAnnotation.superview convertPoint:pointAnnotation.layer.position toView:nil];
+    screenPoint.x -= (pointAnnotation.layer.bounds.size.width * pointAnnotation.layer.anchorPoint.x);
+    screenPoint.y -= (pointAnnotation.layer.bounds.size.height * pointAnnotation.layer.anchorPoint.y);
+    event.screenPoint = screenPoint;
+    event.coordinate =  [pointAnnotation.map convertPoint:pointAnnotation.layer.position toCoordinateFromView:pointAnnotation.map];
+    return event;
+}
+
 + (RCTMGLMapTouchEvent*)_fromPoint:(CGPoint)point withMapView:(MGLMapView *)mapView andEventType:(NSString*)eventType
 {
     RCTMGLMapTouchEvent *event = [[RCTMGLMapTouchEvent alloc] init];
     event.type = eventType;
-    event.coordinate =[mapView convertPoint:point toCoordinateFromView:mapView];
+    event.coordinate = [mapView convertPoint:point toCoordinateFromView:mapView];
     event.screenPoint = point;
     return event;
 }

--- a/ios/RCTMGL/RCTMGLPointAnnotation.h
+++ b/ios/RCTMGL/RCTMGLPointAnnotation.h
@@ -30,6 +30,7 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onSelected;
 @property (nonatomic, copy) RCTBubblingEventBlock onDeselected;
 @property (nonatomic, copy) RCTBubblingEventBlock onDragStart;
+@property (nonatomic, copy) RCTBubblingEventBlock onDrag;
 @property (nonatomic, copy) RCTBubblingEventBlock onDragEnd;
 
 @property (nonatomic, assign) BOOL reactSelected;

--- a/ios/RCTMGL/RCTMGLPointAnnotation.m
+++ b/ios/RCTMGL/RCTMGLPointAnnotation.m
@@ -229,6 +229,10 @@ const float CENTER_Y_OFFSET_BASE = -0.5f;
         }
 
         case MGLAnnotationViewDragStateDragging:
+            if (self.onDrag != nil) {
+                RCTMGLMapTouchEvent *event = [RCTMGLMapTouchEvent makeAnnotationTapEventOnDrag:self];
+                self.onDrag([event toJSON]);
+            }
             break;
 
         case MGLAnnotationViewDragStateEnding:

--- a/ios/RCTMGL/RCTMGLPointAnnotationManager.m
+++ b/ios/RCTMGL/RCTMGLPointAnnotationManager.m
@@ -25,6 +25,7 @@ RCT_REMAP_VIEW_PROPERTY(draggable, reactDraggable, BOOL)
 RCT_REMAP_VIEW_PROPERTY(onMapboxPointAnnotationSelected, onSelected, RCTBubblingEventBlock)
 RCT_REMAP_VIEW_PROPERTY(onMapboxPointAnnotationDeselected, onDeselected, RCTBubblingEventBlock)
 RCT_REMAP_VIEW_PROPERTY(onMapboxPointAnnotationDragStart, onDragStart, RCTBubblingEventBlock)
+RCT_REMAP_VIEW_PROPERTY(onMapboxPointAnnotationDrag, onDrag, RCTBubblingEventBlock)
 RCT_REMAP_VIEW_PROPERTY(onMapboxPointAnnotationDragEnd, onDragEnd, RCTBubblingEventBlock)
 
 - (UIView *)view

--- a/javascript/components/PointAnnotation.js
+++ b/javascript/components/PointAnnotation.js
@@ -93,8 +93,8 @@ class PointAnnotation extends React.PureComponent {
     onDragEnd: PropTypes.func,
 
     /**
-    * This callback is fired during this annotation is being dragged.
-    */
+     * This callback is fired while this annotation is being dragged.
+     */
     onDrag: PropTypes.func,
   };
 

--- a/javascript/components/PointAnnotation.js
+++ b/javascript/components/PointAnnotation.js
@@ -91,6 +91,11 @@ class PointAnnotation extends React.PureComponent {
      * This callback is fired once this annotation has stopped being dragged.
      */
     onDragEnd: PropTypes.func,
+
+    /**
+    * This callback is fired during this annotation is being dragged.
+    */
+    onDrag: PropTypes.func,
   };
 
   static defaultProps = {
@@ -103,6 +108,7 @@ class PointAnnotation extends React.PureComponent {
     this._onSelected = this._onSelected.bind(this);
     this._onDeselected = this._onDeselected.bind(this);
     this._onDragStart = this._onDragStart.bind(this);
+    this._onDrag = this._onDrag.bind(this);
     this._onDragEnd = this._onDragEnd.bind(this);
   }
 
@@ -121,6 +127,12 @@ class PointAnnotation extends React.PureComponent {
   _onDragStart(e) {
     if (isFunction(this.props.onDragStart)) {
       this.props.onDragStart(e.nativeEvent.payload);
+    }
+  }
+
+  _onDrag(e) {
+    if (isFunction(this.props.onDrag)) {
+      this.props.onDrag(e.nativeEvent.payload);
     }
   }
 
@@ -161,6 +173,7 @@ class PointAnnotation extends React.PureComponent {
       onMapboxPointAnnotationSelected: this._onSelected,
       onMapboxPointAnnotationDeselected: this._onDeselected,
       onMapboxPointAnnotationDragStart: this._onDragStart,
+      onMapboxPointAnnotationDrag: this._onDrag,
       onMapboxPointAnnotationDragEnd: this._onDragEnd,
       coordinate: this._getCoordinate(),
     };
@@ -180,6 +193,7 @@ const RCTMGLPointAnnotation = requireNativeComponent(
       onMapboxPointAnnotationSelected: true,
       onMapboxPointAnnotationDeselected: true,
       onMapboxPointAnnotationDragStart: true,
+      onMapboxPointAnnotationDrag: true,
       onMapboxPointAnnotationDragEnd: true,
     },
   },


### PR DESCRIPTION
Expose onDrag callback for iOS and Android. As mapbox on iOS [does not update coordinates on dragging](https://github.com/mapbox/mapbox-gl-native-ios/issues/251), this adds the calculations.