### PR TITLE
~>5.9.0 is the equivalent for ~>5.8 dep we've used before

### DIFF
--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-default_ios_mapbox_version = '~> 5.8.0'
+default_ios_mapbox_version = '~> 5.9.0'
 rnmbgl_ios_version = $ReactNativeMapboxGLIOSVersion || ENV["REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION"] || default_ios_mapbox_version
 if ENV.has_key?("REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION")
   puts "REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION env is deprecated please use `$ReactNativeMapboxGLIOSVersion = \"#{rnmbgl_ios_version}\"`"


### PR DESCRIPTION
We've used to use `~> 5.8`, wit #1052 we've replaced it with `~> 5.8.0`. But `~> 5.8` evaluates to `5.9.0` while `~> 5.8.0` evaluates to `5.8.0`.