### PR TITLE
Add telemetry dependency to avoid android 11 crash

### DIFF
--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     customizableDependencies('rnmbglMapboxLibs') {
         implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:5.1.0'
         implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.1.0'
+        implementation 'com.mapbox.mapboxsdk:mapbox-android-telemetry:6.1.0'
         implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
     }
 


### PR DESCRIPTION
## Description

Fixes #1286

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I updated the documentation `yarn generate`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`index.d.ts`)
* [ ] I added/ updated a sample  (`/example`)
