### PR TITLE
RasterLayer.sourceID should be string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -360,10 +360,6 @@ declare namespace MapboxGL {
     TrafficDay = 'mapbox://styles/mapbox/navigation-preview-day-v4',
     TrafficNight = 'mapbox://styles/mapbox/navigation-preview-night-v4',
   }
-
-  enum StyleSource {
-    DefaultSourceID = 0,
-  }
 }
 
 export type AttributionPosition =
@@ -775,7 +771,7 @@ export interface RasterSourceProps extends TileSourceProps {
 
 export interface LayerBaseProps<T = {}> extends Omit<ViewProps, 'style'> {
   id: string;
-  sourceID?: MapboxGL.StyleSource;
+  sourceID?: string;
   sourceLayerID?: string;
   aboveLayerID?: string;
   belowLayerID?: string;


### PR DESCRIPTION
The example here uses a string for RasterLayer.sourceID:
https://github.com/react-native-mapbox-gl/maps/blob/397482d4adc7e34cea30b39151c638e418a66f89/example/src/examples/WatercolorRasterTiles.js#L62

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/react-native-mapbox-gl/maps/1142)
<!-- Reviewable:end -->
