### PR TITLE
Fix a crash on setting property urls on Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLImageSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLImageSource.java
@@ -58,11 +58,11 @@ public class RCTMGLImageSource extends RCTSource<ImageSource> {
                 mURL = new URL(url);
 
                 if (mSource != null) {
-                    mSource.setUrl(mURL);
+                    mSource.setUri(mURL.toURI());
                 }
             }
 
-        } catch (MalformedURLException e) {
+        } catch (Exception e) {
             Log.w(LOG_TAG, e.getLocalizedMessage());
         }
     }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLImageSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLImageSourceManager.java
@@ -56,7 +56,7 @@ public class RCTMGLImageSourceManager extends ViewGroupManager<RCTMGLImageSource
 
     @ReactProp(name = "url")
     public void setUrl(RCTMGLImageSource source, String url) {
-        source .setURL(url);
+        source.setURL(url);
     }
 
     @ReactProp(name = "coordinates")


### PR DESCRIPTION
This happens only on Android, iOS does not seem to be affected.

- setting url property is catched
- use non deprecated setUri call

![Screenshot_1595424467](https://user-images.githubusercontent.com/24293447/89156724-7044de80-d56b-11ea-98f9-f34320e27c26.png)