### PR TITLE
fix(user-location): exit early without proper location

### DIFF
--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -206,7 +206,7 @@ class UserLocation extends React.Component {
   }
 
   _onLocationUpdate(location) {
-    if (!this._isMounted) {
+    if (!this._isMounted || !location) {
       return;
     }
     let coordinates = null;


### PR DESCRIPTION
# DESCRIPTION
`_onLocationUpdate`  would not check if the `location` was actual valide. 
Instead it would go though it's motions and set the state, thus calling listeners, like `UserLocation` components `onUpdate` callbacks. 
Instead we should check if there even is a proper location and exit early if there isn't

This superseeds #1170 