### PR TITLE
Prevent emitting log events without listeners

### DIFF
--- a/ios/RCTMGL/RCTMGLLogging.m
+++ b/ios/RCTMGL/RCTMGLLogging.m
@@ -2,6 +2,10 @@
 
 @import Mapbox;
 
+@interface RCTMGLLogging()
+@property (nonatomic) BOOL hasListeners;
+@end
+
 @implementation RCTMGLLogging
 
 + (id)allocWithZone:(NSZone *)zone {
@@ -37,8 +41,22 @@ RCT_EXPORT_MODULE();
   return @[@"LogEvent"];
 }
 
+- (void)startObserving
+{
+    [super startObserving];
+    self.hasListeners = true;
+}
+
+- (void)stopObserving
+{
+    [super stopObserving];
+    self.hasListeners = false;
+}
+
 - (void)sendLogWithLevel:(MGLLoggingLevel)loggingLevel filePath:(NSString*)filePath line:(NSUInteger)line message:(NSString*)message
 {
+    if (!self.hasListeners) return;
+
     NSString* level = @"n/a";
     switch (loggingLevel) {
     case MGLLoggingLevelInfo:


### PR DESCRIPTION
Added check before emitting `LogEvent` messages via `RCTEventEmitter`.

On iOS each `RCTEventEmitter` module needs to track whether or not there are observers before sending events. Otherwise when events are emitted without observers a (console) warning is triggered by react-native, in this case: 

> Sending `LogEvent` with no listeners registered.

In practice I experienced Mapbox sending out messages after unmount causing the above warning.

Similar to https://github.com/react-native-mapbox-gl/maps/blob/f2eb9d7bb55cb3227b2ccc432de11e13246c689f/ios/RCTMGL/RCTMGLLocationModule.m#L85-L96
