### PR TITLE
Support mapbox 6.0 and later and switch to $ReactNativeMapboxGLIOSVersion

### DIFF
--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -2,7 +2,8 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-rnmbgl_ios_version = $ReactNativeMapboxGLIOSVersion || ENV["REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION"] || '~> 5.8'
+default_ios_mapbox_version = '~> 5.8'
+rnmbgl_ios_version = $ReactNativeMapboxGLIOSVersion || ENV["REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION"] || default_ios_mapbox_version
 if ENV.has_key?("REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION")
   puts "REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION env is deprecated please use `$ReactNativeMapboxGLIOSVersion = \"#{rnmbgl_ios_version}\"`"
 end
@@ -28,7 +29,7 @@ Pod::Spec.new do |s|
     s.default_subspecs= ['DynamicLibrary']
   else
     s.subspec 'StaticLibraryFixer' do |sp|
-      if rnmbgl_ios_version.split('.')[0].to_i == 5
+      if rnmbgl_ios_version.split('.')[0] =~ /.*(\d+)/ && $1.to_i == 5
         s.dependency '@react-native-mapbox-gl-mapbox-static', rnmbgl_ios_version
       end
     end

--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -2,8 +2,10 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-
-REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION = ENV["REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION"] || '~> 5.8'
+rnmbgl_ios_version = $ReactNativeMapboxGLIOSVersion || ENV["REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION"] || '~> 5.8'
+if ENV.has_key?("REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION")
+  puts "REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION env is deprecated please use `$ReactNativeMapboxGLIOSVersion = \"#{rnmbgl_ios_version}\"`"
+end
 
 Pod::Spec.new do |s|
   s.name		= "react-native-mapbox-gl"
@@ -15,7 +17,7 @@ Pod::Spec.new do |s|
   s.license     	= "MIT"
   s.platform    	= :ios, "8.0"
 
-  s.dependency 'Mapbox-iOS-SDK', REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION
+  s.dependency 'Mapbox-iOS-SDK', rnmbgl_ios_version
   s.dependency 'React'
 
   s.subspec 'DynamicLibrary' do |sp|
@@ -26,7 +28,9 @@ Pod::Spec.new do |s|
     s.default_subspecs= ['DynamicLibrary']
   else
     s.subspec 'StaticLibraryFixer' do |sp|
-      s.dependency '@react-native-mapbox-gl-mapbox-static', REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION
+      if rnmbgl_ios_version.split('.')[0].to_i == 5
+        s.dependency '@react-native-mapbox-gl-mapbox-static', rnmbgl_ios_version
+      end
     end
 
     s.default_subspecs= ['DynamicLibrary', 'StaticLibraryFixer']

--- a/scripts/autogenerate.js
+++ b/scripts/autogenerate.js
@@ -21,7 +21,7 @@ function readIosVersion() {
     'react-native-mapbox-gl.podspec',
   );
   const lines = fs.readFileSync(podspecPath, 'utf8').split('\n');
-  const mapboxLineRegex = /^REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION.*||.+'~>\s+(\d+\.\d+)'$/;
+  const mapboxLineRegex = /^default_ios_mapbox_version\s*=\s*'~>\s+(\d+\.\d+)'$/;
   const mapboxLine = lines.filter(i => mapboxLineRegex.exec(i))[0];
   return `${mapboxLineRegex.exec(mapboxLine)[1]}.0`;
 }

--- a/scripts/autogenerate.js
+++ b/scripts/autogenerate.js
@@ -21,7 +21,7 @@ function readIosVersion() {
     'react-native-mapbox-gl.podspec',
   );
   const lines = fs.readFileSync(podspecPath, 'utf8').split('\n');
-  const mapboxLineRegex = /^REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION\s*=\s*.+'~>\s+(\d+\.\d+)'$/;
+  const mapboxLineRegex = /^REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION.*||.+'~>\s+(\d+\.\d+)'$/;
   const mapboxLine = lines.filter(i => mapboxLineRegex.exec(i))[0];
   return `${mapboxLineRegex.exec(mapboxLine)[1]}.0`;
 }


### PR DESCRIPTION
Deprecates:
```
ENV["REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION"] = "6.2.1"
```

New version:
```
$ReactNativeMapboxGLIOSVersion = "6.2.1"
```