### PR TITLE
build: remove obsolete babel plugins

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,6 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  plugins: [
-    // Use @babel/preset-flow when
-    // https://github.com/babel/babel/issues/7233 is fixed
-    '@babel/plugin-transform-flow-strip-types',
-    ['@babel/plugin-proposal-class-properties', {loose: true}],
-    '@babel/plugin-transform-exponentiation-operator',
-  ],
+  plugins: [['@babel/plugin-proposal-class-properties', {loose: true}]],
   env: {
     production: {
       plugins: ['transform-remove-console'],

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "devDependencies": {
     "@babel/core": "7.5.0",
     "@babel/plugin-proposal-class-properties": "7.10.4",
-    "@babel/plugin-transform-exponentiation-operator": "7.10.4",
     "@babel/plugin-transform-runtime": "7.11.5",
     "@babel/runtime": "7.11.2",
     "babel-core": "6.26.3",


### PR DESCRIPTION
I believe we don't need these anymore:
1. '@babel/plugin-transform-flow-strip-types'
2. '@babel/plugin-transform-exponentiation-operator'

<br>

1. we don't use `flow` anywhere
2. I've checked, and we're not using the exponentiation (`**`) operator anywhere

So, out they go 🤷🏿‍♀️ 