### PR TITLE
feat(ts): add types for Logger class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ PR Title ([#123](link to my pr))
 
 ----
 ## NEXT
+Add types for `Logger` class ([#1316](https://github.com/react-native-mapbox-gl/maps/pull/1316))
 Enable linear easing on map camera ([#1281](https://github.com/react-native-mapbox-gl/maps/pull/1281))  
 Allow MapLibre as an option ([#1311](https://github.com/react-native-mapbox-gl/maps/pull/1311))  
 Fix native UserLocation on Android ([#1284](https://github.com/react-native-mapbox-gl/maps/pull/1284))   

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ export default class App extends Component {
 
 - [MapboxGL](/docs/MapboxGL.md)
 - [CustomHttpHeaders](/docs/CustomHttpHeaders.md)
+- [Logger](/docs/Logger.md)
 
 ## Expo Support
 

--- a/docs/Logger.md
+++ b/docs/Logger.md
@@ -1,0 +1,23 @@
+## Logger
+###
+
+### methods
+#### setLogLevel(LogLevel)
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `LogLevel` | `String` | `Yes` | required level of logging, can be `"error" | "warning" | "info" | "debug" | "verbose"` |
+
+##### Description
+sets the amount of logging
+
+#### setLogCallback(LogCallback)
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `LogCallback` | `function` | `Yes` | callback taking a log object `{ message: String, level: LogLevel, tag: String }` as param. If callback return falsy value then default logging will take place.  |
+
+##### Description
+overwrite logging - good to mute specific errors/ warnings

--- a/index.d.ts
+++ b/index.d.ts
@@ -906,7 +906,7 @@ export interface SnapshotOptions {
 type LogLevel = "error" | "warning" | "info" | "debug" | "verbose";
 
 interface LogObject {
-  level: string;
+  level: LogLevel;
   msg: string;
   tag: string;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -902,4 +902,20 @@ export interface SnapshotOptions {
   writeToDisk?: boolean;
 }
 
+// Logger class
+type LogLevel = "error" | "warning" | "info" | "debug" | "verbose";
+
+interface LogObject {
+  level: string;
+  msg: string;
+  tag: string;
+}
+
+type LogCallback = (object: LogObject) => void;
+
+export class Logger {
+  public static setLogCallback: (cb: LogCallback) => boolean;
+  public static setLogLevel: (level: LogLevel) => void;
+}
+
 export default MapboxGL;


### PR DESCRIPTION
## Description
As the title implies, this adds types for the public methods of the `Logger` class. 
This should be enough to us it in a `.ts|x` file without it screaming in agony. 

Fixes #1289

## Checklist

<!-- Check completed item: [X] -->

* ~[ ] I have tested this on a device/simulator for each compatible OS~
* [x] I updated the documentation `yarn generate`
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`index.d.ts`)
* ~[ ] I added/ updated a sample  (`/example`)~
