### PR TITLE
fix failing #needsLocationManagerRunning tests

### DIFF
--- a/__tests__/components/UserLocation.test.js
+++ b/__tests__/components/UserLocation.test.js
@@ -142,6 +142,7 @@ describe('UserLocation', () => {
 
     beforeEach(() => {
       ul = new UserLocation();
+
       jest.spyOn(locationManager, 'start').mockImplementation(jest.fn());
       jest.spyOn(locationManager, 'stop').mockImplementation(jest.fn());
       jest
@@ -150,11 +151,7 @@ describe('UserLocation', () => {
 
       ul.setState = jest.fn();
 
-      ul.props = {
-        animated: true,
-        visible: true,
-        minDisplacement: 0,
-      };
+      ul.props = UserLocation.defaultProps;
 
       ul._isMounted = true;
     });

--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -198,7 +198,11 @@ class UserLocation extends React.Component {
    * @return {boolean}
    */
   needsLocationManagerRunning() {
-    return !!this.props.onUpdate || (this.props.renderMode === UserLocation.RenderMode.Normal && this.props.visible);
+    return (
+      !!this.props.onUpdate ||
+      (this.props.renderMode === UserLocation.RenderMode.Normal &&
+        this.props.visible)
+    );
   }
 
   _onLocationUpdate(location) {


### PR DESCRIPTION
The change introduced by PR #1135 caused the `UserLocation` tests to fail.
This fixes the failing test