### PR TITLE
fix: No event on cancelled user pan

### DIFF
--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -490,7 +490,8 @@ RCT_EXPORT_METHOD(setSourceVisibility:(nonnull NSNumber *)reactTag
 
 - (void)mapView:(MGLMapView *)mapView regionDidChangeWithReason:(MGLCameraChangeReason)reason animated:(BOOL)animated
 {    
-    if ((reason & MGLCameraChangeReasonTransitionCancelled) == MGLCameraChangeReasonTransitionCancelled) return;
+    if (((reason & MGLCameraChangeReasonTransitionCancelled) == MGLCameraChangeReasonTransitionCancelled)
+        && ((reason & MGLCameraChangeReasonGesturePan) != MGLCameraChangeReasonGesturePan)) return;
 
     ((RCTMGLMapView *) mapView).isUserInteraction = (BOOL)(reason & ~MGLCameraChangeReasonProgrammatic);
     


### PR DESCRIPTION
Fixes #1008

Thanks to @VladMatvei for the suggested solution!

See referenced issue for more context about the bug.

This is narrows down the check to see if it is not a cancelled pan by a user-interaction. In which case it does not short-circuit the method. A pan made by a user, which is cancelled, should still dispatch the `onRegionDidChange`-event.