### PR TITLE
Fix typescript annotation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -477,7 +477,7 @@ export interface UserLocationProps {
   children?: ReactNode;
   minDisplacement?: number;
   onPress?: () => void;
-  onUpdate?: (location: MapboxGL.Location) => void;
+  onUpdate?: (location?: MapboxGL.Location) => void;
   renderMode?: 'normal' | 'native';
   showsUserHeadingIndicator?: boolean,
   visible?: boolean;


### PR DESCRIPTION
### Component **MapboxGL.UserLocation**, property **onUpdate**.

**Problem**
When application doesn't have access to the location service, param `location` in function onUpdate is undefined. Typescript annotation wrongly says it is alway defined.
```onUpdate?: (location: MapboxGL.Location) => void;```

https://github.com/react-native-mapbox-gl/maps/blob/b3d82a85cf95fbdae5c5924fdfe967e24aa4b46f/index.d.ts#L480

Tested on iOS 14.3 physical device.
