### PR TITLE
fix(user-location): fix crash issue when using androidRenderMode

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
@@ -18,6 +18,7 @@ public class RCTMGLNativeUserLocation extends AbstractMapFeature implements OnMa
     private boolean mEnabled = true;
     private MapboxMap mMap;
     private RCTMGLMapView mMapView;
+    private int mRenderMode = -1;
 
     public RCTMGLNativeUserLocation(Context context) {
         super(context);
@@ -28,6 +29,7 @@ public class RCTMGLNativeUserLocation extends AbstractMapFeature implements OnMa
         mEnabled = true;
         mMapView = mapView;
         mapView.getMapAsync(this);
+        if (mRenderMode < 0) { setRenderMode(mRenderMode); }
     }
 
     @Override
@@ -55,7 +57,8 @@ public class RCTMGLNativeUserLocation extends AbstractMapFeature implements OnMa
         locationComponent.showUserLocation(mEnabled);
     }
 
-    public void setRenderMode(@RenderMode.Mode int renderMode) {
+    public void setRenderMode(int renderMode) {
+        mRenderMode = renderMode;
         if (mMapView != null) {
             LocationComponentManager locationComponent = mMapView.getLocationComponentManager();
             locationComponent.setRenderMode(renderMode);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
@@ -56,7 +56,7 @@ public class RCTMGLNativeUserLocation extends AbstractMapFeature implements OnMa
     }
 
     public void setRenderMode(@RenderMode.Mode int renderMode) {
-        if (mMap != null) {
+        if (mMapView != null) {
             LocationComponentManager locationComponent = mMapView.getLocationComponentManager();
             locationComponent.setRenderMode(renderMode);
         }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
@@ -29,7 +29,7 @@ public class RCTMGLNativeUserLocation extends AbstractMapFeature implements OnMa
         mEnabled = true;
         mMapView = mapView;
         mapView.getMapAsync(this);
-        if (mRenderMode >= 0) { setRenderMode(mRenderMode); }
+        setRenderMode(mRenderMode);
     }
 
     @Override

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
@@ -18,7 +18,7 @@ public class RCTMGLNativeUserLocation extends AbstractMapFeature implements OnMa
     private boolean mEnabled = true;
     private MapboxMap mMap;
     private RCTMGLMapView mMapView;
-    private int mRenderMode = -1;
+    private @RenderMode.Mode int mRenderMode = RenderMode.COMPASS;
 
     public RCTMGLNativeUserLocation(Context context) {
         super(context);
@@ -57,7 +57,7 @@ public class RCTMGLNativeUserLocation extends AbstractMapFeature implements OnMa
         locationComponent.showUserLocation(mEnabled);
     }
 
-    public void setRenderMode(int renderMode) {
+    public void setRenderMode(@RenderMode.Mode int renderMode) {
         mRenderMode = renderMode;
         if (mMapView != null) {
             LocationComponentManager locationComponent = mMapView.getLocationComponentManager();

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
@@ -56,7 +56,9 @@ public class RCTMGLNativeUserLocation extends AbstractMapFeature implements OnMa
     }
 
     public void setRenderMode(@RenderMode.Mode int renderMode) {
-        LocationComponentManager locationComponent = mMapView.getLocationComponentManager();
-        locationComponent.setRenderMode(renderMode);
+        if (mMap != null) {
+            LocationComponentManager locationComponent = mMapView.getLocationComponentManager();
+            locationComponent.setRenderMode(renderMode);
+        }
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocation.java
@@ -29,7 +29,7 @@ public class RCTMGLNativeUserLocation extends AbstractMapFeature implements OnMa
         mEnabled = true;
         mMapView = mapView;
         mapView.getMapAsync(this);
-        if (mRenderMode < 0) { setRenderMode(mRenderMode); }
+        if (mRenderMode >= 0) { setRenderMode(mRenderMode); }
     }
 
     @Override


### PR DESCRIPTION
App crashes when user is trying to set `androidRenderMode` as described in issue #1022.

I think I've tracked it down to a missing non-null check in `NativeUserLocation`.
In `setRenderMode` it attempts to call `getLocationComponentManager` on `mMapView` which seems to be `null` at that point in time.

This change fixes the crash. 

Two more things I noticed though:
* no types for `androidRenderMode` in `index.d.ts` (which I will address with a follow-up PR)
* the heading indicator doesn't seem to change when using `androidRenderMode="compass"`(from the short test I did 🤷 )

Feedback appreciated, thanks 🙇 


----

this resolves #1022 