### PR TITLE
Add getClusterExpansionZoom to ShapeSource

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
@@ -171,4 +171,33 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
         AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
         mManager.handleEvent(event);
     }
+
+    public void getClusterExpansionZoom(String callbackID, int clusterId) {
+        if (mSource == null) {
+            WritableMap payload = new WritableNativeMap();
+            payload.putString("error", "source is not yet loaded");
+            AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+            mManager.handleEvent(event);
+            return;
+        }
+        List<Feature> features = mSource.querySourceFeatures(Expression.eq(Expression.id(), clusterId));
+        int zoom = -1;
+        if (features.size() > 0) {
+            zoom = mSource.getClusterExpansionZoom(features.get(0));
+        }
+
+        if (zoom == -1) {
+            WritableMap payload = new WritableNativeMap();
+            payload.putString("error", "Could not get zoom for cluster id " + clusterId);
+            AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+            mManager.handleEvent(event);
+            return;
+        }
+
+        WritableMap payload = new WritableNativeMap();
+        payload.putInt("data", zoom);
+
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+        mManager.handleEvent(event);
+    }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
@@ -148,12 +148,14 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
 
     //region React Methods
     public static final int METHOD_FEATURES = 103;
+    public static final int METHOD_GET_CLUSTER_EXPANSION_ZOOM = 104;
 
     @Nullable
     @Override
     public Map<String, Integer> getCommandsMap() {
         return MapBuilder.<String, Integer>builder()
                 .put("features", METHOD_FEATURES)
+                .put("getClusterExpansionZoom", METHOD_GET_CLUSTER_EXPANSION_ZOOM)
                 .build();
     }
 
@@ -165,6 +167,9 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
                         args.getString(0),
                         ExpressionParser.from(args.getArray(1))
                         );
+                break;
+            case METHOD_GET_CLUSTER_EXPANSION_ZOOM:
+                source.getClusterExpansionZoom(args.getString(0), args.getInt(1));
                 break;
         }
     }

--- a/docs/ShapeSource.md
+++ b/docs/ShapeSource.md
@@ -36,6 +36,22 @@ shapeSource.features()
 ```
 
 
+#### getClusterExpansionZoom(clusterId)
+
+Returns the zoom needed to expand the cluster.
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `clusterId` | `number` | `Yes` | The id of the cluster to expand. |
+
+
+
+```javascript
+const zoom = await shapeSource.getClusterExpansionZoom(clusterId);
+```
+
+
 #### onPress(event)
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3574,6 +3574,33 @@
         ]
       },
       {
+        "name": "getClusterExpansionZoom",
+        "docblock": "Returns the zoom needed to expand the cluster.\n\n@example\nconst zoom = await shapeSource.getClusterExpansionZoom(clusterId);\n\n@param  {number} clusterId - The id of the cluster to expand.\n@return {number}",
+        "modifiers": [
+          "async"
+        ],
+        "params": [
+          {
+            "name": "clusterId",
+            "description": "The id of the cluster to expand.",
+            "type": {
+              "name": "number"
+            },
+            "optional": false
+          }
+        ],
+        "returns": {
+          "description": null,
+          "type": {
+            "name": "number"
+          }
+        },
+        "description": "Returns the zoom needed to expand the cluster.",
+        "examples": [
+          "\nconst zoom = await shapeSource.getClusterExpansionZoom(clusterId);\n\n"
+        ]
+      },
+      {
         "name": "onPress",
         "docblock": null,
         "modifiers": [],

--- a/index.d.ts
+++ b/index.d.ts
@@ -276,7 +276,9 @@ declare namespace MapboxGL {
    * Sources
    */
   class VectorSource extends Component<VectorSourceProps> { }
-  class ShapeSource extends Component<ShapeSourceProps> { }
+  class ShapeSource extends Component<ShapeSourceProps> {
+    getClusterExpansionZoom(clusterId: number): Promise<number>;
+  }
   class RasterSource extends Component<RasterSourceProps> { }
 
   /**

--- a/ios/RCTMGL/RCTMGLShapeSource.h
+++ b/ios/RCTMGL/RCTMGLShapeSource.h
@@ -31,4 +31,6 @@
 
 - (nonnull NSArray<id <MGLFeature>> *)featuresMatchingPredicate:(nullable NSPredicate *)predicate;
 
+- (double)getClusterExpansionZoom:(nonnull NSNumber *)clusterId;
+
 @end

--- a/ios/RCTMGL/RCTMGLShapeSource.m
+++ b/ios/RCTMGL/RCTMGLShapeSource.m
@@ -26,7 +26,7 @@ static UIImage * _placeHolderImage;
 - (void)setShape:(NSString *)shape
 {
     _shape = shape;
-    
+
     if (self.source != nil) {
         MGLShapeSource *source = (MGLShapeSource *)self.source;
         [source setShape: shape == nil ? nil : [RCTMGLUtils shapeFromGeoJSON:_shape]];
@@ -46,19 +46,19 @@ static UIImage * _placeHolderImage;
     if (self.map.style == nil) {
         return;
     }
-    
+
     [super removeFromMap];
 }
 
 - (nullable MGLSource*)makeSource
 {
     NSDictionary<MGLShapeSourceOption, id> *options = [self _getOptions];
-    
+
     if (_shape != nil) {
         MGLShape *shape = [RCTMGLUtils shapeFromGeoJSON:_shape];
         return [[MGLShapeSource alloc] initWithIdentifier:self.id shape:shape options:options];
     }
-    
+
     if (_url != nil) {
         NSURL *url = [[NSURL alloc] initWithString:_url];
         return [[MGLShapeSource alloc] initWithIdentifier:self.id URL:url options:options];
@@ -69,39 +69,49 @@ static UIImage * _placeHolderImage;
 - (NSDictionary<MGLShapeSourceOption, id>*)_getOptions
 {
     NSMutableDictionary<MGLShapeSourceOption, id> *options = [[NSMutableDictionary alloc] init];
-    
+
     if (_cluster != nil) {
         options[MGLShapeSourceOptionClustered] = [NSNumber numberWithBool:[_cluster intValue] == 1];
     }
-    
+
     if (_clusterRadius != nil) {
         options[MGLShapeSourceOptionClusterRadius] = _clusterRadius;
     }
-    
+
     if (_clusterMaxZoomLevel != nil) {
         options[MGLShapeSourceOptionMaximumZoomLevelForClustering] = _clusterMaxZoomLevel;
     }
-    
+
     if (_maxZoomLevel != nil) {
         options[MGLShapeSourceOptionMaximumZoomLevel] = _maxZoomLevel;
     }
-    
+
     if (_buffer != nil) {
         options[MGLShapeSourceOptionBuffer] = _buffer;
     }
-    
+
     if (_tolerance != nil) {
         options[MGLShapeSourceOptionSimplificationTolerance] = _tolerance;
     }
-    
+
     return options;
 }
 
 - (nonnull NSArray<id <MGLFeature>> *)featuresMatchingPredicate:(nullable NSPredicate *)predicate
 {
     MGLShapeSource *shapeSource = (MGLShapeSource *)self.source;
-    
+
     return [shapeSource featuresMatchingPredicate:predicate];
+}
+
+- (double)getClusterExpansionZoom:(nonnull NSNumber *)clusterId
+{
+    MGLShapeSource *shapeSource = (MGLShapeSource *)self.source;
+    NSArray<id<MGLFeature>> *features = [shapeSource featuresMatchingPredicate: [NSPredicate predicateWithFormat:@"%K = %i", @"cluster_id", clusterId.intValue]];
+    if (features.count == 0) {
+        return -1;
+    }
+    return [shapeSource zoomLevelForExpandingCluster:(MGLPointFeatureCluster *)features[0]];
 }
 
 @end

--- a/ios/RCTMGL/RCTMGLShapeSourceManager.m
+++ b/ios/RCTMGL/RCTMGLShapeSourceManager.m
@@ -46,7 +46,7 @@ RCT_EXPORT_METHOD(features:(nonnull NSNumber*)reactTag
 {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
         RCTMGLShapeSource* shapeSource = viewRegistry[reactTag];
-        
+
         if (![shapeSource isKindOfClass:[RCTMGLShapeSource class]]) {
             RCTLogError(@"Invalid react tag, could not find RCTMGLMapView");
             return;
@@ -54,17 +54,38 @@ RCT_EXPORT_METHOD(features:(nonnull NSNumber*)reactTag
 
         NSPredicate* predicate = [FilterParser parse:filter];
         NSArray<id<MGLFeature>> *shapes = [shapeSource featuresMatchingPredicate: predicate];
-        
+
         NSMutableArray<NSDictionary*> *features = [[NSMutableArray alloc] initWithCapacity:shapes.count];
         for (int i = 0; i < shapes.count; i++) {
             [features addObject:shapes[i].geoJSONDictionary];
         }
-        
+
         resolve(@{
                   @"data": @{ @"type": @"FeatureCollection", @"features": features }
                   });
     }];
 }
 
+RCT_EXPORT_METHOD(getClusterExpansionZoom:(nonnull NSNumber*)reactTag
+                                clusterId:(nonnull NSNumber*)clusterId
+                                 resolver:(RCTPromiseResolveBlock)resolve
+                                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
+        RCTMGLShapeSource* shapeSource = (RCTMGLShapeSource *)viewRegistry[reactTag];
+
+        if (![shapeSource isKindOfClass:[RCTMGLShapeSource class]]) {
+            RCTLogError(@"Invalid react tag, could not find RCTMGLMapView");
+            return;
+        }
+
+        double zoom = [shapeSource getClusterExpansionZoom:clusterId];
+        if (zoom == -1) {
+          reject(@"zoom_error", [NSString stringWithFormat:@"Could not get zoom for cluster id %@", clusterId], nil);
+          return;
+        }
+        resolve(@{@"data":@(zoom)});
+    }];
+}
 
 @end

--- a/javascript/components/ShapeSource.js
+++ b/javascript/components/ShapeSource.js
@@ -147,6 +147,24 @@ class ShapeSource extends NativeBridgeComponent(AbstractSource) {
     return res.data;
   }
 
+  /**
+   * Returns the zoom needed to expand the cluster.
+   *
+   * @example
+   * const zoom = await shapeSource.getClusterExpansionZoom(clusterId);
+   *
+   * @param  {number} clusterId - The id of the cluster to expand.
+   * @return {number}
+   */
+  async getClusterExpansionZoom(clusterId) {
+    const res = await this._runNativeCommand(
+      'getClusterExpansionZoom',
+      this._nativeRef,
+      [clusterId],
+    );
+    return res.data;
+  }
+
   setNativeProps(props) {
     const shallowProps = Object.assign({}, props);
 


### PR DESCRIPTION
This allows using the mapbox sdk to get the zoom needed to expand a cluster by adding  getClusterExpansionZoom to instances of ShapeSource.

The code is mostly adapted from a similar method `features` on ShapeSource.

Tested these changes in an app on iOS and android.

```js

const source = React.useRef(null);

...

<MapboxGL.ShapeSource
  ref={source}
  onPress={async (e) => {
    const feature = e.features[0];
    if (feature.properties?.cluster) {
      const zoom = await source.current.getClusterExpansionZoom(
        feature.properties.cluster_id,
      );
      // use zoom
    }
  }}
  cluster
  clusterMaxZoomLevel={13}
  clusterRadius={40}
/>
```