### PR TITLE
fix(access-token): match iOS interface for getAccessToken() on Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLModule.java
@@ -3,7 +3,6 @@ package com.mapbox.rctmgl.modules;
 import android.os.Handler;
 import android.util.Log;
 
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -325,9 +324,12 @@ public class RCTMGLModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void getAccessToken(Promise promise) {
-        WritableMap map = Arguments.createMap();
-        map.putString("accessToken", Mapbox.getAccessToken());
-        promise.resolve(map);
+        String token = Mapbox.getAccessToken();
+        if(token == null) {
+            promise.reject("missing_access_token", "No access token has been set");
+        } else {
+            promise.resolve(token);
+        }
     }
 
     @ReactMethod

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,7 +112,7 @@ declare namespace MapboxGL {
   function removeCustomHeader(headerName: string): void;
   function addCustomHeader(headerName: string, headerValue: string): void;
   function setAccessToken(accessToken: string | null): void;
-  function getAccessToken(): Promise<void>;
+  function getAccessToken(): Promise<string>;
   function setTelemetryEnabled(telemetryEnabled: boolean): void;
   function setConnected(connected: boolean): void;
   function requestAndroidLocationPermissions(): Promise<boolean>;


### PR DESCRIPTION
This pull request addresses issue #937 

I replicated the behaviour of `getAccessToken()` on iOS in the native Android code. Both iOS and Android versions now return a promise that either resolves to a string, or is rejected if the access token is null. Previously, the Android version returned a promise that resolved to an object with an `accessToken` property having the value of the access token.

This is a breaking change, changing the interface of `getAccessToken()` on Android.

### Testing performed

I completed manual testing from a basic app similar to the [getting started example](https://github.com/react-native-mapbox-gl/maps/blob/master/docs/GettingStarted.md), not knowing how or if I should add tests for native Android code:
- `getAccessToken()` returns a string equal to the access token set previously through `setAccessToken()`.
- `getAccessToken()` rejects the promise with an error message if `null` was previously set as the access token through `setAccessToken()`.

I tested the basic app on an Android emulator (API level 28) and on a physical device (Google Pixel, Android 10 build number QP1A.191005.007.A3). The client app uses React Native Version 0.62.2.

I do not have an iOS development environment to test with.