### PR TITLE
Fix #597 - maxBounds/(min|max)ZoomLevel can be updated dynamically

### DIFF
--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -195,6 +195,21 @@ class Camera extends React.Component {
       });
       return;
     }
+    if (nextCamera.maxBounds) {
+      this.refs.camera.setNativeProps({
+        maxBounds: this._getMaxBounds()
+      });
+    }
+    if (nextCamera.minZoomLevel) {
+      this.refs.camera.setNativeProps({
+        minZoomLevel: this.props.minZoomLevel
+      });
+    }
+    if (nextCamera.maxZoomLevel) {
+      this.refs.camera.setNativeProps({
+        maxZoomLevel: this.props.maxZoomLevel
+      });
+    }
 
     const cameraConfig = {
       animationMode: nextCamera.animationMode,
@@ -239,10 +254,16 @@ class Camera extends React.Component {
       c.animationMode !== n.animationMode ||
       c.animationDuration !== n.animationDuration;
 
+    const hasNavigationConstraintsPropsChanged =
+      this._hasMaxBoundsChanged(c, n) ||
+      c.minZoomLevel !== n.minZoomLevel ||
+      c.maxZoomLevel !== n.maxZoomLevel;
+
     return (
       hasDefaultPropsChanged ||
       hasFollowPropsChanged ||
-      hasAnimationPropsChanged
+      hasAnimationPropsChanged ||
+      hasNavigationConstraintsPropsChanged
     );
   }
 
@@ -286,6 +307,26 @@ class Camera extends React.Component {
       cB.paddingLeft !== nB.paddingLeft ||
       cB.paddingRight !== nB.paddingRight ||
       cB.paddingBottom !== nB.paddingBottom
+    );
+  }
+
+  _hasMaxBoundsChanged(currentCamera, nextCamera) {
+    const cMB = currentCamera.maxBounds;
+    const nMB = nextCamera.maxBounds;
+
+    if (!cMB && !nMB) {
+      return false;
+    }
+
+   if (existenceChange(cMB, nMB)) {
+      return true;
+    }
+
+    return (
+      cMB.ne[0] !== nMB.ne[0] ||
+      cMB.ne[1] !== nMB.ne[1] ||
+      cMB.sw[0] !== nMB.sw[0] ||
+      cMB.sw[1] !== nMB.sw[1]
     );
   }
 


### PR DESCRIPTION
Should resolve #597 issue.

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #597.

This module should accept the update of several props: maxBounds, minZoomLevel, maxZoomLevel during the runtime (after the creation of the Camera).

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [x] I updated the documentation `yarn generate`
* [ ] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`index.d.ts`)
* [ ] I added/ updated a sample  (`/example`)

No need to update index.d.ts or change the documentation.

The fix could be added in the CHANGELOG.md (not done yet). 

And an example could be made in order to show changes in the bounds or zooms restrictions, for example after clicking on some buttons. But maybe not so useful.

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
