### PR TITLE
[iOS] ✨ Implemented ShapeSource.features(...) method

### DIFF
--- a/ios/RCTMGL/RCTMGLShapeSource.h
+++ b/ios/RCTMGL/RCTMGLShapeSource.h
@@ -29,4 +29,6 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 @property (nonatomic, assign) BOOL hasPressListener;
 
+- (nonnull NSArray<id <MGLFeature>> *)featuresMatchingPredicate:(nullable NSPredicate *)predicate;
+
 @end

--- a/ios/RCTMGL/RCTMGLShapeSource.m
+++ b/ios/RCTMGL/RCTMGLShapeSource.m
@@ -97,4 +97,11 @@ static UIImage * _placeHolderImage;
     return options;
 }
 
+- (nonnull NSArray<id <MGLFeature>> *)featuresMatchingPredicate:(nullable NSPredicate *)predicate
+{
+    MGLShapeSource *shapeSource = (MGLShapeSource *)self.source;
+    
+    return [shapeSource featuresMatchingPredicate:predicate];
+}
+
 @end

--- a/ios/RCTMGL/RCTMGLShapeSourceManager.h
+++ b/ios/RCTMGL/RCTMGLShapeSourceManager.h
@@ -7,7 +7,8 @@
 //
 
 #import "ViewManager.h"
+#import <React/RCTBridgeModule.h>
 
-@interface RCTMGLShapeSourceManager : ViewManager
+@interface RCTMGLShapeSourceManager : ViewManager<RCTBridgeModule>
 
 @end


### PR DESCRIPTION
- Export RCTMGLShapeSourceManager as RCTMGLShapeSource so it can be found by the native manager instance
- Added featuresMatchingPredicate to RCTMGLShapeSource which is used to query features
- Added features method to RCTMGLShapeSourceManager to query features of shape source from JS side (works no args or a filter arg according to documentation)

Fixes: https://github.com/react-native-mapbox-gl/maps/issues/1138