### PR TITLE
Update ShapeSource methods to make it usable with any cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 
-Update ShapeSource methods to make it usable with any cluster ([#1499](https://github.com/react-native-mapbox-gl/maps/pull/1499))
+Update ShapeSource methods to make it usable with any cluster ( Use cluster itself instead of cluster_id as first argument for getClusterExpansionZoom/getClusterLeaves/getClusterChildren methods. Till version < 9 methods still support passing cluster_id as a first argument but a deprecation warning will be shown. ) ([#1499](https://github.com/react-native-mapbox-gl/maps/pull/1499))
 ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ```
 Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
+
+Update ShapeSource methods to make it usable with any cluster ([#1499](https://github.com/react-native-mapbox-gl/maps/pull/1499))
 ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 
-Update ShapeSource methods to make it usable with any cluster ( Use cluster itself instead of cluster_id as first argument for getClusterExpansionZoom/getClusterLeaves/getClusterChildren methods. Till version < 9 methods still support passing cluster_id as a first argument but a deprecation warning will be shown. ) ([#1499](https://github.com/react-native-mapbox-gl/maps/pull/1499))
+Update ShapeSource methods to make it usable with any cluster ( Use cluster itself instead of cluster_id as first argument for getClusterExpansionZoom/getClusterLeaves/getClusterChildren methods. Version < 9 methods still supports passing cluster_id as a first argument but a deprecation warning will be shown. ) ([#1499](https://github.com/react-native-mapbox-gl/maps/pull/1499))
 ```
 
 ---

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
@@ -193,14 +193,6 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
    
         int zoom = mSource.getClusterExpansionZoom(feature);
 
-        if (zoom == -1) {
-            WritableMap payload = new WritableNativeMap();
-            payload.putString("error", "Could not get zoom for cluster:" + featureJSON);
-            AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
-            mManager.handleEvent(event);
-            return;
-        }
-
         WritableMap payload = new WritableNativeMap();
         payload.putInt("data", zoom);
 
@@ -209,6 +201,13 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
     }
 
     public void getClusterLeaves(String callbackID, String featureJSON, int number, int offset) {
+        if (mSource == null) {
+            WritableMap payload = new WritableNativeMap();
+            payload.putString("error", "source is not yet loaded");
+            AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+            mManager.handleEvent(event);
+            return;
+        }
         Feature clusterFeature = Feature.fromJson(featureJSON);
         FeatureCollection leaves = mSource.getClusterLeaves(clusterFeature, number, offset);
         WritableMap payload = new WritableNativeMap();
@@ -219,6 +218,13 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
     }
 
     public void getClusterChildren(String callbackID, String featureJSON) {
+        if (mSource == null) {
+            WritableMap payload = new WritableNativeMap();
+            payload.putString("error", "source is not yet loaded");
+            AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+            mManager.handleEvent(event);
+            return;
+        }
         Feature clusterFeature = Feature.fromJson(featureJSON);
         FeatureCollection leaves = mSource.getClusterChildren(clusterFeature);
         WritableMap payload = new WritableNativeMap();
@@ -260,6 +266,13 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
 
     // Deprecated. Will be removed in 9+ ver.
     public void getClusterLeavesById(String callbackID, int clusterId, int number, int offset) {
+        if (mSource == null) {
+            WritableMap payload = new WritableNativeMap();
+            payload.putString("error", "source is not yet loaded");
+            AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+            mManager.handleEvent(event);
+            return;
+        }
         Feature clusterFeature = mSource.querySourceFeatures(Expression.eq(Expression.get("cluster_id"), clusterId)).get(0);
         FeatureCollection leaves = mSource.getClusterLeaves(clusterFeature, number, offset);
         WritableMap payload = new WritableNativeMap();
@@ -271,6 +284,13 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
 
     // Deprecated. Will be removed in 9+ ver.
     public void getClusterChildrenById(String callbackID, int clusterId) {
+        if (mSource == null) {
+            WritableMap payload = new WritableNativeMap();
+            payload.putString("error", "source is not yet loaded");
+            AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+            mManager.handleEvent(event);
+            return;
+        }
         Feature clusterFeature = mSource.querySourceFeatures(Expression.eq(Expression.get("cluster_id"), clusterId)).get(0);
         FeatureCollection leaves = mSource.getClusterChildren(clusterFeature);
         WritableMap payload = new WritableNativeMap();

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
@@ -227,4 +227,56 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
         AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
         mManager.handleEvent(event);
     }
+
+    // Deprecated. Will be removed in 9+ ver. 
+    public void getClusterExpansionZoomById(String callbackID, int clusterId) {
+        if (mSource == null) {
+            WritableMap payload = new WritableNativeMap();
+            payload.putString("error", "source is not yet loaded");
+            AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+            mManager.handleEvent(event);
+            return;
+        }
+        List<Feature> features = mSource.querySourceFeatures(Expression.eq(Expression.id(), clusterId));
+        int zoom = -1;
+        if (features.size() > 0) {
+            zoom = mSource.getClusterExpansionZoom(features.get(0));
+        }
+
+        if (zoom == -1) {
+            WritableMap payload = new WritableNativeMap();
+            payload.putString("error", "Could not get zoom for cluster id " + clusterId);
+            AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+            mManager.handleEvent(event);
+            return;
+        }
+
+        WritableMap payload = new WritableNativeMap();
+        payload.putInt("data", zoom);
+
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+        mManager.handleEvent(event);
+    }
+
+    // Deprecated. Will be removed in 9+ ver.
+    public void getClusterLeavesById(String callbackID, int clusterId, int number, int offset) {
+        Feature clusterFeature = mSource.querySourceFeatures(Expression.eq(Expression.get("cluster_id"), clusterId)).get(0);
+        FeatureCollection leaves = mSource.getClusterLeaves(clusterFeature, number, offset);
+        WritableMap payload = new WritableNativeMap();
+        payload.putString("data", leaves.toJson());
+
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+        mManager.handleEvent(event);
+    }
+
+    // Deprecated. Will be removed in 9+ ver.
+    public void getClusterChildrenById(String callbackID, int clusterId) {
+        Feature clusterFeature = mSource.querySourceFeatures(Expression.eq(Expression.get("cluster_id"), clusterId)).get(0);
+        FeatureCollection leaves = mSource.getClusterChildren(clusterFeature);
+        WritableMap payload = new WritableNativeMap();
+        payload.putString("data", leaves.toJson());
+
+        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
+        mManager.handleEvent(event);
+    }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSource.java
@@ -181,7 +181,7 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
         mManager.handleEvent(event);
     }
 
-    public void getClusterExpansionZoom(String callbackID, int clusterId) {
+    public void getClusterExpansionZoom(String callbackID, String featureJSON) {
         if (mSource == null) {
             WritableMap payload = new WritableNativeMap();
             payload.putString("error", "source is not yet loaded");
@@ -189,15 +189,13 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
             mManager.handleEvent(event);
             return;
         }
-        List<Feature> features = mSource.querySourceFeatures(Expression.eq(Expression.id(), clusterId));
-        int zoom = -1;
-        if (features.size() > 0) {
-            zoom = mSource.getClusterExpansionZoom(features.get(0));
-        }
+        Feature feature = Feature.fromJson(featureJSON);
+   
+        int zoom = mSource.getClusterExpansionZoom(feature);
 
         if (zoom == -1) {
             WritableMap payload = new WritableNativeMap();
-            payload.putString("error", "Could not get zoom for cluster id " + clusterId);
+            payload.putString("error", "Could not get zoom for cluster:" + featureJSON);
             AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
             mManager.handleEvent(event);
             return;
@@ -210,8 +208,8 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
         mManager.handleEvent(event);
     }
 
-    public void getClusterLeaves(String callbackID, int clusterId, int number, int offset) {
-        Feature clusterFeature = mSource.querySourceFeatures(Expression.eq(Expression.get("cluster_id"), clusterId)).get(0);
+    public void getClusterLeaves(String callbackID, String featureJSON, int number, int offset) {
+        Feature clusterFeature = Feature.fromJson(featureJSON);
         FeatureCollection leaves = mSource.getClusterLeaves(clusterFeature, number, offset);
         WritableMap payload = new WritableNativeMap();
         payload.putString("data", leaves.toJson());
@@ -220,8 +218,8 @@ public class RCTMGLShapeSource extends RCTSource<GeoJsonSource> {
         mManager.handleEvent(event);
     }
 
-    public void getClusterChildren(String callbackID, int clusterId) {
-        Feature clusterFeature = mSource.querySourceFeatures(Expression.eq(Expression.get("cluster_id"), clusterId)).get(0);
+    public void getClusterChildren(String callbackID, String featureJSON) {
+        Feature clusterFeature = Feature.fromJson(featureJSON);
         FeatureCollection leaves = mSource.getClusterChildren(clusterFeature);
         WritableMap payload = new WritableNativeMap();
         payload.putString("data", leaves.toJson());

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
@@ -157,6 +157,11 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
     public static final int METHOD_GET_CLUSTER_LEAVES = 105;
     public static final int METHOD_GET_CLUSTER_CHILDREN = 106;
 
+    // Deprecated. Will be removed in 9+ ver.
+    public static final int METHOD_GET_CLUSTER_EXPANSION_ZOOM_BY_ID = 107;
+    public static final int METHOD_GET_CLUSTER_LEAVES_BY_ID = 108;
+    public static final int METHOD_GET_CLUSTER_CHILDREN_BY_ID = 109;
+
     @Nullable
     @Override
     public Map<String, Integer> getCommandsMap() {
@@ -165,6 +170,12 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
                 .put("getClusterExpansionZoom", METHOD_GET_CLUSTER_EXPANSION_ZOOM)
                 .put("getClusterLeaves", METHOD_GET_CLUSTER_LEAVES)
                 .put("getClusterChildren", METHOD_GET_CLUSTER_CHILDREN)
+
+                // Deprecated. Will be removed in 9+ ver.
+                .put("getClusterExpansionZoomById", METHOD_GET_CLUSTER_EXPANSION_ZOOM_BY_ID)
+                .put("getClusterLeavesById", METHOD_GET_CLUSTER_LEAVES_BY_ID)
+                .put("getClusterChildrenById", METHOD_GET_CLUSTER_CHILDREN_BY_ID)
+               
                 .build();
     }
 
@@ -192,6 +203,23 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
                 source.getClusterChildren(
                         args.getString(0),
                         args.getString(1)                        
+                );
+                break;
+            case METHOD_GET_CLUSTER_EXPANSION_ZOOM_BY_ID:
+                source.getClusterExpansionZoomById(args.getString(0), args.getInt(1));
+                break;
+            case METHOD_GET_CLUSTER_LEAVES_BY_ID:
+                source.getClusterLeavesById(
+                        args.getString(0),
+                        args.getInt(1),
+                        args.getInt(2),
+                        args.getInt((3))
+                );
+                break;
+            case METHOD_GET_CLUSTER_CHILDREN_BY_ID:
+                source.getClusterChildrenById(
+                        args.getString(0),
+                        args.getInt(1)                        
                 );
                 break;
         }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/sources/RCTMGLShapeSourceManager.java
@@ -178,12 +178,12 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
                 );
                 break;
             case METHOD_GET_CLUSTER_EXPANSION_ZOOM:
-                source.getClusterExpansionZoom(args.getString(0), args.getInt(1));
+                source.getClusterExpansionZoom(args.getString(0), args.getString(1));
                 break;
             case METHOD_GET_CLUSTER_LEAVES:
                 source.getClusterLeaves(
                         args.getString(0),
-                        args.getInt(1),
+                        args.getString(1),
                         args.getInt(2),
                         args.getInt((3))
                 );
@@ -191,7 +191,7 @@ public class RCTMGLShapeSourceManager extends AbstractEventEmitter<RCTMGLShapeSo
             case METHOD_GET_CLUSTER_CHILDREN:
                 source.getClusterChildren(
                         args.getString(0),
-                        args.getInt(1)                        
+                        args.getString(1)                        
                 );
                 break;
         }

--- a/docs/ShapeSource.md
+++ b/docs/ShapeSource.md
@@ -37,14 +37,14 @@ shapeSource.features()
 ```
 
 
-#### getClusterExpansionZoom(clusterId)
+#### getClusterExpansionZoom(feature)
 
 Returns the zoom needed to expand the cluster.
 
 ##### arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `clusterId` | `number` | `Yes` | The id of the cluster to expand. |
+| `feature` | `Feature` | `Yes` | The feature cluster to expand. |
 
 
 
@@ -53,14 +53,14 @@ const zoom = await shapeSource.getClusterExpansionZoom(clusterId);
 ```
 
 
-#### getClusterLeaves(clusterId, limit, offset)
+#### getClusterLeaves(feature, limit, offset)
 
 Returns the FeatureCollection from the cluster.
 
 ##### arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `clusterId` | `number` | `Yes` | The id of the cluster to expand. |
+| `feature` | `Feature` | `Yes` | The feature cluster to expand. |
 | `limit` | `number` | `Yes` | The number of points to return. |
 | `offset` | `number` | `Yes` | The amount of points to skip (for pagination). |
 
@@ -71,14 +71,14 @@ const collection = await shapeSource.getClusterLeaves(clusterId, limit, offset);
 ```
 
 
-#### getClusterChildren(clusterId)
+#### getClusterChildren(feature)
 
 Returns the FeatureCollection from the cluster (on the next zoom level).
 
 ##### arguments
 | Name | Type | Required | Description  |
 | ---- | :--: | :------: | :----------: |
-| `clusterId` | `number` | `Yes` | The id of the cluster to expand. |
+| `feature` | `Feature` | `Yes` | The feature cluster to expand. |
 
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3575,16 +3575,16 @@
       },
       {
         "name": "getClusterExpansionZoom",
-        "docblock": "Returns the zoom needed to expand the cluster.\n\n@example\nconst zoom = await shapeSource.getClusterExpansionZoom(clusterId);\n\n@param  {number} clusterId - The id of the cluster to expand.\n@return {number}",
+        "docblock": "Returns the zoom needed to expand the cluster.\n\n@example\nconst zoom = await shapeSource.getClusterExpansionZoom(clusterId);\n\n@param  {Feature} feature - The feature cluster to expand.\n@return {number}",
         "modifiers": [
           "async"
         ],
         "params": [
           {
-            "name": "clusterId",
-            "description": "The id of the cluster to expand.",
+            "name": "feature",
+            "description": "The feature cluster to expand.",
             "type": {
-              "name": "number"
+              "name": "Feature"
             },
             "optional": false
           }
@@ -3602,16 +3602,16 @@
       },
       {
         "name": "getClusterLeaves",
-        "docblock": "Returns the FeatureCollection from the cluster.\n\n@example\nconst collection = await shapeSource.getClusterLeaves(clusterId, limit, offset);\n\n@param  {number} clusterId - The id of the cluster to expand.\n@param  {number} limit - The number of points to return.\n@param  {number} offset - The amount of points to skip (for pagination).\n@return {FeatureCollection}",
+        "docblock": "Returns the FeatureCollection from the cluster.\n\n@example\nconst collection = await shapeSource.getClusterLeaves(clusterId, limit, offset);\n\n@param  {Feature} feature - The feature cluster to expand.\n@param  {number} limit - The number of points to return.\n@param  {number} offset - The amount of points to skip (for pagination).\n@return {FeatureCollection}",
         "modifiers": [
           "async"
         ],
         "params": [
           {
-            "name": "clusterId",
-            "description": "The id of the cluster to expand.",
+            "name": "feature",
+            "description": "The feature cluster to expand.",
             "type": {
-              "name": "number"
+              "name": "Feature"
             },
             "optional": false
           },
@@ -3645,16 +3645,16 @@
       },
       {
         "name": "getClusterChildren",
-        "docblock": "Returns the FeatureCollection from the cluster (on the next zoom level).\n\n@example\nconst collection = await shapeSource.getClusterChildren(clusterId);\n\n@param  {number} clusterId - The id of the cluster to expand.\n@return {FeatureCollection}",
+        "docblock": "Returns the FeatureCollection from the cluster (on the next zoom level).\n\n@example\nconst collection = await shapeSource.getClusterChildren(clusterId);\n\n@param  {Feature} feature - The feature cluster to expand.\n@return {FeatureCollection}",
         "modifiers": [
           "async"
         ],
         "params": [
           {
-            "name": "clusterId",
-            "description": "The id of the cluster to expand.",
+            "name": "feature",
+            "description": "The feature cluster to expand.",
             "type": {
-              "name": "number"
+              "name": "Feature"
             },
             "optional": false
           }

--- a/index.d.ts
+++ b/index.d.ts
@@ -297,19 +297,19 @@ declare namespace MapboxGL {
    */
   class VectorSource extends Component<VectorSourceProps> { }
   class ShapeSource extends Component<ShapeSourceProps> {
-    getClusterExpansionZoom(clusterId: number): Promise<number>;
+    getClusterExpansionZoom(feature: Feature<Geometry, Properties>): Promise<number>;
         /**
     * Returns all the leaves of a cluster with pagination support.
-    * @param clusterId the ID of the cluster
+    * @param cluster feature cluster
     * @param limit the number of leaves to return
     * @param offset the amount of points to skip (for pagination)
     */
-     getClusterLeaves: (clusterId: number, limit: number, offset: number ) => object
+     getClusterLeaves: (feature: Feature<Geometry, Properties>, limit: number, offset: number ) => Promise<Array<FeatureCollection<Geometry, Properties>>>
              /**
     * Returns the children of a cluster (on the next zoom level).
-    * @param clusterId the ID of the cluster   
+    * @param cluster feature cluster
     */
-    getClusterChildren: (clusterId: number) => object
+    getClusterChildren: (feature: Feature<Geometry, Properties>) => Promise<Array<FeatureCollection<Geometry, Properties>>>
   }
   class RasterSource extends Component<RasterSourceProps> { }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -297,19 +297,21 @@ declare namespace MapboxGL {
    */
   class VectorSource extends Component<VectorSourceProps> { }
   class ShapeSource extends Component<ShapeSourceProps> {
-    getClusterExpansionZoom(feature: Feature<Geometry, Properties>): Promise<number>;
+    features(filter?: Expression): Promise<FeatureCollection<Geometry, Properties>>
+
+    getClusterExpansionZoom(feature: Feature<Geometry, Properties> | number): Promise<number>
         /**
     * Returns all the leaves of a cluster with pagination support.
     * @param cluster feature cluster
     * @param limit the number of leaves to return
     * @param offset the amount of points to skip (for pagination)
     */
-     getClusterLeaves: (feature: Feature<Geometry, Properties>, limit: number, offset: number ) => Promise<Array<FeatureCollection<Geometry, Properties>>>
+     getClusterLeaves: (feature: Feature<Geometry, Properties> | number, limit: number, offset: number ) => Promise<FeatureCollection<Geometry, Properties>>
              /**
     * Returns the children of a cluster (on the next zoom level).
     * @param cluster feature cluster
     */
-    getClusterChildren: (feature: Feature<Geometry, Properties>) => Promise<Array<FeatureCollection<Geometry, Properties>>>
+      getClusterChildren: (feature: Feature<Geometry, Properties> | number) => Promise<FeatureCollection<Geometry, Properties>>
   }
   class RasterSource extends Component<RasterSourceProps> { }
 

--- a/ios/RCTMGL/RCTMGLShapeSource.h
+++ b/ios/RCTMGL/RCTMGLShapeSource.h
@@ -31,11 +31,22 @@
 @property (nonatomic, assign) BOOL hasPressListener;
 
 - (nonnull NSArray<id <MGLFeature>> *)featuresMatchingPredicate:(nullable NSPredicate *)predicate;
-- (nonnull NSArray<id <MGLFeature>> *)getClusterLeaves:(nonnull NSNumber *)clusterId
+- (nonnull NSArray<id <MGLFeature>> *)getClusterLeaves:(nonnull NSString *)featureJSON
                                                 number:(NSUInteger)number
                                                 offset:(NSUInteger)offset;
-- (nonnull NSArray<id <MGLFeature>> *)getClusterChildren:(nonnull NSNumber *)clusterId;                                               
+- (nonnull NSArray<id <MGLFeature>> *)getClusterChildren:(nonnull NSString *)featureJSON;                                               
 
-- (double)getClusterExpansionZoom:(nonnull NSNumber *)clusterId;
+- (double)getClusterExpansionZoom:(nonnull NSString *)featureJSON;
+
+// Deprecated. Will be removed in 9+ ver.
+- (nonnull NSArray<id <MGLFeature>> *)getClusterLeavesById:(nonnull NSNumber *)clusterId
+                                                number:(NSUInteger)number    
+                                                offset:(NSUInteger)offset;
+
+// Deprecated. Will be removed in 9+ ver.                                                
+- (nonnull NSArray<id <MGLFeature>> *)getClusterChildrenById:(nonnull NSNumber *)clusterId;     
+                                          
+// Deprecated. Will be removed in 9+ ver.
+- (double)getClusterExpansionZoomById:(nonnull NSNumber *)clusterId;
 
 @end

--- a/ios/RCTMGL/RCTMGLShapeSource.m
+++ b/ios/RCTMGL/RCTMGLShapeSource.m
@@ -139,4 +139,42 @@ static UIImage * _placeHolderImage;
     return [shapeSource childrenOfCluster:cluster];
 }
 
+
+// Deprecated. Will be removed in 9+ ver.
+- (double)getClusterExpansionZoomById:(nonnull NSNumber *)clusterId
+{
+    MGLShapeSource *shapeSource = (MGLShapeSource *)self.source;
+    NSArray<id<MGLFeature>> *features = [shapeSource featuresMatchingPredicate: [NSPredicate predicateWithFormat:@"%K = %i", @"cluster_id", clusterId.intValue]];
+    if (features.count == 0) {
+        return -1;
+    }
+    return [shapeSource zoomLevelForExpandingCluster:(MGLPointFeatureCluster *)features[0]];
+}
+
+// Deprecated. Will be removed in 9+ ver.
+- (nonnull NSArray<id <MGLFeature>> *)getClusterLeavesById:(nonnull NSNumber *)clusterId
+    number:(NSUInteger)number
+    offset:(NSUInteger)offset
+{
+    MGLShapeSource *shapeSource = (MGLShapeSource *)self.source;
+    
+    NSPredicate* predicate = [NSPredicate predicateWithFormat:@"cluster_id == %@", clusterId];
+    NSArray<id<MGLFeature>> *features = [shapeSource featuresMatchingPredicate:predicate];
+    
+    MGLPointFeatureCluster * cluster = (MGLPointFeatureCluster *)features[0];
+    return [shapeSource leavesOfCluster:cluster offset:offset limit:number];
+}
+
+// Deprecated. Will be removed in 9+ ver.
+- (nonnull NSArray<id <MGLFeature>> *)getClusterChildrenById:(nonnull NSNumber *)clusterId
+{
+    MGLShapeSource *shapeSource = (MGLShapeSource *)self.source;
+    
+    NSPredicate* predicate = [NSPredicate predicateWithFormat:@"cluster_id == %@", clusterId];
+    NSArray<id<MGLFeature>> *features = [shapeSource featuresMatchingPredicate:predicate];
+    
+    MGLPointFeatureCluster * cluster = (MGLPointFeatureCluster *)features[0];
+    return [shapeSource childrenOfCluster:cluster];
+}
+
 @end

--- a/ios/RCTMGL/RCTMGLShapeSource.m
+++ b/ios/RCTMGL/RCTMGLShapeSource.m
@@ -108,37 +108,34 @@ static UIImage * _placeHolderImage;
     return [shapeSource featuresMatchingPredicate:predicate];
 }
 
-- (double)getClusterExpansionZoom:(nonnull NSNumber *)clusterId
+- (double)getClusterExpansionZoom:(nonnull NSString *)featureJSON
 {
     MGLShapeSource *shapeSource = (MGLShapeSource *)self.source;
-    NSArray<id<MGLFeature>> *features = [shapeSource featuresMatchingPredicate: [NSPredicate predicateWithFormat:@"%K = %i", @"cluster_id", clusterId.intValue]];
-    if (features.count == 0) {
-        return -1;
-    }
-    return [shapeSource zoomLevelForExpandingCluster:(MGLPointFeatureCluster *)features[0]];
+
+    MGLPointFeature *feature = (MGLPointFeature*)[RCTMGLUtils shapeFromGeoJSON:featureJSON];
+ 
+    return [shapeSource zoomLevelForExpandingCluster:(MGLPointFeatureCluster *)feature];
 }
 
-- (nonnull NSArray<id <MGLFeature>> *)getClusterLeaves:(nonnull NSNumber *)clusterId
+- (nonnull NSArray<id <MGLFeature>> *)getClusterLeaves:(nonnull NSString *)featureJSON
     number:(NSUInteger)number
     offset:(NSUInteger)offset
 {
     MGLShapeSource *shapeSource = (MGLShapeSource *)self.source;
-    
-    NSPredicate* predicate = [NSPredicate predicateWithFormat:@"cluster_id == %@", clusterId];
-    NSArray<id<MGLFeature>> *features = [shapeSource featuresMatchingPredicate:predicate];
-    
-    MGLPointFeatureCluster * cluster = (MGLPointFeatureCluster *)features[0];
+
+    MGLPointFeature *feature = (MGLPointFeature*)[RCTMGLUtils shapeFromGeoJSON:featureJSON];
+
+    MGLPointFeatureCluster * cluster = (MGLPointFeatureCluster *)feature;
     return [shapeSource leavesOfCluster:cluster offset:offset limit:number];
 }
 
-- (nonnull NSArray<id <MGLFeature>> *)getClusterChildren:(nonnull NSNumber *)clusterId
+- (nonnull NSArray<id <MGLFeature>> *)getClusterChildren:(nonnull NSString *)featureJSON
 {
     MGLShapeSource *shapeSource = (MGLShapeSource *)self.source;
     
-    NSPredicate* predicate = [NSPredicate predicateWithFormat:@"cluster_id == %@", clusterId];
-    NSArray<id<MGLFeature>> *features = [shapeSource featuresMatchingPredicate:predicate];
+    MGLPointFeature *feature = (MGLPointFeature*)[RCTMGLUtils shapeFromGeoJSON:featureJSON];
     
-    MGLPointFeatureCluster * cluster = (MGLPointFeatureCluster *)features[0];
+    MGLPointFeatureCluster * cluster = (MGLPointFeatureCluster *)feature;
     return [shapeSource childrenOfCluster:cluster];
 }
 

--- a/ios/RCTMGL/RCTMGLShapeSourceManager.m
+++ b/ios/RCTMGL/RCTMGLShapeSourceManager.m
@@ -134,4 +134,72 @@ RCT_EXPORT_METHOD(getClusterChildren:(nonnull NSNumber*)reactTag
     }];
 }
 
+// Deprecated. Will be removed in 9+ ver.
+RCT_EXPORT_METHOD(getClusterExpansionZoomById:(nonnull NSNumber*)reactTag
+                                clusterId:(nonnull NSNumber*)clusterId
+                                 resolver:(RCTPromiseResolveBlock)resolve
+                                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
+        RCTMGLShapeSource* shapeSource = (RCTMGLShapeSource *)viewRegistry[reactTag];
+
+        if (![shapeSource isKindOfClass:[RCTMGLShapeSource class]]) {
+            RCTLogError(@"Invalid react tag, could not find RCTMGLMapView");
+            return;
+        }
+
+        double zoom = [shapeSource getClusterExpansionZoomById:clusterId];
+        if (zoom == -1) {
+          reject(@"zoom_error", [NSString stringWithFormat:@"Could not get zoom for cluster id %@", clusterId], nil);
+          return;
+        }
+        resolve(@{@"data":@(zoom)});
+    }];
+}
+
+// Deprecated. Will be removed in 9+ ver.
+RCT_EXPORT_METHOD(getClusterLeavesById:(nonnull NSNumber*)reactTag
+                  clusterId:(nonnull NSNumber *)clusterId
+                  number:(NSUInteger) number
+                  offset:(NSUInteger) offset
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
+        RCTMGLShapeSource* shapeSource = (RCTMGLShapeSource *)viewRegistry[reactTag];
+
+        NSArray<id<MGLFeature>> *shapes = [shapeSource getClusterLeavesById:clusterId number:number offset:offset];
+
+        NSMutableArray<NSDictionary*> *features = [[NSMutableArray alloc] initWithCapacity:shapes.count];
+        for (int i = 0; i < shapes.count; i++) {
+            [features addObject:shapes[i].geoJSONDictionary];
+        }
+
+        resolve(@{
+                  @"data": @{ @"type": @"FeatureCollection", @"features": features }
+                  });
+    }];
+}
+// Deprecated. Will be removed in 9+ ver.
+RCT_EXPORT_METHOD(getClusterChildrenById:(nonnull NSNumber*)reactTag
+                  clusterId:(nonnull NSNumber *)clusterId                  
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
+        RCTMGLShapeSource* shapeSource = (RCTMGLShapeSource *)viewRegistry[reactTag];
+
+        NSArray<id<MGLFeature>> *shapes = [shapeSource getClusterChildrenById: clusterId];
+
+        NSMutableArray<NSDictionary*> *features = [[NSMutableArray alloc] initWithCapacity:shapes.count];
+        for (int i = 0; i < shapes.count; i++) {
+            [features addObject:shapes[i].geoJSONDictionary];
+        }
+
+        resolve(@{
+                  @"data": @{ @"type": @"FeatureCollection", @"features": features }
+                  });
+    }];
+}
+
 @end

--- a/ios/RCTMGL/RCTMGLShapeSourceManager.m
+++ b/ios/RCTMGL/RCTMGLShapeSourceManager.m
@@ -68,7 +68,7 @@ RCT_EXPORT_METHOD(features:(nonnull NSNumber*)reactTag
 }
 
 RCT_EXPORT_METHOD(getClusterExpansionZoom:(nonnull NSNumber*)reactTag
-                                clusterId:(nonnull NSNumber*)clusterId
+                                featureJSON:(nonnull NSString*)featureJSON
                                  resolver:(RCTPromiseResolveBlock)resolve
                                  rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -80,9 +80,9 @@ RCT_EXPORT_METHOD(getClusterExpansionZoom:(nonnull NSNumber*)reactTag
             return;
         }
 
-        double zoom = [shapeSource getClusterExpansionZoom:clusterId];
+        double zoom = [shapeSource getClusterExpansionZoom: featureJSON];
         if (zoom == -1) {
-          reject(@"zoom_error", [NSString stringWithFormat:@"Could not get zoom for cluster id %@", clusterId], nil);
+          reject(@"zoom_error", [NSString stringWithFormat:@"Could not get zoom for cluster %@", featureJSON], nil);
           return;
         }
         resolve(@{@"data":@(zoom)});
@@ -91,7 +91,7 @@ RCT_EXPORT_METHOD(getClusterExpansionZoom:(nonnull NSNumber*)reactTag
 
 
 RCT_EXPORT_METHOD(getClusterLeaves:(nonnull NSNumber*)reactTag
-                  clusterId:(nonnull NSNumber *)clusterId
+                  featureJSON:(nonnull NSString*)featureJSON
                   number:(NSUInteger) number
                   offset:(NSUInteger) offset
                   resolver:(RCTPromiseResolveBlock)resolve
@@ -100,7 +100,7 @@ RCT_EXPORT_METHOD(getClusterLeaves:(nonnull NSNumber*)reactTag
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
         RCTMGLShapeSource* shapeSource = (RCTMGLShapeSource *)viewRegistry[reactTag];
 
-        NSArray<id<MGLFeature>> *shapes = [shapeSource getClusterLeaves:clusterId number:number offset:offset];
+        NSArray<id<MGLFeature>> *shapes = [shapeSource getClusterLeaves:featureJSON number:number offset:offset];
 
         NSMutableArray<NSDictionary*> *features = [[NSMutableArray alloc] initWithCapacity:shapes.count];
         for (int i = 0; i < shapes.count; i++) {
@@ -114,14 +114,14 @@ RCT_EXPORT_METHOD(getClusterLeaves:(nonnull NSNumber*)reactTag
 }
 
 RCT_EXPORT_METHOD(getClusterChildren:(nonnull NSNumber*)reactTag
-                  clusterId:(nonnull NSNumber *)clusterId                  
+                  featureJSON:(nonnull NSString*)featureJSON                
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, NSDictionary<NSNumber*, UIView*> *viewRegistry) {
         RCTMGLShapeSource* shapeSource = (RCTMGLShapeSource *)viewRegistry[reactTag];
 
-        NSArray<id<MGLFeature>> *shapes = [shapeSource getClusterChildren: clusterId];
+        NSArray<id<MGLFeature>> *shapes = [shapeSource getClusterChildren: featureJSON];
 
         NSMutableArray<NSDictionary*> *features = [[NSMutableArray alloc] initWithCapacity:shapes.count];
         for (int i = 0; i < shapes.count; i++) {

--- a/javascript/components/ShapeSource.js
+++ b/javascript/components/ShapeSource.js
@@ -164,6 +164,18 @@ class ShapeSource extends NativeBridgeComponent(AbstractSource) {
    * @return {number}
    */
   async getClusterExpansionZoom(feature) {
+    if (typeof feature === 'number') {
+      console.warn(
+        'Using cluster_id is deprecated and will be removed from the future releases. Please use cluster as an argument instead.',
+      );
+      const res = await this._runNativeCommand(
+        'getClusterExpansionZoomById',
+        this._nativeRef,
+        [feature],
+      );
+      return res.data;
+    }
+
     const res = await this._runNativeCommand(
       'getClusterExpansionZoom',
       this._nativeRef,
@@ -184,6 +196,23 @@ class ShapeSource extends NativeBridgeComponent(AbstractSource) {
    * @return {FeatureCollection}
    */
   async getClusterLeaves(feature, limit, offset) {
+    if (typeof feature === 'number') {
+      console.warn(
+        'Using cluster_id is deprecated and will be removed from the future releases. Please use cluster as an argument instead.',
+      );
+      const res = await this._runNativeCommand(
+        'getClusterLeavesById',
+        this._nativeRef,
+        [feature, limit, offset],
+      );
+
+      if (isAndroid()) {
+        return JSON.parse(res.data);
+      }
+
+      return res.data;
+    }
+
     const res = await this._runNativeCommand(
       'getClusterLeaves',
       this._nativeRef,
@@ -207,6 +236,23 @@ class ShapeSource extends NativeBridgeComponent(AbstractSource) {
    * @return {FeatureCollection}
    */
   async getClusterChildren(feature) {
+    if (typeof feature === 'number') {
+      console.warn(
+        'Using cluster_id is deprecated and will be removed from the future releases. Please use cluster as an argument instead.',
+      );
+      const res = await this._runNativeCommand(
+        'getClusterChildrenById',
+        this._nativeRef,
+        [feature],
+      );
+
+      if (isAndroid()) {
+        return JSON.parse(res.data);
+      }
+
+      return res.data;
+    }
+
     const res = await this._runNativeCommand(
       'getClusterChildren',
       this._nativeRef,

--- a/javascript/components/ShapeSource.js
+++ b/javascript/components/ShapeSource.js
@@ -160,14 +160,14 @@ class ShapeSource extends NativeBridgeComponent(AbstractSource) {
    * @example
    * const zoom = await shapeSource.getClusterExpansionZoom(clusterId);
    *
-   * @param  {number} clusterId - The id of the cluster to expand.
+   * @param  {Feature} feature - The feature cluster to expand.
    * @return {number}
    */
-  async getClusterExpansionZoom(clusterId) {
+  async getClusterExpansionZoom(feature) {
     const res = await this._runNativeCommand(
       'getClusterExpansionZoom',
       this._nativeRef,
-      [clusterId],
+      [JSON.stringify(feature)],
     );
     return res.data;
   }
@@ -178,16 +178,16 @@ class ShapeSource extends NativeBridgeComponent(AbstractSource) {
    * @example
    * const collection = await shapeSource.getClusterLeaves(clusterId, limit, offset);
    *
-   * @param  {number} clusterId - The id of the cluster to expand.
+   * @param  {Feature} feature - The feature cluster to expand.
    * @param  {number} limit - The number of points to return.
    * @param  {number} offset - The amount of points to skip (for pagination).
    * @return {FeatureCollection}
    */
-  async getClusterLeaves(clusterId, limit, offset) {
+  async getClusterLeaves(feature, limit, offset) {
     const res = await this._runNativeCommand(
       'getClusterLeaves',
       this._nativeRef,
-      [clusterId, limit, offset],
+      [JSON.stringify(feature), limit, offset],
     );
 
     if (isAndroid()) {
@@ -203,14 +203,14 @@ class ShapeSource extends NativeBridgeComponent(AbstractSource) {
    * @example
    * const collection = await shapeSource.getClusterChildren(clusterId);
    *
-   * @param  {number} clusterId - The id of the cluster to expand.
+   * @param  {Feature} feature - The feature cluster to expand.
    * @return {FeatureCollection}
    */
-  async getClusterChildren(clusterId) {
+  async getClusterChildren(feature) {
     const res = await this._runNativeCommand(
       'getClusterChildren',
       this._nativeRef,
-      [clusterId],
+      [JSON.stringify(feature)],
     );
 
     if (isAndroid()) {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Since current implementation of `getClusterExpansionZoom`, `getClusterLeaves` and `getClusterChildren` uses querySourceFeatures / featuresMatchingPredicate to get desired data, it sets a limitation on functionality provided by native (original) corresponding methods. For now, obtaining needed data from this method is only possible for the clusters that are currently rendered on the map. But according to docs of the SDK it should be possible to use it on any cluster ( even deeply nested )

**This PR updates these methods by passing the cluster itself not cluster_id**.


## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I updated the documentation `yarn generate`
* [x] I mentioned this change in `CHANGELOG.md`
* [x] I updated the typings files (`index.d.ts`)
* [ ] I added/ updated a sample  (`/example`)

## Screenshot OR Video

Possible use case:
To zoom or just find a cluster for any single point on the map. 

Solution:
Recursively use `getClusterChildren(rootCluster)` to find desired cluster and then with `getClusterExpansionZoom(deeplyNestedCluster)` smoothly zoom to it. ( For example, user searches some place on the map using search input ) 


## Example
```javascript
 <ShapeSource
     ref={shapeSourceRef}
     onPress={async event => {
        const { features } = event;
        const cluster = features[0];
     
        const featureCollection = await shapeSourceRef.current.getClusterChildren(cluster);

     }}
 
 
 
```
