### PR TITLE
Fix TypeScript type for Callout's textStyle prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
 
+Fix TypeScript type for Callout's textStyle prop ([#1450](https://github.com/react-native-mapbox-gl/maps/pull/1450))
+
 ---
 
 ## 8.2.1

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ import {
   ViewProps,
   ViewStyle,
   StyleProp,
+  TextStyle,
   ImageSourcePropType,
 } from 'react-native';
 import ReactNative from 'react-native';
@@ -796,7 +797,7 @@ export interface CalloutProps extends Omit<ViewProps, 'style'> {
   containerStyle?: StyleProp<WithExpression<ViewStyle>>;
   contentStyle?: StyleProp<WithExpression<ViewStyle>>;
   tipStyle?: StyleProp<WithExpression<ViewStyle>>;
-  textStyle?: StyleProp<WithExpression<ViewStyle>>;
+  textStyle?: StyleProp<WithExpression<TextStyle>>;
 }
 
 export interface TileSourceProps extends ViewProps {


### PR DESCRIPTION
## Description

The textStyle prop is passed to a <Text/> component, not a <View/>.
Therefore its type must be of type TextStyle, not ViewStyle.


## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I updated the documentation `yarn generate`
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`index.d.ts`)
* [ ] I added/ updated a sample  (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
