### PR TITLE
Fix heading indicator alignment

### DIFF
--- a/javascript/components/HeadingIndicator.js
+++ b/javascript/components/HeadingIndicator.js
@@ -9,6 +9,7 @@ const style = {
   iconImage: headingIcon,
   iconAllowOverlap: true,
   iconPitchAlignment: 'map',
+  iconRotationAlignment: 'map',
 };
 
 const HeadingIndicator = (heading) => (


### PR DESCRIPTION
Fixes the bug described in this issues: https://github.com/react-native-mapbox-gl/maps/issues/1214 https://github.com/react-native-mapbox-gl/maps/issues/1023