### PR TITLE
chore: release 8.2.0 beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,18 @@ PR Title ([#123](link to my pr))
 
 ----
 ## NEXT
-Add types for `Logger` class ([#1316](https://github.com/react-native-mapbox-gl/maps/pull/1316))
+
+
+----
+
+## 8.2.0-beta2
+Add types for `Logger` class ([#1316](https://github.com/react-native-mapbox-gl/maps/pull/1316))  
 Enable linear easing on map camera ([#1281](https://github.com/react-native-mapbox-gl/maps/pull/1281))  
 Allow MapLibre as an option ([#1311](https://github.com/react-native-mapbox-gl/maps/pull/1311))  
 Fix native UserLocation on Android ([#1284](https://github.com/react-native-mapbox-gl/maps/pull/1284))   
 Add getClusterExpansionZoom to ShapeSource ([#1279](https://github.com/react-native-mapbox-gl/maps/pull/1279))  
 Add type definition for AnimatedPoint ([#1280](https://github.com/react-native-mapbox-gl/maps/pull/1280))  
 
-----
 
 ## 8.2.0-beta1
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,24 @@
+# How to create a release for this repo
+## Make sure `master` builds correctly
+Are all our [actions](https://github.com/react-native-mapbox-gl/maps/actions) passing successfully?
+If not, make sure to investigate the issue and fix it prior to a release.
+
+## Bump the version in our package.json
+Once you verified, that `master` isn't broken, go on and increase the `version` within our `package.json`.
+
+## Update the CHANGELOG accordingly
+Our CHANGELOG.md should be updated whenever a PR is merged/ noteworthy changes are commited to `master`.
+Prior to a release the changes should be documented under the `NEXT` section.  
+Once it's clear, that a release is about to be published, move the items under `NEXT` to this releases sections.  
+Let your actions be guided by the previous release entries.
+
+## Draft a new release on Github
+Within the [releases](https://github.com/react-native-mapbox-gl/maps/releases) section of the repo  
+you can [`Draft a new release`](https://github.com/react-native-mapbox-gl/maps/releases/new). 
+
+`Tag version` & `Release title` should be the same.
+As redundant as it might sound, please add the changes from the `CHANGELOG.md` into the body of the release.
+
+## Monitor the repos issues for updates
+Once the release is out the door, make sure to monitor the issues closely for problems the community might encounter
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-native-mapbox-gl/maps",
   "description": "A Mapbox GL react native module for creating custom maps",
-  "version": "8.2.0-beta1",
+  "version": "8.2.0-beta2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Description
Preparation for release of `8.2.0-beta2`
Updates `Changelog` & adds a `RELEASE.md` file to share knowledge on how to prepare and publish a release
