### PR TITLE
stopLocationManger on Destroy

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLocationModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLocationModule.java
@@ -43,7 +43,7 @@ public class RCTMGLLocationModule extends ReactContextBaseJavaModule {
 
         @Override
         public void onHostDestroy() {
-            startLocationManager();
+            stopLocationManager();
         }
     };
 


### PR DESCRIPTION
We got some issues with locations being probed while the app is in the background.  
This is one of those issues: https://github.com/react-native-mapbox-gl/maps/issues/1363#

And as mentioned in this comment: https://github.com/react-native-mapbox-gl/maps/issues/1363#issuecomment-852849109

The locationmanager is being started onHostDestroy.  
Probably a copy/ paste error from the big expression update.

