### PR TITLE
Fix: App crash when ProGuard is set to true

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/RCTMGLNativeUserLocationManager.java
@@ -8,7 +8,7 @@ import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import javax.annotation.Nonnull;
 
 public class RCTMGLNativeUserLocationManager extends ViewGroupManager<RCTMGLNativeUserLocation> {
-    public static final String REACT_CLASS = RCTMGLNativeUserLocation.class.getSimpleName();
+    public static final String REACT_CLASS = "RCTMGLNativeUserLocation";
 
     @Nonnull
     @Override

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLAndroidTextureMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLAndroidTextureMapView.java
@@ -8,7 +8,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 
 @SuppressWarnings({"MissingPermission"})
 public class RCTMGLAndroidTextureMapView extends RCTMGLMapView {
-	public static final String LOG_TAG = RCTMGLAndroidTextureMapView.class.getSimpleName();
+	public static final String LOG_TAG = "RCTMGLAndroidTextureMapView";
 	
     public RCTMGLAndroidTextureMapView(Context context, RCTMGLAndroidTextureMapViewManager manager, MapboxMapOptions options) {
         super(context, manager, options);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLAndroidTextureMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLAndroidTextureMapViewManager.java
@@ -10,7 +10,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
  */
 
 public class RCTMGLAndroidTextureMapViewManager extends RCTMGLMapViewManager {
-    public static final String LOG_TAG = RCTMGLAndroidTextureMapViewManager.class.getSimpleName();
+    public static final String LOG_TAG = "RCTMGLAndroidTextureMapViewManager";
     public static final String REACT_CLASS = "RCTMGLAndroidTextureMapView";
 
     public RCTMGLAndroidTextureMapViewManager(ReactApplicationContext context) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -97,7 +97,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         MapView.OnWillStartRenderingFrameListener, MapView.OnDidFinishRenderingFrameListener,
         MapView.OnWillStartRenderingMapListener, MapView.OnDidFinishRenderingMapListener,
         MapView.OnDidFinishLoadingStyleListener, MapView.OnStyleImageMissingListener {
-    public static final String LOG_TAG = RCTMGLMapView.class.getSimpleName();
+    public static final String LOG_TAG = "RCTMGLMapView";
 
     private RCTMGLMapViewManager mManager;
     private Context mContext;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -38,7 +38,7 @@ import static com.facebook.react.bridge.UiThreadUtil.runOnUiThread;
  */
 
 public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
-    public static final String LOG_TAG = RCTMGLMapViewManager.class.getSimpleName();
+    public static final String LOG_TAG = "RCTMGLMapViewManager";
     public static final String REACT_CLASS = "RCTMGLMapView";
 
     private Map<Integer, RCTMGLMapView> mViews;
@@ -332,7 +332,7 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
                         }
                         catch (Exception ex)
                         {
-                            Log.e(getClass().getSimpleName() , " disposeNativeMapView() exception destroying map view", ex);
+                            Log.e(LOG_TAG , " disposeNativeMapView() exception destroying map view", ex);
                         }
                     }
                 });

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/layers/RCTLayer.java
@@ -25,7 +25,7 @@ import java.util.Set;
  */
 
 public abstract class RCTLayer<T extends Layer> extends AbstractMapFeature {
-    public static final String LOG_TAG = RCTLayer.class.getSimpleName();
+    public static final String LOG_TAG = "RCTLayer";
 
     protected String mID;
     protected String mSourceID;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLImageSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLImageSource.java
@@ -19,7 +19,7 @@ import android.net.Uri;
  */
 
 public class RCTMGLImageSource extends RCTSource<ImageSource> {
-    public static final String LOG_TAG = RCTMGLImageSource.class.getSimpleName();
+    public static final String LOG_TAG = "RCTMGLImageSource";
 
     private URL mURL;
     private int mResourceId;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
@@ -39,7 +39,7 @@ import java.util.Map;
  */
 
 public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSource> {
-    public static final String LOG_TAG = RCTMGLShapeSourceManager.class.getSimpleName();
+    public static final String LOG_TAG = "RCTMGLShapeSourceManager";
     public static final String REACT_CLASS = "RCTMGLShapeSource";
 
     private ReactApplicationContext mContext;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/EventEmitter.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/EventEmitter.java
@@ -11,7 +11,7 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 
 public class EventEmitter {
-    public static final String LOG_TAG = EventEmitter.class.getSimpleName();
+    public static final String LOG_TAG = "EventEmitter";
 
 
     private static ReactContext getCurrentReactContext(ReactApplicationContext reactApplicationContext) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/LocationManager.java
@@ -32,7 +32,7 @@ public class LocationManager implements LocationEngineCallback<LocationEngineRes
     static final long DEFAULT_FASTEST_INTERVAL_MILLIS = 1000;
     static final long DEFAULT_INTERVAL_MILLIS = 1000;
 
-    public static final String LOG_TAG = LocationManager.class.getSimpleName();
+    public static final String LOG_TAG = "LocationManager";
 
     private LocationEngine locationEngine;
     private Context context;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/BitmapUtils.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/BitmapUtils.java
@@ -25,7 +25,7 @@ import java.net.URL;
  */
 
 public class BitmapUtils {
-    public static final String LOG_TAG = BitmapUtils.class.getSimpleName();
+    public static final String LOG_TAG = "BitmapUtils";
 
     private  static int CACHE_SIZE = 1024 * 1024;
     private static LruCache<String, Bitmap> mCache = new LruCache<String, Bitmap>(CACHE_SIZE) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/ConvertUtils.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/ConvertUtils.java
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 
 public class ConvertUtils {
-    public static final String LOG_TAG = ConvertUtils.class.getSimpleName();
+    public static final String LOG_TAG = "ConvertUtils";
 
     public static JsonObject toJsonObject(ReadableMap map) {
         if (map == null) return null;

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/DownloadMapImageTask.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/utils/DownloadMapImageTask.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
  */
 
 public class DownloadMapImageTask extends AsyncTask<Map.Entry<String, ImageEntry>, Void, List<Map.Entry<String, Bitmap>>> {
-    public static final String LOG_TAG = DownloadMapImageTask.class.getSimpleName();
+    public static final String LOG_TAG = "DownloadMapImageTask";
 
     private WeakReference<Context> mContext;
     private WeakReference<MapboxMap> mMap;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -95,7 +95,7 @@ def enableSeparateBuildPerCPUArchitecture = false
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore.


### PR DESCRIPTION
Fixing issue https://github.com/react-native-mapbox-gl/maps/issues/1183 . This PR is just extending previous PR to one more file https://github.com/react-native-mapbox-gl/maps/pull/260.

And enabling ProGuard which was by accident switch off in https://github.com/react-native-mapbox-gl/maps/pull/432