### PR TITLE
Fixed issue with PointAnnotation refresh by using default native bridge, fixed types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -234,7 +234,9 @@ declare namespace MapboxGL {
     identity(attributeName: string): number;
   }
 
-  class PointAnnotation extends Component<PointAnnotationProps> {}
+  class PointAnnotation extends Component<PointAnnotationProps> {
+    refresh(): void;
+  }
   class MarkerView extends Component<MarkerViewProps> {}
   class Callout extends Component<CalloutProps> {}
   interface Style extends React.FC<StyleProps> {}


### PR DESCRIPTION
For me the `refresh` on `PointAnnotation` didn't work. The JS invoked `UIManager.dispatchViewManagerCommand` which never reached the native component.
With this fix, I let `PointAnnotation` use the "default" native bridge implementation used everywhere else and fixed the issue (so that the commands reach the native side).

Happy to see this merged 😊 if there is anything left to do for me, just tell so!