### PR TITLE
Fix inccorecct position of compass when `compassViewPosition` on `MapView` is set to `2`

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -1088,7 +1088,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
                     uiSettings.setCompassGravity(Gravity.TOP | Gravity.END);
                     break;
                 case 2:
-                    uiSettings.setCompassGravity(Gravity.BOTTOM | Gravity.END);
+                    uiSettings.setCompassGravity(Gravity.BOTTOM | Gravity.START);
                     break;
                 case 3:
                     uiSettings.setCompassGravity(Gravity.BOTTOM | Gravity.END);


### PR DESCRIPTION
Fix inccorecct position of compass when `compassViewPosition` on `MapView` is set to `2`