### PR TITLE
fix(types): add renderMode and androidRenderMode to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -472,13 +472,15 @@ export interface CameraSettings {
 }
 
 export interface UserLocationProps {
+  androidRenderMode?: 'normal' | 'compass' | 'gps'
   animated?: boolean;
-  visible?: boolean;
+  children?: ReactNode;
+  minDisplacement?: number;
   onPress?: () => void;
   onUpdate?: (location: MapboxGL.Location) => void;
+  renderMode?: 'normal' | 'native';
   showsUserHeadingIndicator?: boolean,
-  minDisplacement?: number;
-  children?: ReactNode;
+  visible?: boolean;
 }
 
 export type WithExpression<T> = {


### PR DESCRIPTION
`renderMode` and `androidRenderMode` were missing from `UserLocationProps` interface. 

This PR adds them.