### PR TITLE
Feature/replace deprecated api

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/annotation/RCTMGLPointAnnotationManager.java
@@ -37,15 +37,7 @@ public class RCTMGLPointAnnotationManager extends AbstractEventEmitter<RCTMGLPoi
     }
 
     //region React Methods
-    public static final int METHOD_REFRESH = 2;
-
-    @Nullable
-    @Override
-    public Map<String, Integer> getCommandsMap() {
-        return MapBuilder.<String, Integer>builder()
-                .put("refresh", METHOD_REFRESH)
-                .build();
-    }
+    public static final String METHOD_REFRESH = "refresh";
 
     @Override
     public String getName() {
@@ -78,8 +70,8 @@ public class RCTMGLPointAnnotationManager extends AbstractEventEmitter<RCTMGLPoi
     }
 
     @Override
-    public void receiveCommand(RCTMGLPointAnnotation annotation, int commandID, @Nullable ReadableArray args) {
-        switch (commandID) {
+    public void receiveCommand(RCTMGLPointAnnotation annotation, String commandName, @Nullable ReadableArray args) {
+        switch (commandName) {
             case METHOD_REFRESH:
                 annotation.refresh();
                 break;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -113,7 +113,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     private List<RCTMGLImages> mImages;
 
     private CameraChangeTracker mCameraChangeTracker = new CameraChangeTracker();
-    private List<Pair<Integer, ReadableArray>> mPreRenderMethods = new ArrayList<>();
+    private List<Pair<String, ReadableArray>> mPreRenderMethods = new ArrayList<>();
 
     private MapboxMap mMap;
 
@@ -202,8 +202,8 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         mDestroyed = true;
     }
 
-    public void enqueuePreRenderMapMethod(Integer methodID, @Nullable ReadableArray args) {
-        mPreRenderMethods.add(new Pair<>(methodID, args));
+    public void enqueuePreRenderMapMethod(String methodName, @Nullable ReadableArray args) {
+        mPreRenderMethods.add(new Pair<>(methodName, args));
     }
 
     public void addFeature(View childView, int childPosition) {
@@ -715,10 +715,10 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     @Override
     public void onDidFinishRenderingMap(boolean fully) {
         if (fully) {
-            for (Pair<Integer, ReadableArray> preRenderMethod : mPreRenderMethods) {
-                Integer methodID = preRenderMethod.first;
+            for (Pair<String, ReadableArray> preRenderMethod : mPreRenderMethods) {
+                String methodName = preRenderMethod.first;
                 ReadableArray args = preRenderMethod.second;
-                mManager.receiveCommand(this, methodID, args);
+                mManager.(this, methodName, args);
             }
             mPreRenderMethods.clear();
             handleMapChangedEvent(EventTypes.DID_FINISH_RENDERING_MAP_FULLY);
@@ -1121,7 +1121,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     public double[] getContentInset() {
         if (mInsets == null) {
             double[] result = {0,0,0,0};
-        
+
             return result;
         }
         double top = 0, right = 0, bottom = 0, left = 0;
@@ -1144,7 +1144,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         }
 
         final DisplayMetrics metrics = mContext.getResources().getDisplayMetrics();
-    
+
         double[] result = {left * metrics.scaledDensity, top * metrics.scaledDensity, right * metrics.scaledDensity, bottom * metrics.scaledDensity};
         return result;
     }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -718,7 +718,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
             for (Pair<String, ReadableArray> preRenderMethod : mPreRenderMethods) {
                 String methodName = preRenderMethod.first;
                 ReadableArray args = preRenderMethod.second;
-                mManager.(this, methodName, args);
+                mManager.receiveCommand(this, methodName, args);
             }
             mPreRenderMethods.clear();
             handleMapChangedEvent(EventTypes.DID_FINISH_RENDERING_MAP_FULLY);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -204,46 +204,30 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
     //endregion
 
     //region React Methods
-    public static final int METHOD_QUERY_FEATURES_POINT = 2;
-    public static final int METHOD_QUERY_FEATURES_RECT = 3;
-    public static final int METHOD_VISIBLE_BOUNDS = 4;
-    public static final int METHOD_GET_POINT_IN_VIEW = 5;
-    public static final int METHOD_GET_COORDINATE_FROM_VIEW = 6;
-    public static final int METHOD_TAKE_SNAP = 7;
-    public static final int METHOD_GET_ZOOM = 8;
-    public static final int METHOD_GET_CENTER = 9;
-    public static final int METHOD_SET_HANDLED_MAP_EVENTS = 10;
-    public static final int METHOD_SHOW_ATTRIBUTION = 11;
-    public static final int METHOD_SET_SOURCE_VISIBILITY = 12;
+    public static final String METHOD_QUERY_FEATURES_POINT = "queryRenderedFeaturesAtPoint";
+    public static final String METHOD_QUERY_FEATURES_RECT = "queryRenderedFeaturesInRect";
+    public static final String METHOD_VISIBLE_BOUNDS = "getVisibleBounds";
+    public static final String METHOD_GET_POINT_IN_VIEW = "getPointInView";
+    public static final String METHOD_GET_COORDINATE_FROM_VIEW = "getCoordinateFromView";
+    public static final String METHOD_TAKE_SNAP = "takeSnap";
+    public static final String METHOD_GET_ZOOM = "getZoom";
+    public static final String METHOD_GET_CENTER = "getCenter";
+    public static final String METHOD_SET_HANDLED_MAP_EVENTS = "setHandledMapChangedEvents";
+    public static final String METHOD_SHOW_ATTRIBUTION = "showAttribution";
+    public static final String METHOD_SET_SOURCE_VISIBILITY = "setSourceVisibility";
 
-    @Nullable
-    @Override
-    public Map<String, Integer> getCommandsMap() {
-        return MapBuilder.<String, Integer>builder()
-                .put("queryRenderedFeaturesAtPoint", METHOD_QUERY_FEATURES_POINT)
-                .put("queryRenderedFeaturesInRect", METHOD_QUERY_FEATURES_RECT)
-                .put("getVisibleBounds", METHOD_VISIBLE_BOUNDS)
-                .put("getPointInView", METHOD_GET_POINT_IN_VIEW)
-                .put("getCoordinateFromView", METHOD_GET_COORDINATE_FROM_VIEW)
-                .put("takeSnap", METHOD_TAKE_SNAP)
-                .put("getZoom", METHOD_GET_ZOOM)
-                .put("getCenter", METHOD_GET_CENTER)
-                .put( "setHandledMapChangedEvents", METHOD_SET_HANDLED_MAP_EVENTS)
-                .put("showAttribution", METHOD_SHOW_ATTRIBUTION)
-                .put("setSourceVisibility", METHOD_SET_SOURCE_VISIBILITY)
-                .build();
-    }
+
 
     @Override
-    public void receiveCommand(RCTMGLMapView mapView, int commandID, @Nullable ReadableArray args) {
+    public void receiveCommand(RCTMGLMapView mapView, String commandName, @Nullable ReadableArray args) {
         // allows method calls to work with componentDidMount
         MapboxMap mapboxMap = mapView.getMapboxMap();
         if (mapboxMap == null) {
-            mapView.enqueuePreRenderMapMethod(commandID, args);
+            mapView.enqueuePreRenderMapMethod(commandName, args);
             return;
         }
 
-        switch (commandID) {
+        switch (commandName) {
             case METHOD_QUERY_FEATURES_POINT:
                 mapView.queryRenderedFeaturesAtPoint(
                         args.getString(0),

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
@@ -147,19 +147,11 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
     }
 
     //region React Methods
-    public static final int METHOD_FEATURES = 103;
-
-    @Nullable
+    public static final String METHOD_FEATURES = "features";
+    
     @Override
-    public Map<String, Integer> getCommandsMap() {
-        return MapBuilder.<String, Integer>builder()
-                .put("features", METHOD_FEATURES)
-                .build();
-    }
-
-    @Override
-    public void receiveCommand(RCTMGLShapeSource source, int commandID, @Nullable ReadableArray args) {
-        switch (commandID) {
+    public void receiveCommand(RCTMGLShapeSource source, String commandName, @Nullable ReadableArray args) {
+        switch (commandName) {
             case METHOD_FEATURES:
                 source.querySourceFeatures(
                         args.getString(0),

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLVectorSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLVectorSourceManager.java
@@ -58,20 +58,12 @@ public class RCTMGLVectorSourceManager extends RCTMGLTileSourceManager<RCTMGLVec
     }
 
     //region React Methods
-    public static final int METHOD_FEATURES = 102;
-
-    @Nullable
-    @Override
-    public Map<String, Integer> getCommandsMap() {
-        return MapBuilder.<String, Integer>builder()
-                .put("features", METHOD_FEATURES)
-                .build();
-    }
+    public static final String METHOD_FEATURES = "features";
 
     @Override
-    public void receiveCommand(RCTMGLVectorSource vectorSource, int commandID, @Nullable ReadableArray args) {
+    public void receiveCommand(RCTMGLVectorSource vectorSource, String commandName, @Nullable ReadableArray args) {
 
-        switch (commandID) {
+        switch (commandName) {
             case METHOD_FEATURES:
                 vectorSource.querySourceFeatures(
                         args.getString(0),

--- a/javascript/utils/index.js
+++ b/javascript/utils/index.js
@@ -74,7 +74,7 @@ export function runNativeCommand(module, name, nativeRef, args = []) {
   if (isAndroid()) {
     return NativeModules.UIManager.dispatchViewManagerCommand(
       handle,
-      managerInstance.Commands[name],
+      name,
       args,
     );
   }


### PR DESCRIPTION
This PR replaces the deprecated 
```
 public void receiveCommand(ReactScrollView scrollView, int commandId, @Nullable ReadableArray args)
```
with
```
 public void receiveCommand(ReactScrollView scrollView, String commandName, @Nullable ReadableArray args)
```
Furthermore this PR fixes the Issue from  #972, which happened because the JS-Side already passed the commandName instead of the id.
 