### PR TITLE
fix: update type declaration of UserTrackingModes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -332,10 +332,9 @@ declare namespace MapboxGL {
    * Constants
    */
   enum UserTrackingModes {
-    None = 0,
-    Follow = 1,
-    FollowWithCourse = 2,
-    FollowWithHeading = 3,
+    Follow = 'normal',
+    FollowWithHeading = 'compass',
+    FollowWithCourse = 'course',
   }
 
   enum InterpolationMode {


### PR DESCRIPTION
As of [1], the values for this enum are no longer numbers, but strings.
See also docs for `followUserMode` at [2].

[1] https://github.com/react-native-mapbox-gl/maps/pull/33
[2] https://github.com/react-native-mapbox-gl/maps/blob/396e77c2c9025dfbc7f8b09914aceccccda2e2bd/docs/Camera.md#mapboxglcamera-