### PR TITLE
build: remove install dependency

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -25,7 +25,6 @@
     "@turf/nearest-point-on-line": ">= 4.0.0 <7.0.0",
     "buffer": "^5.1.0",
     "debounce": "^1.2.0",
-    "install": "^0.12.2",
     "moment": "^2.24.0",
     "npm": "^6.13.4",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
we have this `install` dependency and we don't seem to use it 🤷🏿 

removing