### PR TITLE
fix(readme): correct typo for android emulator example

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -67,7 +67,7 @@ yarn start
 
 <br>
 
-## Run Android Simulator
+## Run Android Emulator
 
 * Start Android emulator
 * Run `yarn android` from `example` directory


### PR DESCRIPTION
## Description
tiny correction => Android **E**mulators

## Checklist
* [ ] I have tested this on a device/simulator for each compatible OS
* [x] I updated the documentation `yarn generate`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`index.d.ts`)
* [ ] I added/ updated a sample  (`/example`)

## Screenshot OR Video
none