### PR TITLE
Fixed doc typo, added React to podfile

### DIFF
--- a/javascript/utils/Logger.js
+++ b/javascript/utils/Logger.js
@@ -53,7 +53,7 @@ class Logger {
   }
 
   /**
-   * @type {('error'|'warning'|'info'|'debug'|'verobse')} LogLevel - Supported log levels
+   * @type {('error'|'warning'|'info'|'debug'|'verbose')} LogLevel - Supported log levels
    */
 
   start() {

--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Mapbox-iOS-SDK', rnmbgl_ios_version
   s.dependency 'React-Core'
+  s.dependency 'React'
 
   s.subspec 'DynamicLibrary' do |sp|
     sp.source_files	= "ios/RCTMGL/**/*.{h,m}"


### PR DESCRIPTION
It seems we need `React` in addition to `React-Core` as we're using `#import <React/RCTImageLoader.h>` (was an issue on RN0.60)