### PR TITLE
Adds getClusterChildren for iOS and Android

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
@@ -219,4 +219,14 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
         AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
         mManager.handleEvent(event);
     }
+
+    public void getClusterChildren(String callbackID, int clusterId) {
+        Feature clusterFeature = mSource.querySourceFeatures(Expression.eq(Expression.get("cluster_id"), clusterId)).get(0);
+        FeatureCollection leaves = mSource.getClusterChildren(clusterFeature);
+        WritableMap payload = new WritableNativeMap();
+        payload.putString("data", leaves.toJson());
+
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+        mManager.handleEvent(event);
+    }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
@@ -155,6 +155,7 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
     public static final int METHOD_FEATURES = 103;
     public static final int METHOD_GET_CLUSTER_EXPANSION_ZOOM = 104;
     public static final int METHOD_GET_CLUSTER_LEAVES = 105;
+    public static final int METHOD_GET_CLUSTER_CHILDREN = 106;
 
     @Nullable
     @Override
@@ -163,6 +164,7 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
                 .put("features", METHOD_FEATURES)
                 .put("getClusterExpansionZoom", METHOD_GET_CLUSTER_EXPANSION_ZOOM)
                 .put("getClusterLeaves", METHOD_GET_CLUSTER_LEAVES)
+                .put("getClusterChildren", METHOD_GET_CLUSTER_CHILDREN)
                 .build();
     }
 
@@ -184,6 +186,12 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
                         args.getInt(1),
                         args.getInt(2),
                         args.getInt((3))
+                );
+                break;
+            case METHOD_GET_CLUSTER_CHILDREN:
+                source.getClusterChildren(
+                        args.getString(0),
+                        args.getInt(1)                        
                 );
                 break;
         }

--- a/docs/ShapeSource.md
+++ b/docs/ShapeSource.md
@@ -71,6 +71,22 @@ const collection = await shapeSource.getClusterLeaves(clusterId, limit, offset);
 ```
 
 
+#### getClusterChildren(clusterId)
+
+Returns the FeatureCollection from the cluster (on the next zoom level).
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `clusterId` | `number` | `Yes` | The id of the cluster to expand. |
+
+
+
+```javascript
+const collection = await shapeSource.getClusterChildren(clusterId);
+```
+
+
 #### onPress(event)
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3644,6 +3644,33 @@
         ]
       },
       {
+        "name": "getClusterChildren",
+        "docblock": "Returns the FeatureCollection from the cluster (on the next zoom level).\n\n@example\nconst collection = await shapeSource.getClusterChildren(clusterId);\n\n@param  {number} clusterId - The id of the cluster to expand.\n@return {FeatureCollection}",
+        "modifiers": [
+          "async"
+        ],
+        "params": [
+          {
+            "name": "clusterId",
+            "description": "The id of the cluster to expand.",
+            "type": {
+              "name": "number"
+            },
+            "optional": false
+          }
+        ],
+        "returns": {
+          "description": null,
+          "type": {
+            "name": "FeatureCollection"
+          }
+        },
+        "description": "Returns the FeatureCollection from the cluster (on the next zoom level).",
+        "examples": [
+          "\nconst collection = await shapeSource.getClusterChildren(clusterId);\n\n"
+        ]
+      },
+      {
         "name": "onPress",
         "docblock": null,
         "modifiers": [],

--- a/index.d.ts
+++ b/index.d.ts
@@ -305,6 +305,11 @@ declare namespace MapboxGL {
     * @param offset the amount of points to skip (for pagination)
     */
      getClusterLeaves: (clusterId: number, limit: number, offset: number ) => object
+             /**
+    * Returns the children of a cluster (on the next zoom level).
+    * @param clusterId the ID of the cluster   
+    */
+    getClusterChildren: (clusterId: number) => object
   }
   class RasterSource extends Component<RasterSourceProps> { }
 

--- a/ios/RCTMGL/RCTMGLShapeSource.h
+++ b/ios/RCTMGL/RCTMGLShapeSource.h
@@ -34,6 +34,7 @@
 - (nonnull NSArray<id <MGLFeature>> *)getClusterLeaves:(nonnull NSNumber *)clusterId
                                                 number:(NSUInteger)number
                                                 offset:(NSUInteger)offset;
+- (nonnull NSArray<id <MGLFeature>> *)getClusterChildren:(nonnull NSNumber *)clusterId;                                               
 
 - (double)getClusterExpansionZoom:(nonnull NSNumber *)clusterId;
 

--- a/ios/RCTMGL/RCTMGLShapeSource.m
+++ b/ios/RCTMGL/RCTMGLShapeSource.m
@@ -131,4 +131,15 @@ static UIImage * _placeHolderImage;
     return [shapeSource leavesOfCluster:cluster offset:offset limit:number];
 }
 
+- (nonnull NSArray<id <MGLFeature>> *)getClusterChildren:(nonnull NSNumber *)clusterId
+{
+    MGLShapeSource *shapeSource = (MGLShapeSource *)self.source;
+    
+    NSPredicate* predicate = [NSPredicate predicateWithFormat:@"cluster_id == %@", clusterId];
+    NSArray<id<MGLFeature>> *features = [shapeSource featuresMatchingPredicate:predicate];
+    
+    MGLPointFeatureCluster * cluster = (MGLPointFeatureCluster *)features[0];
+    return [shapeSource childrenOfCluster:cluster];
+}
+
 @end

--- a/ios/RCTMGL/RCTMGLShapeSourceManager.m
+++ b/ios/RCTMGL/RCTMGLShapeSourceManager.m
@@ -113,4 +113,25 @@ RCT_EXPORT_METHOD(getClusterLeaves:(nonnull NSNumber*)reactTag
     }];
 }
 
+RCT_EXPORT_METHOD(getClusterChildren:(nonnull NSNumber*)reactTag
+                  clusterId:(nonnull NSNumber *)clusterId                  
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
+        RCTMGLShapeSource* shapeSource = (RCTMGLShapeSource *)viewRegistry[reactTag];
+
+        NSArray<id<MGLFeature>> *shapes = [sтвhapeSource getClusterChildren: clusterId];
+
+        NSMutableArray<NSDictionary*> *features = [[NSMutableArray alloc] initWithCapacity:shapes.count];
+        for (int i = 0; i < shapes.count; i++) {
+            [features addObject:shapes[i].geoJSONDictionary];
+        }
+
+        resolve(@{
+                  @"data": @{ @"type": @"FeatureCollection", @"features": features }
+                  });
+    }];
+}
+
 @end

--- a/javascript/components/ShapeSource.js
+++ b/javascript/components/ShapeSource.js
@@ -197,6 +197,29 @@ class ShapeSource extends NativeBridgeComponent(AbstractSource) {
     return res.data;
   }
 
+  /**
+   * Returns the FeatureCollection from the cluster (on the next zoom level).
+   *
+   * @example
+   * const collection = await shapeSource.getClusterChildren(clusterId);
+   *
+   * @param  {number} clusterId - The id of the cluster to expand.
+   * @return {FeatureCollection}
+   */
+  async getClusterChildren(clusterId) {
+    const res = await this._runNativeCommand(
+      'getClusterChildren',
+      this._nativeRef,
+      [clusterId],
+    );
+
+    if (isAndroid()) {
+      return JSON.parse(res.data);
+    }
+
+    return res.data;
+  }
+
   setNativeProps(props) {
     const shallowProps = Object.assign({}, props);
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

<!-- OR, if you're implementing a new feature: -->

Adds `getClusterChildren` method to `ShapeSource` that allows you to retrieve the features from a cluster by the cluster's ID.  (on the next zoom level)

Features may include nested clusters as well.

```javascript
shapeSourceRef.current.getClusterChildren(clusterId);
```


## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I updated the documentation `yarn generate`
* [ ] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`index.d.ts`)
* [ ] I added/ updated a sample  (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
