### PR TITLE
Fix: onUpdate not called when renderMode is native

### DIFF
--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -198,10 +198,7 @@ class UserLocation extends React.Component {
    * @return {boolean}
    */
   needsLocationManagerRunning() {
-    if (this.props.renderMode === UserLocation.RenderMode.Native) {
-      return false;
-    }
-    return !!this.props.onUpdate || this.props.visible;
+    return !!this.props.onUpdate || (this.props.renderMode === UserLocation.RenderMode.Normal && this.props.visible);
   }
 
   _onLocationUpdate(location) {


### PR DESCRIPTION
Fixing https://github.com/react-native-mapbox-gl/maps/issues/854

There are two conditions where _LocationManager_ have to run:
- When user provides _onUpdate_ callback. 
- When _renderMode_ is _Normal_ and _UserLocation_ component is visible, then need _LocationManager_ running in order to update user location marker(blue dot) on the map.

_LocationManager_ in this context refers to JS _LocationManager_. In other words whether we need to push a stream of location changes over bridge. 