### PR TITLE
Support dynamically changing local JSON in styleURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ PR Title ([#123](link to my pr))
 
 ----
 ## NEXT
+Support dynamically changing local JSON in styleURL ([#1399](https://github.com/react-native-mapbox-gl/maps/pull/1399))  
 Add missing types to `SymbolLayerStyle` & `ImagesProps` ([#1360](https://github.com/react-native-mapbox-gl/maps/pull/1360))  
 Fix error while updating coordinates of RCTMGLImageSource ([#1310](https://github.com/react-native-mapbox-gl/maps/pull/1310))
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -770,12 +770,21 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
         if (mMap != null) {
             removeAllSourcesFromMap();
 
-            mMap.setStyle(styleURL, new Style.OnStyleLoaded() {
-                @Override
-                public void onStyleLoaded(@NonNull Style style) {
-                    addAllSourcesToMap();
-                }
-            });
+            if (isJSONValid(mStyleURL)) {
+                mMap.setStyle(new Style.Builder().fromJson(mStyleURL), new Style.OnStyleLoaded() {
+                    @Override
+                    public void onStyleLoaded(@NonNull Style style) {
+                        addAllSourcesToMap();
+                    }
+                });
+            } else {
+                mMap.setStyle(styleURL, new Style.OnStyleLoaded() {
+                    @Override
+                    public void onStyleLoaded(@NonNull Style style) {
+                        addAllSourcesToMap();
+                    }
+                });
+            }
         }
     }
 


### PR DESCRIPTION
When dynamically changing a `MapView`s `styleURL` prop that is a locally defined style.json `setReactStyleURL` will call `MapboxMap`s `setStyle`.  
Without a passed in Builder, it'll use the default one - which assumes that the style stings is an URI (which it is not). 

To prevent a `Mapbox error [HTTP] Unable to parse resourceUrl` error  we need to pass in our own Builder that uses `fromJSON` instead `fromUri`

Note:
* this is not an issue on initial load - only on prop changes
* this is not an issue on iOS

@mattijsf, I've added you as a reviewer, because this is relevant to the changes we implemented


## Checklist
* [x] I have tested this on a device/simulator for each compatible OS
* [x] I mentioned this change in `CHANGELOG.md`
~* [ ] I updated the documentation `yarn generate`~
~* [ ] I updated the typings files (`index.d.ts`)~
~* [ ] I added/ updated a sample  (`/example`)~