### PR TITLE
refactor(eslint): some updates to our linting workflow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
+  root: true,
   parser: 'babel-eslint',
-  plugins: ['react', 'react-native', 'prettier', 'fp', 'flowtype', 'import'],
+  plugins: ['react', 'react-native', 'prettier', 'fp', 'import'],
   env: {
     jest: true,
   },
@@ -8,7 +9,6 @@ module.exports = {
     react: {
       version: require('./package.json').dependencies.react,
       pragma: 'React',
-      flowVersion: '0.87',
     },
     'import/resolver': {
       node: {
@@ -39,7 +39,6 @@ module.exports = {
     'eslint:recommended',
     'plugin:react/recommended',
     'prettier',
-    'plugin:flowtype/recommended',
     '@react-native-community',
   ],
   rules: {
@@ -67,7 +66,7 @@ module.exports = {
     'class-methods-use-this': [0],
     'no-bitwise': [1],
     'prefer-destructuring': [1],
-    'consistent-return': [1],
+    'consistent-return': [0],
     'no-warning-comments': [1],
     'no-mixed-requires': [0],
     'no-return-assign': 0,

--- a/__tests__/components/MapView.test.js
+++ b/__tests__/components/MapView.test.js
@@ -9,8 +9,8 @@ describe('MapView', () => {
 
     const {getByTestId} = render(<MapView testID={expectedTestId} />);
 
-    // expect(() => {
-    //   getByTestId(expectedTestId);
-    // }).not.toThrowError();
+    expect(() => {
+      getByTestId(expectedTestId);
+    }).not.toThrowError();
   });
 });

--- a/example/.eslintrc.js
+++ b/example/.eslintrc.js
@@ -1,13 +1,19 @@
 module.exports = {
+  root: true,
   parser: '@typescript-eslint/parser',
   env: {
     jest: true,
+    es6: true,
+    browser: true,
+    node: true,
   },
   extends: [
     'plugin:@typescript-eslint/recommended',
     'plugin:react-native/all',
     'prettier',
-    'prettier/@typescript-eslint'
+    'prettier/@typescript-eslint',
+    "eslint:recommended",
+    "plugin:react/recommended"
   ],
   parserOptions: {
     ecmaFeatures: {
@@ -34,11 +40,16 @@ module.exports = {
           ".tsx"
         ]
       }
-    }
+    },
+    "react": {
+      "version": "detect", // React version. "detect" automatically picks the version you have installed.
+                           // You can also use `16.0`, `16.3`, etc, if you want to override the detected value.
+                           // default to latest and warns if missing
+                           // It will default to "detect" in the future
+    },
   },
   rules: {
     camelcase: 0,
-    indent: ['error', 2, { SwitchCase: 1 }],
     'linebreak-style': ['error', 'unix'],
     quotes: ['error', 'single'],
     semi: ['error', 'always'],
@@ -73,6 +84,7 @@ module.exports = {
     'react/destructuring-assignment': 0,
     'react/no-unescaped-entities': 0,
     'react-native/split-platform-components': 0,
+    'react-native/no-color-literals': 0,
     'react/jsx-filename-extension': [
       1,
       { extensions: ['.js', '.jsx', '.tsx'] }

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint .",
+    "lint": "eslint ./src",
     "postinstall": "node ./scripts/set_access_token.js && jetifier"
   },
   "dependencies": {
@@ -52,7 +52,7 @@
     "@types/react-test-renderer": "^16.9.2",
     "babel-jest": "^24.9.0",
     "babel-plugin-module-resolver": "^3.2.0",
-    "eslint": "^6.8.0",
+    "eslint": "^7.3.0",
     "eslint-config-prettier": "^6.11.0",
     "@typescript-eslint/eslint-plugin": "^3.0.0",
     "@typescript-eslint/parser": "^3.0.0",

--- a/example/src/examples/BugReportExample.js
+++ b/example/src/examples/BugReportExample.js
@@ -6,7 +6,6 @@ import {
   SymbolLayer,
   CircleLayer,
   Camera,
-  Images,
 } from '@react-native-mapbox-gl/maps';
 
 const features = {

--- a/example/src/examples/CacheManagement.js
+++ b/example/src/examples/CacheManagement.js
@@ -16,22 +16,11 @@ import BaseExamplePropTypes from './common/BaseExamplePropTypes';
 import Page from './common/Page';
 
 const styles = StyleSheet.create({
-  controlsContainer: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-  },
-  control: {
-    width: '40%',
-    alignItems: 'center',
-    justifyContent: 'center',
-    margin: 16,
-    padding: 8,
-  },
   button: {
     alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 3,
     backgroundColor: 'blue',
+    borderRadius: 3,
+    justifyContent: 'center',
     padding: 8,
     width: '100%',
   },
@@ -39,12 +28,23 @@ const styles = StyleSheet.create({
     color: 'white',
     textAlign: 'center',
   },
+  control: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 16,
+    padding: 8,
+    width: '40%',
+  },
+  controlsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
   textInput: {
-    width: '100%',
     borderBottomColor: 'grey',
     borderBottomWidth: 1,
     marginBottom: 8,
     padding: 8,
+    width: '100%',
   },
 });
 

--- a/example/src/examples/CreateOfflineRegion.js
+++ b/example/src/examples/CreateOfflineRegion.js
@@ -20,25 +20,25 @@ const CENTER_COORD = [-73.970895, 40.723279];
 const MAPBOX_VECTOR_TILE_SIZE = 512;
 
 const styles = StyleSheet.create({
-  percentageText: {
+  button: {
+    alignItems: 'center',
+    backgroundColor: 'blue',
+    borderRadius: 3,
+    flex: 0.4,
+    justifyContent: 'center',
     padding: 8,
-    textAlign: 'center',
   },
   buttonCnt: {
+    alignItems: 'center',
     flexDirection: 'row',
-    alignItems: 'center',
     justifyContent: 'space-between',
-  },
-  button: {
-    flex: 0.4,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 3,
-    backgroundColor: 'blue',
-    padding: 8,
   },
   buttonTxt: {
     color: 'white',
+  },
+  percentageText: {
+    padding: 8,
+    textAlign: 'center',
   },
 });
 

--- a/example/src/examples/DriveTheLine.js
+++ b/example/src/examples/DriveTheLine.js
@@ -17,18 +17,18 @@ import PulseCircleLayer from './common/PulseCircleLayer';
 const SF_ZOO_COORDINATE = [-122.505412, 37.737463];
 
 const styles = StyleSheet.create({
+  button: {
+    backgroundColor: 'blue',
+    borderRadius: 3,
+  },
   buttonCnt: {
+    backgroundColor: 'transparent',
+    bottom: 16,
     flexDirection: 'row',
     justifyContent: 'space-around',
-    backgroundColor: 'transparent',
-    position: 'absolute',
-    bottom: 16,
     left: 0,
+    position: 'absolute',
     right: 0,
-  },
-  button: {
-    borderRadius: 3,
-    backgroundColor: 'blue',
   },
 });
 

--- a/example/src/examples/IndoorBuilding.js
+++ b/example/src/examples/IndoorBuilding.js
@@ -12,8 +12,8 @@ import BaseExamplePropTypes from './common/BaseExamplePropTypes';
 
 const styles = StyleSheet.create({
   slider: {
-    flex: 1,
     alignItems: 'stretch',
+    flex: 1,
     justifyContent: 'center',
     maxHeight: 60,
     paddingHorizontal: 24,

--- a/example/src/examples/ShowPointAnnotation.js
+++ b/example/src/examples/ShowPointAnnotation.js
@@ -12,22 +12,22 @@ const ANNOTATION_SIZE = 45;
 
 const styles = StyleSheet.create({
   annotationContainer: {
-    width: ANNOTATION_SIZE,
-    height: ANNOTATION_SIZE,
     alignItems: 'center',
-    justifyContent: 'center',
     backgroundColor: 'white',
+    borderColor: 'rgba(0, 0, 0, 0.45)',
     borderRadius: ANNOTATION_SIZE / 2,
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: 'rgba(0, 0, 0, 0.45)',
+    height: ANNOTATION_SIZE,
+    justifyContent: 'center',
     overflow: 'hidden',
+    width: ANNOTATION_SIZE,
   },
   annotationFill: {
-    width: ANNOTATION_SIZE - 3,
-    height: ANNOTATION_SIZE - 3,
-    borderRadius: (ANNOTATION_SIZE - 3) / 2,
     backgroundColor: 'orange',
+    borderRadius: (ANNOTATION_SIZE - 3) / 2,
+    height: ANNOTATION_SIZE - 3,
     transform: [{scale: 0.6}],
+    width: ANNOTATION_SIZE - 3,
   },
 });
 
@@ -42,9 +42,15 @@ class AnnotationWithRemoteImage extends React.Component {
         coordinate={coordinate}
         title={title}
         draggable
-        onDrag={(e) => console.log('onDrag:', e.properties.id, e.geometry.coordinates)}
-        onDragStart={(e) => console.log('onDragStart:', e.properties.id, e.geometry.coordinates)}
-        onDragEnd={(e) => console.log('onDragEnd:', e.properties.id, e.geometry.coordinates)}
+        onDrag={(e) =>
+          console.log('onDrag:', e.properties.id, e.geometry.coordinates)
+        }
+        onDragStart={(e) =>
+          console.log('onDragStart:', e.properties.id, e.geometry.coordinates)
+        }
+        onDragEnd={(e) =>
+          console.log('onDragEnd:', e.properties.id, e.geometry.coordinates)
+        }
         ref={(ref) => (this.annotationRef = ref)}>
         <View style={styles.annotationContainer}>
           <Image

--- a/example/src/examples/SymbolCircleLayer/ShapeSource.tsx
+++ b/example/src/examples/SymbolCircleLayer/ShapeSource.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import MapboxGL from '@react-native-mapbox-gl/maps';
 import {View} from 'react-native';
-let {MapView, Camera, Images, ShapeSource, SymbolLayer} = MapboxGL;
 
 import exampleIcon from '../../assets/example.png';
+const {MapView, Camera, Images, ShapeSource, SymbolLayer} = MapboxGL;
 
 const styles = {
   icon: {

--- a/example/src/examples/TakeSnapshotWithMap.js
+++ b/example/src/examples/TakeSnapshotWithMap.js
@@ -10,9 +10,9 @@ import Page from './common/Page';
 
 const styles = StyleSheet.create({
   button: {
-    height: 60,
-    backgroundColor: colors.primary.blueLight,
     alignItems: 'center',
+    backgroundColor: colors.primary.blueLight,
+    height: 60,
     justifyContent: 'center',
   },
 });

--- a/example/src/examples/WatercolorRasterTiles.js
+++ b/example/src/examples/WatercolorRasterTiles.js
@@ -12,8 +12,8 @@ import BaseExamplePropTypes from './common/BaseExamplePropTypes';
 
 const styles = StyleSheet.create({
   slider: {
-    flex: 1,
     alignItems: 'stretch',
+    flex: 1,
     justifyContent: 'center',
     maxHeight: 60,
     paddingHorizontal: 24,

--- a/example/src/examples/common/Bubble.js
+++ b/example/src/examples/common/Bubble.js
@@ -4,16 +4,16 @@ import {View, StyleSheet, TouchableOpacity} from 'react-native';
 
 const styles = StyleSheet.create({
   container: {
-    borderRadius: 30,
-    position: 'absolute',
-    bottom: 16,
-    left: 48,
-    right: 48,
-    paddingVertical: 16,
-    minHeight: 60,
     alignItems: 'center',
-    justifyContent: 'center',
     backgroundColor: 'white',
+    borderRadius: 30,
+    bottom: 16,
+    justifyContent: 'center',
+    left: 48,
+    minHeight: 60,
+    paddingVertical: 16,
+    position: 'absolute',
+    right: 48,
   },
 });
 

--- a/example/src/examples/common/MapHeader.js
+++ b/example/src/examples/common/MapHeader.js
@@ -6,12 +6,12 @@ import {Header} from 'react-native-elements';
 import colors from '../../styles/colors';
 
 const styles = StyleSheet.create({
-  label: {
-    fontSize: 24,
-    color: colors.secondary.white,
-  },
   container: {
     borderBottomWidth: 0,
+  },
+  label: {
+    color: colors.secondary.white,
+    fontSize: 24,
   },
 });
 

--- a/example/src/examples/common/TabBarPage.js
+++ b/example/src/examples/common/TabBarPage.js
@@ -12,12 +12,12 @@ const TAB_BAR_HEIGHT = 70;
 
 const styles = StyleSheet.create({
   buttonGroup: {
+    backgroundColor: colors.secondary.white,
     height: TAB_BAR_HEIGHT,
+    marginBottom: 0,
     marginLeft: 0,
     marginRight: 0,
     marginTop: 0,
-    marginBottom: 0,
-    backgroundColor: colors.secondary.white,
   },
   scrollableButton: {
     paddingHorizontal: 24,

--- a/example/src/scenes/Home.js
+++ b/example/src/scenes/Home.js
@@ -55,30 +55,30 @@ import ShapeSourceTS from '../examples/SymbolCircleLayer/ShapeSource';
 import CacheManagement from '../examples/CacheManagement';
 
 const styles = StyleSheet.create({
-  header: {
-    marginTop: 48,
-    fontSize: 24,
-    textAlign: 'center',
+  exampleBackground: {
+    backgroundColor: colors.primary.pinkFaint,
+    flex: 1,
   },
   exampleList: {
     flex: 1,
   },
-  exampleListItemBorder: {
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#ccc',
-  },
   exampleListItem: {
-    paddingVertical: 32,
-    paddingHorizontal: 16,
     flexDirection: 'row',
     justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 32,
+  },
+  exampleListItemBorder: {
+    borderBottomColor: '#ccc',
+    borderBottomWidth: StyleSheet.hairlineWidth,
   },
   exampleListLabel: {
     fontSize: 18,
   },
-  exampleBackground: {
-    flex: 1,
-    backgroundColor: colors.primary.pinkFaint,
+  header: {
+    fontSize: 24,
+    marginTop: 48,
+    textAlign: 'center',
   },
 });
 
@@ -182,7 +182,7 @@ function ExampleGroupComponent({items, navigation, showBack}) {
     navigation.navigate(item.navigationType, item);
   }
 
-  function renderItem({item, index}) {
+  function renderItem({item}) {
     return (
       <View style={styles.exampleListItemBorder}>
         <TouchableOpacity onPress={() => itemPress(item)}>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "unittest": "jest",
     "unittest:single": "jest --testNamePattern",
     "format": "npm run lint -- --fix",
-    "lint": "eslint . --ignore-pattern 'example' --fix && cd example/ && eslint . --ignore-pattern 'scripts' --fix"
+    "lint": "eslint . --ignore-pattern 'example' --fix && cd example/ && eslint ./src --fix"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.8",


### PR DESCRIPTION
We had the issue, that when linting either `root` together with `example` vs `/example` alone there would be inconsistent results. 

Also, one wasn't able to run `yarn lint` without having the dependencies installed in `/example`, however when installed it could lead to conflicting plugins....

Anyways, this change now allows us to either run `yarn lint` from `root` with or without installed dependencies in `/example` and also run `yarn lint` within `/example`. 

Both will result in the same output. 

Notice, that I didn't really fix many errors in this PR. 
Changes in source files are mainly from `--fix`. 

This is somewhat to prepare for the transition to TS and align `root` and `/example` a bit for that.

Lastly, the eslint rules in the rc files are kinda opinionated by me and the projects I work in.
Let me know if you have other opinions or suggestions.


Feedback highly appreciated
Thanks 🙇 