### PR TITLE
chore(example): align install steps with yarn, ignore created env files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Fix lineGradient showing wrong colors ([#1471](https://github.com/react-native-m
 Support tintColor on Android ([#1465](https://github.com/react-native-mapbox-gl/maps/pull/1465))  
 Feat(android): dynamically update tintColor & add example ([#1469](https://github.com/react-native-mapbox-gl/maps/pull/1469)
 Docs: make background in example pngs transparent ([#1483](https://github.com/react-native-mapbox-gl/maps/pull/1483)
+Examples: align install steps with yarn, ignore created env files ([#1484](https://github.com/react-native-mapbox-gl/maps/pull/1484)
 
 ---
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -2,6 +2,12 @@
 #
 .DS_Store
 
+# MAPBOX token ENVs
+# generated on set-up
+#
+accesstoken
+env.json
+
 # Xcode
 #
 build/

--- a/example/README.md
+++ b/example/README.md
@@ -50,7 +50,7 @@ Not a Mapbox user yet? [Sign up for an account here](https://www.mapbox.com/sign
 ```
 cd example
 ```
-* Create a file called `accesstoken` in the root of the example project and just paste in your [Mapbox access token](https://www.mapbox.com/studio/account/tokens/). (The `accesstoken` file is processed in postinstall, so you need to run `npm install` after adding/changing accesstoken.)
+* Create a file called `accesstoken` in the root of the example project and just paste in your [Mapbox access token](https://www.mapbox.com/studio/account/tokens/). (The `accesstoken` file is processed in postinstall, so you need to run `yarn install` after adding/changing accesstoken.)
 
 * Install our dependencies using `yarn install`.
 
@@ -63,7 +63,7 @@ Open up another tab in your Terminal and run
 yarn start
 ```
 
-*Note*: if modules were added to base lib you might need to run `npm start --reset-cache` because we're using `babel` to [rewrite imports](https://github.com/react-native-mapbox-gl/maps/pull/778)
+*Note*: if modules were added to base lib you might need to run `yarn start --reset-cache` because we're using `babel` to [rewrite imports](https://github.com/react-native-mapbox-gl/maps/pull/778)
 
 <br>
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

During my first time setting-up the repository and the examples I stumbled over these minor improvements.

This PR does:

- align the example docs with `yarn` (and not `npm`)
- add the created env-files from the set-up to gitignore


## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I updated the documentation `yarn generate`
* [x] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`index.d.ts`)
* [ ] I added/ updated a sample  (`/example`)

