### PR TITLE
fix(TS): geoJson errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,6 @@ import {
   LineString,
   Coord,
   Units,
-  Point,
   BBox,
   Id,
   FeatureCollection,
@@ -170,12 +169,12 @@ declare namespace MapboxGL {
       coordinate: GeoJSON.Position,
       filter?: Expression,
       layerIds?: Array<string>,
-    ): Promise<GeoJSON.FeatureCollection?>;
+    ): Promise<GeoJSON.FeatureCollection | undefined>;
     queryRenderedFeaturesInRect(
       coordinate: GeoJSON.Position,
       filter?: Expression,
       layerIds?: Array<string>,
-    ): Promise<GeoJSON.FeatureCollection?>;
+    ): Promise<GeoJSON.FeatureCollection | undefined>;
     takeSnap(writeToDisk?: boolean): Promise<string>;
     getZoom(): Promise<number>;
     getCenter(): Promise<GeoJSON.Position>;
@@ -364,7 +363,7 @@ export interface MapViewProps extends ViewProps {
   userTrackingMode?: MapboxGL.UserTrackingModes;
   userLocationVerticalAlignment?: number;
   contentInset?: Array<number>;
-  style?: StyleProp;
+  style?: StyleProp<ViewStyle>;
   styleURL?: string;
   localizeLabels?: boolean;
   zoomEnabled?: boolean;
@@ -721,14 +720,14 @@ export interface VectorSourceProps extends TileSourceProps {
 export interface ShapeSourceProps extends ViewProps {
   id?: string;
   url?: string;
-  shape?: GeoJSON.Geometries | GeoJSON.Feature | GeoJSON.FeatureCollection;
+  shape?: GeoJSON.GeometryCollection | GeoJSON.Feature | GeoJSON.FeatureCollection;
   cluster?: boolean;
   clusterRadius?: number;
   clusterMaxZoomLevel?: number;
   maxZoomLevel?: number;
   buffer?: number;
   tolerance?: number;
-  images?: {assets?: string[]; [key: string]: ImageSourcePropType};
+  images?: {assets?: string[]} & {[key: string]: ImageSourcePropType};
   onPress?: (event: OnPressEvent) => void;
   hitbox?: {
     width: number;
@@ -785,7 +784,7 @@ export interface HeatmapLayerProps extends LayerBaseProps {
 }
 
 export interface ImagesProps extends ViewProps {
-  images?: {assets?: string[]; [key: string]: ImageSourcePropType};
+  images?: {assets?: string[]} & {[key: string]: ImageSourcePropType};
 }
 
 export interface ImageSourceProps extends ViewProps {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@turf/nearest-point-on-line": ">= 4.0.0 <7.0.0",
     "@turf/helpers": ">= 4.6.0 <7.0.0",
     "@turf/length": ">= 4.6.0 <7.0.0",
+    "@types/geojson": "^7946.0.7",
     "debounce": "^1.2.0"
   },
   "devDependencies": {
@@ -49,7 +50,6 @@
     "@babel/plugin-transform-flow-strip-types": "7.10.1",
     "@babel/plugin-transform-runtime": "7.10.3",
     "@babel/runtime": "7.10.3",
-    "@types/geojson": "^7946.0.7",
     "babel-core": "6.26.3",
     "babel-eslint": "^10.0.1",
     "documentation": "13.0.1",


### PR DESCRIPTION
Fixes https://github.com/react-native-mapbox-gl/maps/issues/883

Fixes the TypeScript errors we are seeing in our app and mentioned in the above issue. Also moves `@types/geojson` from `devDependencies` to `dependencies` (could alternatively be a peer dependency I guess) - this is needed because those types are imported into the types definition for this package, so it's therefore not a dev dependency.