### PR TITLE
build(react-navigation): remove react-native-safe-area-view

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -34,7 +34,6 @@
     "react-native-elements": "^2.2.1",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-safe-area-context": "^0.7.3",
-    "react-native-safe-area-view": "^0.13.1",
     "react-native-screens": "^2.4.0",
     "react-native-svg": "^12.1.0",
     "react-native-vector-icons": "6.6.0",


### PR DESCRIPTION
## DESCRIPTION
remove [`react-native-safe-area-view`](https://github.com/react-navigation/react-native-safe-area-view#react-native-safe-area-view), as it is deprecated and we do not need it