### PR TITLE
Fix type definition for OfflineManager

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -308,6 +308,7 @@ declare namespace MapboxGL {
       errorListener?: (pack: OfflinePack, err: OfflineProgressError) => void
     ): Promise<void>;
     deletePack(name: string): Promise<void>;
+    invalidatePack(name: string): Promise<void>;
     getPacks(): Promise<Array<OfflinePack>>;
     getPack(name: string): Promise<OfflinePack | undefined>;
     invalidateAmbientCache(): Promise<void>;


### PR DESCRIPTION
Adds a missing type definition for [MapboxGL.offlineManager.invalidatePack(name)](https://github.com/react-native-mapbox-gl/maps/blob/c42e96c3aee94758fe810a9fc06ade81d1352422/docs/OfflineManager.md#invalidatepackname)