### PR TITLE
feat(android): dynamically update `tintColor` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
-Support tintColor on Android ([#1465](https://github.com/react-native-mapbox-gl/maps/pull/1465))
+
 Fix TypeScript type for Callout's textStyle prop ([#1450](https://github.com/react-native-mapbox-gl/maps/pull/1450))  
 Build(ios): pin maplibre version to 5.12.0 ([#1454](https://github.com/react-native-mapbox-gl/maps/pull/1454))  
 Update geoUtils helpers types to correspond with `turf/helpers` ([#1455](https://github.com/react-native-mapbox-gl/maps/pull/1455))  
@@ -12,6 +12,8 @@ Fix crash with missing okhttp dependency ([#1452](https://github.com/react-nativ
 Move from react-native-testing-library => @testing-library/react-native ([#1453](https://github.com/react-native-mapbox-gl/maps/pull/1453))  
 Feat(camera): maxBounds/(min|max)ZoomLevel can be updated dynamically ([#1462](https://github.com/react-native-mapbox-gl/maps/pull/1462))  
 Refactor(example): clean up folder structure ([#1464](https://github.com/react-native-mapbox-gl/maps/pull/1464))  
+Support tintColor on Android ([#1465](https://github.com/react-native-mapbox-gl/maps/pull/1465))  
+Feat(android): dynamically update tintColor & add example ([#1469](https://github.com/react-native-mapbox-gl/maps/pull/1469)
 
 ---
 

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/LocationComponentManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/location/LocationComponentManager.java
@@ -100,7 +100,9 @@ public class LocationComponentManager {
     }
 
     public void update(boolean displayUserLocation, @NonNull Style style) {
-        if (mLocationComponent == null) {
+        Integer tintColor = mMapView.getTintColor();
+
+        if (mLocationComponent == null || tintColor != null ) {
             mLocationComponent = mMap.getLocationComponent();
 
             LocationComponentActivationOptions locationComponentActivationOptions = LocationComponentActivationOptions

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -1505,7 +1505,10 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
     }
 
     public void setTintColor(@Nullable Integer tintColor) {
+        if (mTintColor == tintColor) return;
         mTintColor = tintColor;
         updateUISettings();
+        if (mLocationComponentManager == null) return;
+        mLocationComponentManager.update(getMapboxMap().getStyle());
     }
 }

--- a/example/src/examples/UserLocation/SetTintColor.js
+++ b/example/src/examples/UserLocation/SetTintColor.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import MapboxGL from '@react-native-mapbox-gl/maps';
+
+import sheet from '../../styles/sheet';
+
+import BaseExamplePropTypes from '../common/BaseExamplePropTypes';
+import TabBarPage from '../common/TabBarPage';
+
+const COLOR = ['red', 'yellow', 'green'];
+const OPTIONS = [{label: 'red'}, {label: 'yellow'}, {label: 'green'}];
+
+class SetTintColor extends React.Component {
+  static propTypes = {
+    ...BaseExamplePropTypes,
+  };
+
+  state = {tintColor: COLOR[0]};
+
+  onTintColorChange = (index) => {
+    this.setState({tintColor: COLOR[index]});
+  };
+
+  render() {
+    return (
+      <TabBarPage
+        {...this.props}
+        options={OPTIONS}
+        onOptionPress={this.onTintColorChange}>
+        <MapboxGL.MapView 
+          style={sheet.matchParent}
+          tintColor={this.state.tintColor} 
+        >
+          <MapboxGL.Camera
+            followZoomLevel={16}
+            followUserMode="compass"
+            followUserLocation
+          />
+
+          <MapboxGL.UserLocation 
+          renderMode='native' 
+          androidRenderMode='compass'
+          />
+        </MapboxGL.MapView>
+      </TabBarPage>
+    );
+  }
+}
+
+export default SetTintColor;

--- a/example/src/scenes/Home.js
+++ b/example/src/scenes/Home.js
@@ -62,6 +62,7 @@ import ShapeSourceIcon from '../examples/SymbolCircleLayer/ShapeSourceIcon';
 
 // USERLOCATION
 import SetDisplacement from '../examples/UserLocation/SetDisplacement';
+import SetTintColor from '../examples/UserLocation/SetTintColor';
 import SetUserLocationRenderMode from '../examples/UserLocation/SetUserLocationRenderMode';
 import SetUserLocationVerticalAlignment from '../examples/UserLocation/SetUserLocationVerticalAlignment';
 import UserLocationChange from '../examples/UserLocation/UserLocationChange';
@@ -129,6 +130,7 @@ const Examples = [
     new ExampleItem('Change Layer Color', ChangeLayerColor),
     new ExampleItem('Source Layer Visiblity', SourceLayerVisibility),
     new ExampleItem('Style JSON', StyleJson),
+    new ExampleItem('Set Tint Color', SetTintColor),
   ]),
   new ExampleGroup('Camera', [
     new ExampleItem('Set Pitch', SetPitch),


### PR DESCRIPTION
## Description
PR  #1465 added editing of tintColor for Android, unfortunately it didn't update dynamically.

This extends that PR with that functionality and adds a `Set Tint Color` example

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I added/ updated a sample  (`/example`)

## Screenshot
### iOS
red | yellow | green
---|---|---
![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-07-23 at 12 27 04](https://user-images.githubusercontent.com/26439946/126769881-d6c0f362-40c4-4a96-a752-c7be79a0d791.png) | ![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-07-23 at 12 27 07](https://user-images.githubusercontent.com/26439946/126769920-c287b37b-6e76-451a-9822-ada90104f978.png) | ![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-07-23 at 12 27 10](https://user-images.githubusercontent.com/26439946/126769926-a79aaa09-ed30-426c-a043-e3254fb22c63.png)

### Android
read | yellow | green
---|---|---
![android_screenshot_emulator-5554_21-07-23_14 52 41](https://user-images.githubusercontent.com/26439946/126784399-1c2db881-165a-49d5-a304-8bf8aefca0b2.png) | ![android_screenshot_emulator-5554_21-07-23_14 52 52](https://user-images.githubusercontent.com/26439946/126784375-3fb099bf-be4d-40e3-8c2e-a479385c8e15.png) | ![android_screenshot_emulator-5554_21-07-23_14 52 59](https://user-images.githubusercontent.com/26439946/126784387-3839be0c-fed5-40d3-bfd3-c917dec07209.png)


