### PR TITLE
fix(layer, sources): id is required

### DIFF
--- a/docs/BackgroundLayer.md
+++ b/docs/BackgroundLayer.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| id | `string` | `none` | `false` | A string that uniquely identifies the source in the style to which it is added. |
+| id | `string` | `none` | `true` | A string that uniquely identifies the source in the style to which it is added. |
 | sourceID | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined. |
 | sourceLayerID | `string` | `none` | `false` | Identifier of the layer within the source identified by the sourceID property from which the receiver obtains the data to style. |
 | aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |

--- a/docs/CircleLayer.md
+++ b/docs/CircleLayer.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| id | `string` | `none` | `false` | A string that uniquely identifies the source in the style to which it is added. |
+| id | `string` | `none` | `true` | A string that uniquely identifies the source in the style to which it is added. |
 | sourceID | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | The source from which to obtain the data to style.<br/>If the source has not yet been added to the current style, the behavior is undefined. |
 | sourceLayerID | `string` | `none` | `false` | Identifier of the layer within the source identified by the sourceID property<br/>from which the receiver obtains the data to style. |
 | aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |

--- a/docs/FillExtrusionLayer.md
+++ b/docs/FillExtrusionLayer.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| id | `string` | `none` | `false` | A string that uniquely identifies the source in the style to which it is added. |
+| id | `string` | `none` | `true` | A string that uniquely identifies the source in the style to which it is added. |
 | sourceID | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined. |
 | sourceLayerID | `string` | `none` | `false` | Identifier of the layer within the source identified by the sourceID property from which the receiver obtains the data to style. |
 | aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |

--- a/docs/FillLayer.md
+++ b/docs/FillLayer.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| id | `string` | `none` | `false` | A string that uniquely identifies the source in the style to which it is added. |
+| id | `string` | `none` | `true` | A string that uniquely identifies the source in the style to which it is added. |
 | sourceID | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined. |
 | sourceLayerID | `string` | `none` | `false` | Identifier of the layer within the source identified by the sourceID property from which the receiver obtains the data to style. |
 | aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |

--- a/docs/HeatmapLayer.md
+++ b/docs/HeatmapLayer.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| id | `string` | `none` | `false` | A string that uniquely identifies the source in the style to which it is added. |
+| id | `string` | `none` | `true` | A string that uniquely identifies the source in the style to which it is added. |
 | sourceID | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | The source from which to obtain the data to style.<br/>If the source has not yet been added to the current style, the behavior is undefined. |
 | sourceLayerID | `string` | `none` | `false` | Identifier of the layer within the source identified by the sourceID property<br/>from which the receiver obtains the data to style. |
 | aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |

--- a/docs/ImageSource.md
+++ b/docs/ImageSource.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| id | `string` | `none` | `false` | A string that uniquely identifies the source. |
+| id | `string` | `none` | `true` | A string that uniquely identifies the source. |
 | url | `union` | `none` | `false` | An HTTP(S) URL, absolute file URL, or local file URL to the source image.<br/>Gifs are currently not supported. |
 | coordinates | `array` | `none` | `true` | The top left, top right, bottom right, and bottom left coordinates for the image. |
 

--- a/docs/LineLayer.md
+++ b/docs/LineLayer.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| id | `string` | `none` | `false` | A string that uniquely identifies the source in the style to which it is added. |
+| id | `string` | `none` | `true` | A string that uniquely identifies the source in the style to which it is added. |
 | sourceID | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | The source from which to obtain the data to style.<br/>If the source has not yet been added to the current style, the behavior is undefined. |
 | sourceLayerID | `string` | `none` | `false` | Identifier of the layer within the source identified by the sourceID property from which the receiver obtains the data to style. |
 | aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |

--- a/docs/RasterLayer.md
+++ b/docs/RasterLayer.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| id | `string` | `none` | `false` | A string that uniquely identifies the source in the style to which it is added. |
+| id | `string` | `none` | `true` | A string that uniquely identifies the source in the style to which it is added. |
 | sourceID | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined. |
 | sourceLayerID | `string` | `none` | `false` | Identifier of the layer within the source identified by the sourceID property from which the receiver obtains the data to style. |
 | aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |

--- a/docs/SymbolLayer.md
+++ b/docs/SymbolLayer.md
@@ -5,7 +5,7 @@
 ### props
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
-| id | `string` | `none` | `false` | A string that uniquely identifies the source in the style to which it is added. |
+| id | `string` | `none` | `true` | A string that uniquely identifies the source in the style to which it is added. |
 | sourceID | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined. |
 | sourceLayerID | `string` | `none` | `false` | Identifier of the layer within the source identified by the sourceID property from which the receiver obtains the data to style. |
 | aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -6,7 +6,7 @@
     "props": [
       {
         "name": "id",
-        "required": false,
+        "required": true,
         "type": "string",
         "default": "none",
         "description": "A string that uniquely identifies the source in the style to which it is added."
@@ -749,7 +749,7 @@
     "props": [
       {
         "name": "id",
-        "required": false,
+        "required": true,
         "type": "string",
         "default": "none",
         "description": "A string that uniquely identifies the source in the style to which it is added."
@@ -1341,7 +1341,7 @@
     "props": [
       {
         "name": "id",
-        "required": false,
+        "required": true,
         "type": "string",
         "default": "none",
         "description": "A string that uniquely identifies the source in the style to which it is added."
@@ -1601,7 +1601,7 @@
     "props": [
       {
         "name": "id",
-        "required": false,
+        "required": true,
         "type": "string",
         "default": "none",
         "description": "A string that uniquely identifies the source in the style to which it is added."
@@ -1818,7 +1818,7 @@
     "props": [
       {
         "name": "id",
-        "required": false,
+        "required": true,
         "type": "string",
         "default": "none",
         "description": "A string that uniquely identifies the source."
@@ -2000,7 +2000,7 @@
     "props": [
       {
         "name": "id",
-        "required": false,
+        "required": true,
         "type": "string",
         "default": "none",
         "description": "A string that uniquely identifies the source in the style to which it is added."
@@ -3216,7 +3216,7 @@
     "props": [
       {
         "name": "id",
-        "required": false,
+        "required": true,
         "type": "string",
         "default": "none",
         "description": "A string that uniquely identifies the source in the style to which it is added."
@@ -3751,7 +3751,7 @@
     "props": [
       {
         "name": "id",
-        "required": false,
+        "required": true,
         "type": "string",
         "default": "none",
         "description": "A string that uniquely identifies the source in the style to which it is added."

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1090,7 +1090,7 @@
     "props": [
       {
         "name": "id",
-        "required": false,
+        "required": true,
         "type": "string",
         "default": "none",
         "description": "A string that uniquely identifies the source in the style to which it is added."

--- a/example/src/examples/ShowPointAnnotation.js
+++ b/example/src/examples/ShowPointAnnotation.js
@@ -42,9 +42,15 @@ class AnnotationWithRemoteImage extends React.Component {
         coordinate={coordinate}
         title={title}
         draggable
-        onDrag={(e) => console.log('onDrag:', e.properties.id, e.geometry.coordinates)}
-        onDragStart={(e) => console.log('onDragStart:', e.properties.id, e.geometry.coordinates)}
-        onDragEnd={(e) => console.log('onDragEnd:', e.properties.id, e.geometry.coordinates)}
+        onDrag={(e) =>
+          console.log('onDrag:', e.properties.id, e.geometry.coordinates)
+        }
+        onDragStart={(e) =>
+          console.log('onDragStart:', e.properties.id, e.geometry.coordinates)
+        }
+        onDragEnd={(e) =>
+          console.log('onDragEnd:', e.properties.id, e.geometry.coordinates)
+        }
         ref={(ref) => (this.annotationRef = ref)}>
         <View style={styles.annotationContainer}>
           <Image

--- a/index.d.ts
+++ b/index.d.ts
@@ -724,7 +724,7 @@ export interface CalloutProps extends Omit<ViewProps, 'style'> {
 }
 
 export interface TileSourceProps extends ViewProps {
-  id?: string;
+  id: string;
   url?: string;
   tileUrlTemplates?: Array<string>;
   minZoomLevel?: number;
@@ -740,7 +740,7 @@ export interface VectorSourceProps extends TileSourceProps {
 }
 
 export interface ShapeSourceProps extends ViewProps {
-  id?: string;
+  id: string;
   url?: string;
   shape?: GeoJSON.GeometryCollection | GeoJSON.Feature | GeoJSON.FeatureCollection;
   cluster?: boolean;
@@ -762,7 +762,7 @@ export interface RasterSourceProps extends TileSourceProps {
 }
 
 export interface LayerBaseProps<T = {}> extends Omit<ViewProps, 'style'> {
-  id?: string;
+  id: string;
   sourceID?: MapboxGL.StyleSource;
   sourceLayerID?: string;
   aboveLayerID?: string;
@@ -811,7 +811,7 @@ export interface ImagesProps extends ViewProps {
 }
 
 export interface ImageSourceProps extends ViewProps {
-  id?: string;
+  id: string;
   url?: number | string;
   coordinates: [
     GeoJSON.Position,

--- a/index.d.ts
+++ b/index.d.ts
@@ -781,7 +781,8 @@ export interface CircleLayerProps extends LayerBaseProps {
   style?: StyleProp<CircleLayerStyle>;
 }
 
-export interface FillExtrusionLayerProps extends LayerBaseProps {
+export interface FillExtrusionLayerProps extends Omit<LayerBaseProps, 'id'>  {
+  id: string;
   style?: StyleProp<FillExtrusionLayerStyle>;
 }
 

--- a/javascript/components/BackgroundLayer.js
+++ b/javascript/components/BackgroundLayer.js
@@ -18,7 +18,7 @@ class BackgroundLayer extends AbstractLayer {
     /**
      * A string that uniquely identifies the source in the style to which it is added.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined.

--- a/javascript/components/CircleLayer.js
+++ b/javascript/components/CircleLayer.js
@@ -21,7 +21,7 @@ class CircleLayer extends AbstractLayer {
     /**
      * A string that uniquely identifies the source in the style to which it is added.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * The source from which to obtain the data to style.

--- a/javascript/components/FillExtrusionLayer.js
+++ b/javascript/components/FillExtrusionLayer.js
@@ -21,7 +21,7 @@ class FillExtrusionLayer extends AbstractLayer {
     /**
      * A string that uniquely identifies the source in the style to which it is added.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined.

--- a/javascript/components/FillLayer.js
+++ b/javascript/components/FillLayer.js
@@ -21,7 +21,7 @@ class FillLayer extends AbstractLayer {
     /**
      * A string that uniquely identifies the source in the style to which it is added.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined.

--- a/javascript/components/HeatmapLayer.js
+++ b/javascript/components/HeatmapLayer.js
@@ -21,7 +21,7 @@ class HeatmapLayer extends AbstractLayer {
     /**
      * A string that uniquely identifies the source in the style to which it is added.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * The source from which to obtain the data to style.

--- a/javascript/components/ImageSource.js
+++ b/javascript/components/ImageSource.js
@@ -24,7 +24,7 @@ class ImageSource extends AbstractSource {
     /**
      * A string that uniquely identifies the source.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * An HTTP(S) URL, absolute file URL, or local file URL to the source image.

--- a/javascript/components/LineLayer.js
+++ b/javascript/components/LineLayer.js
@@ -21,7 +21,7 @@ class LineLayer extends AbstractLayer {
     /**
      * A string that uniquely identifies the source in the style to which it is added.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * The source from which to obtain the data to style.

--- a/javascript/components/RasterLayer.js
+++ b/javascript/components/RasterLayer.js
@@ -18,7 +18,7 @@ class RasterLayer extends AbstractLayer {
     /**
      * A string that uniquely identifies the source in the style to which it is added.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined.

--- a/javascript/components/RasterSource.js
+++ b/javascript/components/RasterSource.js
@@ -26,7 +26,7 @@ class RasterSource extends AbstractSource {
     /**
      * A string that uniquely identifies the source.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * A URL to a TileJSON configuration file describing the source’s contents and other metadata.

--- a/javascript/components/ShapeSource.js
+++ b/javascript/components/ShapeSource.js
@@ -32,7 +32,7 @@ class ShapeSource extends NativeBridgeComponent(AbstractSource) {
     /**
      * A string that uniquely identifies the source.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * An HTTP(S) URL, absolute file URL, or local file URL relative to the current application’s resource bundle.

--- a/javascript/components/SymbolLayer.js
+++ b/javascript/components/SymbolLayer.js
@@ -21,7 +21,7 @@ class SymbolLayer extends AbstractLayer {
     /**
      * A string that uniquely identifies the source in the style to which it is added.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * The source from which to obtain the data to style. If the source has not yet been added to the current style, the behavior is undefined.

--- a/javascript/components/VectorSource.js
+++ b/javascript/components/VectorSource.js
@@ -29,7 +29,7 @@ class VectorSource extends NativeBridgeComponent(AbstractSource) {
     /**
      * A string that uniquely identifies the source.
      */
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
 
     /**
      * A URL to a TileJSON configuration file describing the source’s contents and other metadata.


### PR DESCRIPTION
This PR replaces optional `id`s in 
* `TileSourceProps`
* `ShapeSourceProps`
* `LayerBaseProps`
* `ImageSourceProps`
with mandatory ones. 

Hopefully this will prevent people from running into any crashes when omitting `id`s.



-----------
PREVIOUS PR DESCRIPTION

Replacing the work done in #969.

@mfazekas, don't maybe all layers expect a present `id`?

Maybe we could change the optional `id` in the `LayerBaseProps` types to required instead of optional.
Thoughts?