### PR TITLE
test(layer-id): Add the now required ID for layers

### DIFF
--- a/__tests__/components/BackgroundLayer.test.js
+++ b/__tests__/components/BackgroundLayer.test.js
@@ -7,7 +7,9 @@ export const NATIVE_MODULE_NAME = 'RCTMGLBackgroundLayer';
 
 describe('BackgroundLayer', () => {
   test('renders correctly with default props', () => {
-    const {queryByTestId} = render(<BackgroundLayer />);
+    const {queryByTestId} = render(
+      <BackgroundLayer id="requiredBackgroundLayerID" />,
+    );
 
     const backgroundLayer = queryByTestId('rctmglBackgroundLayer');
     const {props} = backgroundLayer;

--- a/__tests__/components/CircleLayer.test.js
+++ b/__tests__/components/CircleLayer.test.js
@@ -5,7 +5,7 @@ import CircleLayer from '../../javascript/components/CircleLayer';
 
 describe('CircleLayer', () => {
   test('renders correctly with default props', () => {
-    const {queryByTestId} = render(<CircleLayer />);
+    const {queryByTestId} = render(<CircleLayer id="requiredCircleLayerID" />);
     const circleLayer = queryByTestId('rctmglCircleLayer');
     const {props} = circleLayer;
 

--- a/__tests__/components/HeatmapLayer.test.js
+++ b/__tests__/components/HeatmapLayer.test.js
@@ -5,7 +5,9 @@ import HeatmapLayer from '../../javascript/components/HeatmapLayer';
 
 describe('HeatmapLayer', () => {
   test('renders correctly with default props', () => {
-    const {UNSAFE_getByType} = render(<HeatmapLayer />);
+    const {UNSAFE_getByType} = render(
+      <HeatmapLayer id="requiredHeatmapLayerID" />,
+    );
     const heatmapLayer = UNSAFE_getByType('RCTMGLHeatmapLayer');
     const {props} = heatmapLayer;
     expect(props.sourceID).toStrictEqual('DefaultSourceID');

--- a/__tests__/components/SymbolLayer.test.js
+++ b/__tests__/components/SymbolLayer.test.js
@@ -8,7 +8,9 @@ import SymbolLayer, {
 
 describe('SymbolLayer', () => {
   test('renders correctly with default props', () => {
-    const {UNSAFE_getByType} = render(<SymbolLayer />);
+    const {UNSAFE_getByType} = render(
+      <SymbolLayer id="requiredSymbolLayerID" />,
+    );
     const symbolLayer = UNSAFE_getByType(NATIVE_MODULE_NAME);
     const {props} = symbolLayer;
 


### PR DESCRIPTION
Missed the now required IDs for layers. 
Were causing tests to fail