### PR TITLE
fix(marker-view): Add children propType check to MarkerView

### DIFF
--- a/docs/MarkerView.md
+++ b/docs/MarkerView.md
@@ -9,5 +9,6 @@
 | anchor | `shape` | `{x: 0.5, y: 0.5}` | `false` | Specifies the anchor being set on a particular point of the annotation.<br/>The anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],<br/>where (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.<br/>Note this is only for custom annotations not the default pin view.<br/>Defaults to the center of the view. |
 | &nbsp;&nbsp;x | `number` | `none` | `true` | FIX ME NO DESCRIPTION |
 | &nbsp;&nbsp;y | `number` | `none` | `true` | FIX ME NO DESCRIPTION |
+| children | `element` | `none` | `true` | Expects one child - can be container with multiple elements |
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3045,6 +3045,13 @@
         },
         "default": "{x: 0.5, y: 0.5}",
         "description": "Specifies the anchor being set on a particular point of the annotation.\nThe anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],\nwhere (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.\nNote this is only for custom annotations not the default pin view.\nDefaults to the center of the view."
+      },
+      {
+        "name": "children",
+        "required": true,
+        "type": "element",
+        "default": "none",
+        "description": "Expects one child - can be container with multiple elements"
       }
     ],
     "composes": [

--- a/javascript/components/MarkerView.js
+++ b/javascript/components/MarkerView.js
@@ -35,6 +35,9 @@ class MarkerView extends React.PureComponent {
       y: PropTypes.number.isRequired,
     }),
 
+    /**
+     * Expects one child - can be container with multiple elements
+     */
     children: PropTypes.element.isRequired,
   };
 

--- a/javascript/components/MarkerView.js
+++ b/javascript/components/MarkerView.js
@@ -34,6 +34,8 @@ class MarkerView extends React.PureComponent {
       x: PropTypes.number.isRequired,
       y: PropTypes.number.isRequired,
     }),
+
+    children: PropTypes.element.isRequired,
   };
 
   static defaultProps = {
@@ -57,6 +59,7 @@ class MarkerView extends React.PureComponent {
       anchor: this.props.anchor,
       coordinate: this._getCoordinate(),
     };
+
     return (
       <RCTMGLMarkerView {...props}>{this.props.children}</RCTMGLMarkerView>
     );


### PR DESCRIPTION
Based on this [ticket](https://github.com/react-native-mapbox-gl/maps/issues/962) added a propTypes check for the passed children. On more than one element, it will display a warning, which will hopefully help people when debugging issue with multiple unwrapped children.