### PR TITLE
Created Expo config plugin

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 index.d.ts
 scripts/
+plugin/build

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
 index.d.ts
 scripts/
-plugin/build
+/plugin/build

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ coverage
 *.iml
 
 react-native-mapbox-gl-maps.tgz
+
+# Config plugin
+/plugin/build

--- a/.npmignore
+++ b/.npmignore
@@ -42,3 +42,7 @@ android/local.properties
 example
 __tests__
 coverage
+
+plugin/src
+plugin/jest.config.js
+plugin/tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
+Add Expo config plugin ([#1388](https://github.com/react-native-mapbox-gl/maps/pull/1388))  
 
 
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ npm install @react-native-mapbox-gl/maps --save
 
 - [Android](/android/install.md)
 - [iOS](/ios/install.md)
+- [Expo](/plugin/install.md)
 - [Example](/example)
+
 
 ## Getting Started
 For more information, check out our [Getting Started](/docs/GettingStarted.md) section
@@ -147,7 +149,7 @@ export default class App extends Component {
 
 ## Expo Support
 
-We have a feature request open with Expo if you want to see it get in show your support https://expo.canny.io/feature-requests/p/add-mapbox-gl-support
+This package is not available in the [Expo Go](https://expo.io/client) app. Learn how you can use it with [custom dev clients](/plugin/install.md).
 
 ## Testing with Jest
 

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withMapbox');

--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
     "unittest": "jest",
     "unittest:single": "jest --testNamePattern",
     "format": "npm run lint -- --fix",
-    "lint": "eslint . --ignore-pattern 'example' --fix && cd example/ && eslint ./src --fix"
+    "lint": "eslint . --ignore-pattern 'example' --fix && npm run lint:plugin --fix && cd example/ && eslint ./src --fix",
+    "prepare": "yarn build:plugin",
+    "test:plugin": "expo-module test plugin",
+    "build:plugin": "tsc --build plugin",
+    "lint:plugin": "eslint plugin/src/*"
   },
   "peerDependencies": {
     "prop-types": ">=15.5.8",
@@ -34,6 +38,7 @@
     "react-native": ">=0.59.9"
   },
   "dependencies": {
+    "@expo/config-plugins": "^2.0.2",
     "@mapbox/geo-viewport": ">= 0.4.0",
     "@turf/along": ">= 4.0.0 <7.0.0",
     "@turf/distance": ">= 4.0.0 <7.0.0",
@@ -58,6 +63,7 @@
     "@react-native-community/eslint-config": "^2.0.0",
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "2.23.4",
+    "expo-module-scripts": "^2.0.0",
     "husky": "4.3.8",
     "jest": "25.5.4",
     "@sinonjs/fake-timers": "^7.0.1",

--- a/plugin/install.md
+++ b/plugin/install.md
@@ -1,0 +1,32 @@
+# Expo installation
+
+> This package cannot be used in the "Expo Go" app because [it requires custom native code](https://docs.expo.io/workflow/customizing/).
+
+First install the package with yarn, npm, or [`expo install`](https://docs.expo.io/workflow/expo-cli/#expo-install).
+
+```sh
+expo install @react-native-mapbox-gl/maps
+```
+
+After installing this npm package, add the [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
+
+```json
+{
+  "expo": {
+    "plugins": ["@react-native-mapbox-gl/maps"]
+  }
+}
+```
+
+Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
+
+## API
+
+This plugin doesn't currently provide any additional properties for customization. The plugin simply generates the pre-install block in the `ios/Podfile` (the post-install block is not required for Expo support). No additional changes are done on Android.
+
+## Manual Setup
+
+For bare workflow projects, you can follow the manual setup guides:
+
+- [iOS](/ios/install.md)
+- [Android](/android/install.md)

--- a/plugin/jest.config.js
+++ b/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/plugin/src/__tests__/__snapshots__/withMapbox-test.ts.snap
+++ b/plugin/src/__tests__/__snapshots__/withMapbox-test.ts.snap
@@ -1,0 +1,198 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`applyCocoaPodsModifications adds blocks to a expo prebuild template podfile 1`] = `
+"
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+  use_unimodules!
+  config = use_native_modules!
+
+# @generated begin pre_installer - expo prebuild (DO NOT MODIFY) sync-c8812095000d6054b846ce74840f0ffb540c2757
+  pre_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-pre_installer - expo prebuild (DO NOT MODIFY) sync-5a7ed0a20d5aff2d61639bc5bb4fd5551233d57c
+    $RNMBGL.pre_install(installer)
+# @generated end @react-native-mapbox-gl/maps-pre_installer
+  end
+# @generated end pre_installer
+  use_react_native!(:path => config[\\"reactNativePath\\"])
+
+  # Uncomment to opt-in to using Flipper
+  #
+  # if !ENV['CI']
+  #   use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  #   post_install do |installer|
+  #     flipper_post_install(installer)
+  #   end
+  # end
+end
+"
+`;
+
+exports[`applyCocoaPodsModifications adds blocks to a expo prebuild template podfile with custom modifications  1`] = `
+"
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+  use_unimodules!
+  config = use_native_modules!
+
+# @generated begin pre_installer - expo prebuild (DO NOT MODIFY) sync-c8812095000d6054b846ce74840f0ffb540c2757
+  pre_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-pre_installer - expo prebuild (DO NOT MODIFY) sync-5a7ed0a20d5aff2d61639bc5bb4fd5551233d57c
+    $RNMBGL.pre_install(installer)
+# @generated end @react-native-mapbox-gl/maps-pre_installer
+  end
+# @generated end pre_installer
+  use_react_native!(:path => config[\\"reactNativePath\\"])
+
+  # pre_install do |installer|
+  # end
+
+  # Uncomment to opt-in to using Flipper
+  #
+  # if !ENV['CI']
+  #   use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  #   post_install do |installer|
+  #     flipper_post_install(installer)
+  #   end
+  # end
+end
+"
+`;
+
+exports[`applyCocoaPodsModifications adds blocks to a react native template podfile 1`] = `
+"
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+  config = use_native_modules!
+
+# @generated begin pre_installer - expo prebuild (DO NOT MODIFY) sync-c8812095000d6054b846ce74840f0ffb540c2757
+  pre_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-pre_installer - expo prebuild (DO NOT MODIFY) sync-5a7ed0a20d5aff2d61639bc5bb4fd5551233d57c
+    $RNMBGL.pre_install(installer)
+# @generated end @react-native-mapbox-gl/maps-pre_installer
+  end
+# @generated end pre_installer
+  use_react_native!(
+    :path => config[:reactNativePath],
+    # to enable hermes on iOS, change \`false\` to \`true\` and then install pods
+    :hermes_enabled => false
+  )
+
+  target 'HelloWorldTests' do
+    inherit! :complete
+    # Pods for testing
+  end
+
+  # Enables Flipper.
+  #
+  # Note that if you have use_frameworks! enabled, Flipper will not work and
+  # you should disable the next line.
+  use_flipper!()
+
+  post_install do |installer|
+    react_native_post_install(installer)
+  end
+end
+"
+`;
+
+exports[`applyCocoaPodsModifications doesn't work with revisions to blocks after comments 1`] = `
+"
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+  use_unimodules!
+  config = use_native_modules!
+  # pre_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-pre_installer - expo prebuild (DO NOT MODIFY) sync-5a7ed0a20d5aff2d61639bc5bb4fd5551233d57c
+    $RNMBGL.pre_install(installer)
+# @generated end @react-native-mapbox-gl/maps-pre_installer
+  # end
+
+  # Uncomment to opt-in to using Flipper
+  #
+  # if !ENV['CI']
+  #   use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  #   post_install do |installer|
+  #     flipper_post_install(installer)
+  #   end
+  # end
+
+# @generated begin post_installer - expo prebuild (DO NOT MODIFY) sync-00old-id-2
+INVALID_post_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-post_installer - expo prebuild (DO NOT MODIFY) sync-001
+  INVALID_$RNMBGL.post_install(installer)
+# @generated end @react-native-mapbox-gl/maps-post_installer
+end
+# @generated end post_installer
+# @generated begin pre_installer - expo prebuild (DO NOT MODIFY) sync-c8812095000d6054b846ce74840f0ffb540c2757
+  pre_install do |installer|
+  end
+# @generated end pre_installer
+  use_react_native!(:path => config[\\"reactNativePath\\"])
+
+
+end
+"
+`;
+
+exports[`applyCocoaPodsModifications works after revisions to blocks 1`] = `
+"
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+  use_unimodules!
+  config = use_native_modules!
+
+# @generated begin post_installer - expo prebuild (DO NOT MODIFY) sync-00old-id-2
+INVALID_post_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-post_installer - expo prebuild (DO NOT MODIFY) sync-001
+  INVALID_$RNMBGL.post_install(installer)
+# @generated end @react-native-mapbox-gl/maps-post_installer
+end
+# @generated end post_installer
+# @generated begin pre_installer - expo prebuild (DO NOT MODIFY) sync-c8812095000d6054b846ce74840f0ffb540c2757
+  pre_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-pre_installer - expo prebuild (DO NOT MODIFY) sync-5a7ed0a20d5aff2d61639bc5bb4fd5551233d57c
+    $RNMBGL.pre_install(installer)
+# @generated end @react-native-mapbox-gl/maps-pre_installer
+  end
+# @generated end pre_installer
+  use_react_native!(:path => config[\\"reactNativePath\\"])
+
+  # pre_install do |installer|
+  # end
+
+  # Uncomment to opt-in to using Flipper
+  #
+  # if !ENV['CI']
+  #   use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  #   post_install do |installer|
+  #     flipper_post_install(installer)
+  #   end
+  # end
+end
+"
+`;

--- a/plugin/src/__tests__/fixtures/cocoapodFiles.ts
+++ b/plugin/src/__tests__/fixtures/cocoapodFiles.ts
@@ -1,0 +1,173 @@
+export const reactNativeTemplatePodfile = `
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+  config = use_native_modules!
+
+  use_react_native!(
+    :path => config[:reactNativePath],
+    # to enable hermes on iOS, change \`false\` to \`true\` and then install pods
+    :hermes_enabled => false
+  )
+
+  target 'HelloWorldTests' do
+    inherit! :complete
+    # Pods for testing
+  end
+
+  # Enables Flipper.
+  #
+  # Note that if you have use_frameworks! enabled, Flipper will not work and
+  # you should disable the next line.
+  use_flipper!()
+
+  post_install do |installer|
+    react_native_post_install(installer)
+  end
+end
+`;
+
+export const expoTemplatePodfile = `
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+  use_unimodules!
+  config = use_native_modules!
+
+  use_react_native!(:path => config["reactNativePath"])
+
+  # Uncomment to opt-in to using Flipper
+  #
+  # if !ENV['CI']
+  #   use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  #   post_install do |installer|
+  #     flipper_post_install(installer)
+  #   end
+  # end
+end
+`;
+
+export const customExpoTemplatePodfile = `
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+  use_unimodules!
+  config = use_native_modules!
+
+  use_react_native!(:path => config["reactNativePath"])
+
+  # pre_install do |installer|
+  # end
+
+  # Uncomment to opt-in to using Flipper
+  #
+  # if !ENV['CI']
+  #   use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  #   post_install do |installer|
+  #     flipper_post_install(installer)
+  #   end
+  # end
+end
+`;
+
+// This tests that if an invalid revision is pushed, the plugin can correct it based on the ID.
+export const expoTemplateWithRevisions = `
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+  use_unimodules!
+  config = use_native_modules!
+
+# @generated begin pre_installer - expo prebuild (DO NOT MODIFY) sync-00old-id
+INVALID_pre_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-pre_installer - expo prebuild (DO NOT MODIFY) sync-00
+  INVALID_$RNMBGL.pre_install(installer)
+# @generated end @react-native-mapbox-gl/maps-pre_installer
+end
+# @generated end pre_installer
+# @generated begin post_installer - expo prebuild (DO NOT MODIFY) sync-00old-id-2
+INVALID_post_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-post_installer - expo prebuild (DO NOT MODIFY) sync-001
+  INVALID_$RNMBGL.post_install(installer)
+# @generated end @react-native-mapbox-gl/maps-post_installer
+end
+# @generated end post_installer
+  use_react_native!(:path => config["reactNativePath"])
+
+  # pre_install do |installer|
+  # end
+
+  # Uncomment to opt-in to using Flipper
+  #
+  # if !ENV['CI']
+  #   use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  #   post_install do |installer|
+  #     flipper_post_install(installer)
+  #   end
+  # end
+end
+`;
+
+export const expoTemplateWithRevisionsAfterComments = `
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/react-native-unimodules/cocoapods.rb'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+  use_unimodules!
+  config = use_native_modules!
+  # pre_install do |installer|
+  # end
+
+  # Uncomment to opt-in to using Flipper
+  #
+  # if !ENV['CI']
+  #   use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  #   post_install do |installer|
+  #     flipper_post_install(installer)
+  #   end
+  # end
+
+# @generated begin pre_installer - expo prebuild (DO NOT MODIFY) sync-00old-id
+INVALID_pre_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-pre_installer - expo prebuild (DO NOT MODIFY) sync-00
+  INVALID_$RNMBGL.pre_install(installer)
+# @generated end @react-native-mapbox-gl/maps-pre_installer
+end
+# @generated end pre_installer
+# @generated begin post_installer - expo prebuild (DO NOT MODIFY) sync-00old-id-2
+INVALID_post_install do |installer|
+# @generated begin @react-native-mapbox-gl/maps-post_installer - expo prebuild (DO NOT MODIFY) sync-001
+  INVALID_$RNMBGL.post_install(installer)
+# @generated end @react-native-mapbox-gl/maps-post_installer
+end
+# @generated end post_installer
+  use_react_native!(:path => config["reactNativePath"])
+
+
+end
+`;
+
+export const blankTemplatePodfile = `
+platform :ios, '11.0'
+
+target 'HelloWorld' do
+end
+`;

--- a/plugin/src/__tests__/withMapbox-test.ts
+++ b/plugin/src/__tests__/withMapbox-test.ts
@@ -1,0 +1,50 @@
+import {applyCocoaPodsModifications} from '../withMapbox';
+
+import * as fixtures from './fixtures/cocoapodFiles';
+
+describe(applyCocoaPodsModifications, () => {
+  it('adds blocks to a react native template podfile', () => {
+    expect(
+      applyCocoaPodsModifications(fixtures.reactNativeTemplatePodfile),
+    ).toMatchSnapshot();
+  });
+  it('adds blocks to a expo prebuild template podfile', () => {
+    expect(
+      applyCocoaPodsModifications(fixtures.expoTemplatePodfile),
+    ).toMatchSnapshot();
+  });
+  it('adds blocks to a expo prebuild template podfile with custom modifications ', () => {
+    expect(
+      applyCocoaPodsModifications(fixtures.customExpoTemplatePodfile),
+    ).toMatchSnapshot();
+  });
+  it('fails to add blocks to a bare podfile', () => {
+    expect(() =>
+      applyCocoaPodsModifications(fixtures.blankTemplatePodfile),
+    ).toThrow('Failed to match');
+    expect(() => applyCocoaPodsModifications('')).toThrow('Failed to match');
+  });
+  it('does not re add blocks to an applied template podfile', () => {
+    const runOnce = applyCocoaPodsModifications(
+      fixtures.reactNativeTemplatePodfile,
+    );
+
+    expect(applyCocoaPodsModifications(runOnce)).toMatch(runOnce);
+  });
+  it('works after revisions to blocks', () => {
+    const runOnce = applyCocoaPodsModifications(
+      fixtures.expoTemplateWithRevisions,
+    );
+
+    expect(runOnce).toMatchSnapshot();
+  });
+  // A known issue is that the regex won't work if the template
+  // has a pre_install/post_install block commented out, before the `use_react_native` function.
+  it('does not work with revisions to blocks after comments', () => {
+    const runOnce = applyCocoaPodsModifications(
+      fixtures.expoTemplateWithRevisionsAfterComments,
+    );
+
+    expect(runOnce).toMatchSnapshot();
+  });
+});

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -11,7 +11,7 @@ import {
   removeGeneratedContents,
 } from '@expo/config-plugins/build/utils/generateCode';
 
-const pkg = require('mapbox-config-plugin/package.json');
+const pkg = require('@react-native-mapbox-gl/maps/package.json');
 
 type InstallerBlockName = 'pre' | 'post';
 

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -1,0 +1,106 @@
+import {promises} from 'fs';
+import path from 'path';
+
+import {
+  ConfigPlugin,
+  createRunOncePlugin,
+  withDangerousMod,
+} from '@expo/config-plugins';
+import {
+  mergeContents,
+  removeGeneratedContents,
+} from '@expo/config-plugins/build/utils/generateCode';
+
+const pkg = require('mapbox-config-plugin/package.json');
+
+type InstallerBlockName = 'pre' | 'post';
+
+/**
+ * Dangerously adds the custom installer hooks to the Podfile.
+ * In the future this should be removed in favor of some custom hooks provided by Expo autolinking.
+ *
+ * https://github.com/react-native-mapbox-gl/maps/blob/master/ios/install.md#react-native--0600
+ * @param config
+ * @returns
+ */
+const withCocoaPodsInstallerBlocks: ConfigPlugin = (c) => {
+  return withDangerousMod(c, [
+    'ios',
+    async (config) => {
+      const file = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+
+      const contents = await promises.readFile(file, 'utf8');
+
+      await promises.writeFile(
+        file,
+        applyCocoaPodsModifications(contents),
+        'utf-8',
+      );
+      return config;
+    },
+  ]);
+};
+
+// Only the preinstaller block is required, the post installer block is
+// used for spm (swift package manager) which Expo doesn't currently support.
+export function applyCocoaPodsModifications(contents: string): string {
+  // Ensure installer blocks exist
+  let src = addInstallerBlock(contents, 'pre');
+  // src = addInstallerBlock(src, "post");
+  src = addMapboxInstallerBlock(src, 'pre');
+  // src = addMapboxInstallerBlock(src, "post");
+  return src;
+}
+
+export function addInstallerBlock(
+  src: string,
+  blockName: InstallerBlockName,
+): string {
+  const matchBlock = new RegExp(`${blockName}_install do \\|installer\\|`);
+  const tag = `${blockName}_installer`;
+  for (const line of src.split('\n')) {
+    const contents = line.trim();
+    // Ignore comments
+    if (!contents.startsWith('#')) {
+      // Prevent adding the block if it exists outside of comments.
+      if (contents.match(matchBlock)) {
+        // This helps to still allow revisions, since we enabled the block previously.
+        // Only continue if the generated block exists...
+        const modified = removeGeneratedContents(src, tag);
+        if (!modified) {
+          return src;
+        }
+      }
+    }
+  }
+
+  return mergeContents({
+    tag,
+    src,
+    newSrc: [`  ${blockName}_install do |installer|`, '  end'].join('\n'),
+    anchor: /use_react_native/,
+    // We can't go after the use_react_native block because it might have parameters, causing it to be multi-line (see react-native template).
+    offset: 0,
+    comment: '#',
+  }).contents;
+}
+
+export function addMapboxInstallerBlock(
+  src: string,
+  blockName: InstallerBlockName,
+): string {
+  return mergeContents({
+    tag: `@react-native-mapbox-gl/maps-${blockName}_installer`,
+    src,
+    newSrc: `    $RNMBGL.${blockName}_install(installer)`,
+    anchor: new RegExp(`${blockName}_install do \\|installer\\|`),
+    offset: 1,
+    comment: '#',
+  }).contents;
+}
+
+const withMapbox: ConfigPlugin = (config) => {
+  return withCocoaPodsInstallerBlocks(config);
+};
+
+export default createRunOncePlugin(withMapbox, pkg.name, pkg.version);

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# Why

With Expo SDK 41 we've rolled out an interface called [config plugins](https://docs.expo.io/guides/config-plugins/) which lets users add native modules that aren't in the Expo Go app to their native cloud builds and locally when [prebuilding](https://expo.fyi/prebuilding).

This is a [highly requested package](https://expo.canny.io/feature-requests/p/mapbox-gl) so I've created the plugin personally.

We’re still working on improving the development experience for config plugins and custom managed workflow, feel free to add any feedback. People won’t be able to use this in an Expo-Go-like-app until we release “Expo Development Client” ([more info](https://blog.expo.io/expo-managed-workflow-in-2021-d1c9b68aa10)). 

This plugin is a bit "dangerous" as it uses regexes to add podfile modifications, we plan to add autolinking hooks to expo in the future to make this operation safer.

# How

- Added a `/plugin` folder and an `app.plugin.js` as the main entry point to the plugin. Plugins must run in at node LTS environments (currently that means 12 and greater), so a custom `tsconfig.json` is used for transpilation.
- The plugin is like a different package that's vendored for versioning purposes. Building is done with `tsc --build plugin` (`yarn build:plugin`).

# Test Plan

- Run `npm pack` in the package
- Install the package in a managed Expo project `yarn add file:/path/to/react-native-mapbox-gl-maps.tgz`
- Then add `@react-native-mapbox-gl/maps` to the plugins array (vscode-expo users should have autocomplete) and build the native app locally with `expo prebuild` and `yarn ios`, `yarn android`. We plan to further automate these steps with `expo install` and `expo run` commands.


## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I updated the documentation
* [x] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`index.d.ts`)
* [ ] I added/ updated a sample  (`/example`)

