### PR TITLE
[expo][config plugin] fallback on unversioned if package.json cannot be found

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "unittest": "jest",
     "unittest:single": "jest --testNamePattern",
     "format": "npm run lint -- --fix",
-    "lint": "eslint . --ignore-pattern 'example' --fix && npm run lint:plugin --fix && cd example/ && eslint ./src --fix",
+    "lint": "eslint . --ignore-pattern 'example' --fix && eslint plugin/src/* --fix && cd example/ && eslint ./src --fix",
     "prepare": "yarn build:plugin",
     "test:plugin": "expo-module test plugin",
     "build:plugin": "tsc --build plugin",

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -11,7 +11,12 @@ import {
   removeGeneratedContents,
 } from '@expo/config-plugins/build/utils/generateCode';
 
-const pkg = require('@react-native-mapbox-gl/maps/package.json');
+let pkg: {name: string; version?: string} = {
+  name: '@react-native-mapbox-gl/maps',
+};
+try {
+  pkg = require('@react-native-mapbox-gl/maps/package.json');
+} catch {}
 
 type InstallerBlockName = 'pre' | 'post';
 


### PR DESCRIPTION

## Description

The android test seems to fail when the package.json cannot be resolved in the plugin, this wouldn't happen in practice and the package.json check is just to ensure colliding versions don't get [run more than once](https://docs.expo.io/guides/config-plugins/#adding-plugins-to-pluginhistory). Wrap the check in a try/catch and fallback on unversioned functionality. 

