### PR TITLE
Make errors during remove source a warning rather than a hard error

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTSource.java
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.mapbox.geojson.Feature;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.log.Logger;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.sources.Source;
@@ -28,6 +29,7 @@ import java.util.Map;
 
 public abstract class RCTSource<T extends Source> extends AbstractMapFeature {
     public static final String DEFAULT_ID = "composite";
+    public static final String LOG_TAG = "RCTSource";
 
     public static final double DEFAULT_HITBOX_WIDTH = 44.0;
     public static final double DEFAULT_HITBOX_HEIGHT = 44.0;
@@ -155,7 +157,11 @@ public abstract class RCTSource<T extends Source> extends AbstractMapFeature {
             mQueuedLayers.clear();
         }
         if (mMap != null && mSource != null  && mMap.getStyle() != null) {
-            mMap.getStyle().removeSource(mSource);
+            try {
+                mMap.getStyle().removeSource(mSource);
+            } catch (Throwable ex) {
+                Logger.w(LOG_TAG, String.format("RCTSource.removeFromMap: %s - %s", mSource, ex.getMessage()), ex);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes/silences the following error:
```
java.lang.Error: Cannot remove detached source
    at com.mapbox.mapboxsdk.maps.NativeMapView.nativeRemoveSource(NativeMapView.java)
    at com.mapbox.mapboxsdk.maps.NativeMapView.removeSource(NativeMapView.java:925)
    at com.mapbox.mapboxsdk.maps.Style.removeSource(Style.java:175)
    at com.mapbox.rctmgl.components.styles.sources.RCTSource.removeFromMap(RCTSource.java:158)
    at com.mapbox.rctmgl.components.mapview.RCTMGLMapView.removeAllSourcesFromMap(RCTMGLMapView.java:1229)
    at com.mapbox.rctmgl.components.mapview.RCTMGLMapView.setReactStyleURL(RCTMGLMapView.java:755)
    at com.mapbox.rctmgl.components.mapview.RCTMGLMapViewManager.setStyleURL(RCTMGLMapViewManager.java:120)
    at java.lang.reflect.Method.invoke(Method.java)
```

I could not reproduce the root cause, either a race, or because the sources were removed twice, somehow.
In any case the errors during source remove is now a warning only.