### PR TITLE
fix compile issues with flipper

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -42,7 +42,7 @@ target 'RNMapboxGLExample' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
+  use_flipper!({ 'Flipper-Folly' => '2.3.0' })
   post_install do |installer|
     flipper_post_install(installer)
     $RNMBGL.post_install(installer)


### PR DESCRIPTION
as discussed [here](https://github.com/react-native-mapbox-gl/maps/pull/1262#issuecomment-791588054), 
ios builds with flipper integration won't build otherwise