### PR TITLE
Update FillExtrusionLayer.md

### DIFF
--- a/docs/FillExtrusionLayer.md
+++ b/docs/FillExtrusionLayer.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| id | `string` | `none` | `false` | A string that uniquely identifies the source in the style to which it is added. |
+| id | `string` | `none` | `true` | A string that uniquely identifies the source in the style to which it is added. |
 | sourceID | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined. |
 | sourceLayerID | `string` | `none` | `false` | Identifier of the layer within the source identified by the sourceID property from which the receiver obtains the data to style. |
 | aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |


### PR DESCRIPTION
This is actually a required field, else you run into an error.

`Cannot add a layer without id to the map: <RCTMGLFillExtrusionLayer: ...`

<img width="445" alt="Screen Shot 2020-07-25 at 6 35 11 PM" src="https://user-images.githubusercontent.com/15609358/88471458-94d2f380-cea5-11ea-94f9-180056ccaee7.png">
