### PR TITLE
build(example): update rn-elements from 1.1.0 => 2.2.1 [current]

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -31,7 +31,7 @@
     "prop-types": "^15.7.2",
     "react": "16.11.0",
     "react-native": "0.62.1",
-    "react-native-elements": "^1.1.0",
+    "react-native-elements": "^2.2.1",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-safe-area-context": "^0.7.3",
     "react-native-safe-area-view": "^0.13.1",


### PR DESCRIPTION
The back button in the example app was driving me crazy on a physical device.
Apparently they increased the hitzone with this version... 