### PR TITLE
Use build_type to handle non use_frameworks

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -35,6 +35,9 @@ target 'RNMapboxGLExample' do
 
   use_native_modules!
 
+  pre_install do |installer|
+    $RNMBGL.pre_install(installer)
+  end
   # Enables Flipper.
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
@@ -42,6 +45,7 @@ target 'RNMapboxGLExample' do
   use_flipper!
   post_install do |installer|
     flipper_post_install(installer)
+    $RNMBGL.post_install(installer)
   end
 end
 

--- a/example/ios/RNMapboxGLExample.xcodeproj/project.pbxproj
+++ b/example/ios/RNMapboxGLExample.xcodeproj/project.pbxproj
@@ -478,7 +478,6 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNMapboxGLExample/Pods-RNMapboxGLExample-resources.sh",
-				"${PODS_ROOT}/MapboxMobileEvents/MapboxMobileEvents/Resources/logger.html",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf",
@@ -499,7 +498,6 @@
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/logger.html",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AntDesign.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Entypo.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EvilIcons.ttf",
@@ -552,13 +550,13 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNMapboxGLExample/Pods-RNMapboxGLExample-frameworks.sh",
-				"${PODS_ROOT}/@react-native-mapbox-gl-mapbox-static/dynamic/MapboxMobileEvents.framework",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxMobileEvents/MapboxMobileEvents.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/install.md
+++ b/ios/install.md
@@ -2,9 +2,28 @@
 
 ## React-Native > `0.60.0`
 
-If you are using autolinking feature introduced in React-Native `0.60.0`, you just need `npm install @react-native-mapbox-gl/maps`, followed by `pod install` from the `ios` directory.
+If you are using autolinking feature introduced in React-Native `0.60.0`, you just need `npm install @react-native-mapbox-gl/maps`, 
 
-## Using CocoaPods
+Add the following to your `ios/Podfile`:
+
+```ruby
+  pre_install do |installer|
+    $RNMBGL.pre_install(installer)
+    ... other pre install hooks
+  end
+```
+
+```ruby
+  post_install do |installer|
+    $RNMBGL.post_install(installer)
+    ... other post install hooks
+  end
+```
+
+
+followed by `pod install` from the `ios` directory. Please also add the pre/post install cocoapods hooks.
+
+## Using CocoaPods without autolink
 
 To install with CocoaPods, add the following to your `Podfile`:
 
@@ -16,20 +35,6 @@ To install with CocoaPods, add the following to your `Podfile`:
 
 Then run `pod install` and rebuild your project.
 
-## use_frameworks!
-
-Mapbox normally [requires](https://github.com/mapbox/mapbox-gl-native-ios/issues/154) `use_frameworks!` in cocoapods. By default we implement a [workaround](https://github.com/react-native-mapbox-gl/maps/pull/714). In case you need `use_frameworks!` for some reason, you can use the mapbox pod without the workaround with the `DynamicLibrary` subspec:
-
-
-```ruby
-  # Mapbox
-  pod 'react-native-mapbox-gl/DynamicLibrary', :path => '../node_modules/@react-native-mapbox-gl/maps'
-
-  ...
-
-  use_frameworks!
-
-```
 
 ## Mapbox Maps SDK
 

--- a/react-native-mapbox-gl.podspec
+++ b/react-native-mapbox-gl.podspec
@@ -8,6 +8,32 @@ if ENV.has_key?("REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION")
   puts "REACT_NATIVE_MAPBOX_MAPBOX_IOS_VERSION env is deprecated please use `$ReactNativeMapboxGLIOSVersion = \"#{rnmbgl_ios_version}\"`"
 end
 
+TargetsToChangeToDynamic = ['MapboxMobileEvents']
+
+$RNMBGL = Object.new
+
+def $RNMBGL.post_install(installer)
+  installer.pod_targets.each do |pod|
+    if TargetsToChangeToDynamic.include?(pod.name)
+      if pod.send(:build_type) != Pod::BuildType.dynamic_framework
+        pod.instance_variable_set(:@build_type,Pod::BuildType.dynamic_framework)
+        puts "* Changed #{pod.name} to `#{pod.send(:build_type)}`"
+        fail "Unable to change build_type" unless mobile_events_target.send(:build_type) == Pod::BuildType.dynamic_framework
+      end
+    end
+  end
+end
+
+def $RNMBGL.pre_install(installer)
+  installer.aggregate_targets.each do |target|
+    target.pod_targets.select { |p| TargetsToChangeToDynamic.include?(p.name) }.each do |mobile_events_target|
+      mobile_events_target.instance_variable_set(:@build_type,Pod::BuildType.dynamic_framework)
+      puts "* Changed #{mobile_events_target.name} to #{mobile_events_target.send(:build_type)}"
+      fail "Unable to change build_type" unless mobile_events_target.send(:build_type) == Pod::BuildType.dynamic_framework
+    end
+  end
+end
+
 Pod::Spec.new do |s|
   s.name		= "react-native-mapbox-gl"
   s.summary		= "React Native Component for Mapbox GL"
@@ -30,7 +56,7 @@ Pod::Spec.new do |s|
     s.default_subspecs= ['DynamicLibrary']
   else
     s.subspec 'StaticLibraryFixer' do |sp|
-      s.dependency '@react-native-mapbox-gl-mapbox-static', rnmbgl_ios_version
+      # s.dependency '@react-native-mapbox-gl-mapbox-static', rnmbgl_ios_version
     end
 
     s.default_subspecs= ['DynamicLibrary', 'StaticLibraryFixer']


### PR DESCRIPTION
Fixes: #1097 

This needs to be added to the Podfile:

```ruby
pre_install do |installer|
   $RNMBGL.pre_install(installer)
   ...
end
```


```ruby
post_install do |installer|
   $RNMBGL.post_install(installer)
   ....
end
```

