### PR TITLE
Add some missing props to TypeScript lib def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 
+Add some missing props to TypeScript lib def ([#1360](https://github.com/react-native-mapbox-gl/maps/pull/1360))
+
 ----
 ## NEXT
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -667,6 +667,7 @@ export interface SymbolLayerStyle {
   symbolPlacement?: 'point' | 'line' | Expression;
   symbolSpacing?: number | Expression;
   symbolAvoidEdges?: boolean | Expression;
+  symbolSortKey?: number | Expression;
   symbolZOrder?: 'auto' | 'viewport-y' | 'source' | Expression;
   iconAllowOverlap?: boolean | Expression;
   iconIgnorePlacement?: boolean | Expression;
@@ -869,6 +870,8 @@ export interface HeatmapLayerProps extends LayerBaseProps {
 
 export interface ImagesProps extends ViewProps {
   images?: { assets?: string[] } & { [key: string]: ImageSourcePropType };
+  nativeAssetImages?: string[]
+  onImageMissing?: (imageKey: string) => void
 }
 
 export interface ImageSourceProps extends ViewProps {


### PR DESCRIPTION
## Description

This adds some missing props to the TypeScript lib def file that I have encountered. 

I am aware of #1067, but I guess it will still take some time before that one is merged and released.

I have not used `onImageMissing` myself, but from looking at the source code it seems like this function is called with the name of the missing image as a string. Please correct me if I'm wrong.

## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I updated the documentation `yarn generate`
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`index.d.ts`)
* [ ] I added/ updated a sample  (`/example`)
