### PR TITLE
Allow Mapbox or MapLibre from SPM on iOS, and different libs on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ PR Title ([#123](link to my pr))
 
 ----
 ## NEXT
+Allow MapLibre as an option ([#1311](https://github.com/react-native-mapbox-gl/maps/pull/1311))
 Fix native UserLocation on Android ([#1284](https://github.com/react-native-mapbox-gl/maps/pull/1284))   
 Add getClusterExpansionZoom to ShapeSource ([#1279](https://github.com/react-native-mapbox-gl/maps/pull/1279))  
 Add type definition for AnimatedPoint ([#1280](https://github.com/react-native-mapbox-gl/maps/pull/1280))  

--- a/android/install.md
+++ b/android/install.md
@@ -42,3 +42,42 @@ Check the current version of the SDK [here](https://docs.mapbox.com/android/maps
 
 
 If you are using version newer versions of the SDK, you will need to authorize your download of the Maps SDK with a secret access token with the DOWNLOADS:READ scope. This [guide](https://docs.mapbox.com/android/maps/guides/install/#configure-credentials) explains how to configure the secret token under section `Configure your secret token`.
+
+## Using MapLibre
+
+[MapLibre](https://github.com/maplibre/maplibre-gl-native) is an OSS fork of MapboxGL
+
+Overwrite mapbox dependecies within your `android/build.gradle`
+
+```
+buildscript {
+    ext {
+        ...
+
+        rnmbglMapboxLibs = {
+            implementation ("org.maplibre.gl:android-sdk:9.2.1")
+            implementation ("com.mapbox.mapboxsdk:mapbox-sdk-turf:5.3.0")
+        }
+
+        rnmbglMapboxPlugins = {
+            implementation ("com.mapbox.mapboxsdk:mapbox-android-gestures:0.7.0")
+            implementation ("com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.12.0")    {
+                exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
+            }
+            implementation ("com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0")        {
+                exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
+            }
+            implementation ("com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v9:0.4.0") {
+                exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
+            }
+        }
+    }
+}
+
+repositories {
+    ...
+    maven {
+        url = "https://dl.bintray.com/maplibre/maplibre-gl-native"
+    }
+}
+```

--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -28,6 +28,23 @@ android {
     }
 }
 
+def customizableDependencies(name, defaultDependencies) {
+    if (rootProject.ext.has(name)) {
+        def libs = rootProject.ext.get(name)
+        if (libs instanceof CharSequence) {
+            libs.split(';').each {
+                implementation it
+            }
+        } else {
+            libs.delegate = defaultDependencies.owner.delegate
+            libs.call()
+        }
+    } else {
+        defaultDependencies.delegate = defaultDependencies.owner.delegate
+        defaultDependencies.call()
+    }
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
@@ -35,11 +52,7 @@ dependencies {
     implementation "com.facebook.react:react-native:+"
 
     // Mapbox SDK
-    if (rootProject.ext.has('rnmbglMapboxLibs')) {
-        rootProject.ext.get('rnmbglMapboxLibs').split(';').each {
-           implementation it
-        }
-    } else {
+    customizableDependencies('rnmbglMapboxLibs') {
         implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:5.1.0'
         implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.1.0'
         implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
@@ -51,12 +64,9 @@ dependencies {
     implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '28.0.0')}"
     implementation "com.squareup.okhttp3:okhttp:${safeExtGet('okhttpVersion', '3.12.1')}"
 
+
     // Mapbox plugins
-    if (rootProject.ext.has('rnmbglMapboxPlugins')) {
-        rootProject.ext.get('rnmbglMapboxPlugins').split(';').each {
-           implementation it
-        }
-    } else {
+    customizableDependencies('rnmbglMapboxPlugins') {
         implementation 'com.mapbox.mapboxsdk:mapbox-android-gestures:0.6.0'
         implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.12.0'
         implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v9:0.4.0'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,6 +6,28 @@ buildscript {
         minSdkVersion = 16
         compileSdkVersion = 29
         targetSdkVersion = 29
+
+        useMapLibre = false
+
+        if (useMapLibre) {
+            rnmbglMapboxLibs = {
+                implementation ("org.maplibre.gl:android-sdk:9.2.1")
+                implementation ("com.mapbox.mapboxsdk:mapbox-sdk-turf:5.3.0")
+            }
+
+            rnmbglMapboxPlugins = {
+                implementation ("com.mapbox.mapboxsdk:mapbox-android-gestures:0.7.0")
+                implementation ("com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.12.0")    {
+                    exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
+                }
+                implementation ("com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0")        {
+                    exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
+                }
+                implementation ("com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v9:0.4.0") {
+                    exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
+                }
+            }
+        }
     }
     repositories {
         google()
@@ -29,6 +51,12 @@ allprojects {
         maven {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
+        }
+
+        if (rootProject.ext.get('useMapLibre')) {
+            maven {
+                url = "https://dl.bintray.com/maplibre/maplibre-gl-native"
+            }
         }
 
         google()

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -3,6 +3,19 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 
 platform :ios, '10.0'
 
+useMapLibre = false
+
+if useMapLibre
+  $RNMBGL_Use_SPM = {
+    url: "https://github.com/maplibre/maplibre-gl-native-distribution",
+    requirement: {
+      kind: "upToNextMajorVersion",
+      minimumVersion: "5.11.0"
+    },
+    product_name: "Mapbox"
+  }
+end
+
 # We ingore warning except for RNMBGL
 INHIBIT_WARNING_BY_DEFAULT = true
 

--- a/ios/install.md
+++ b/ios/install.md
@@ -53,3 +53,35 @@ Check the current version of the SDK [here](https://docs.mapbox.com/ios/maps/ove
 ### Mapbox Maps SDK > `v6.0.0`
 
 If you are using version `v6.0.0` of the SDK or later, you will need to authorize your download of the Maps SDK with a secret access token with the `DOWNLOADS:READ` scope. This [guide](https://docs.mapbox.com/ios/maps/overview/#install-the-sdk) explains how to configure the secret token under section `Configure your secret token`.
+
+### Maplibre
+
+## Using MapLibre
+
+[MapLibre](https://github.com/maplibre/maplibre-gl-native) is an OSS fork of MapboxGL
+
+Overwrite mapbox dependecies within your `ios/Podfile`:
+
+
+
+```
+$RNMBGL_Use_SPM = {
+  url: "https://github.com/maplibre/maplibre-gl-native-distribution",
+  requirement: {
+    kind: "upToNextMajorVersion",
+    minimumVersion: "5.11.0"
+  },
+  product_name: "Mapbox"
+}
+
+pre_install do |installer|
+  $RNMBGL.pre_install(installer)
+  ...
+end
+
+post_install do |installer|
+  $RNMBGL.post_install(installer)
+  ...
+end
+
+```


### PR DESCRIPTION
## Description

This PR allows to specify the Mapbox library to be consumed via SwiftPackageManager. This means MapLibre for example can be used instead of Mapbox.

Fixes #1273 


Podfile:
```ruby

$RNMBGL_Use_SPM = {
  url: "https://github.com/maplibre/maplibre-gl-native-distribution",
  requirement: {
    kind: "upToNextMajorVersion",
    minimumVersion: "5.11.0"
  },
  product_name: "Mapbox"
}


pre_install do |installer|
  $RNMBGL.pre_install(installer)
end
...

post_install do |installer|
   flipper_post_install(installer)
   $RNMBGL.post_install(installer)
end
```

Top level build.gradle:
```groovy
buildscript {
    ext {
   ...
         rnmbglMapboxLibs = {
             implementation ("org.maplibre.gl:android-sdk:9.2.1")
             implementation ("com.mapbox.mapboxsdk:mapbox-sdk-turf:5.3.0")
         }

         rnmbglMapboxPlugins = {
             implementation ("com.mapbox.mapboxsdk:mapbox-android-gestures:0.7.0")
             implementation ("com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.12.0")    {
                 exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
             }
             implementation ("com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0")        {
                 exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
             }
             implementation ("com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v9:0.4.0") {
                 exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-sdk'
              }
         }
}
```