### PR TITLE
Allow padding directly on Camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ PR Title ([#123](link to my pr))
 Update ShapeSource methods to make it usable with any cluster ( Use cluster itself instead of cluster_id as first argument for getClusterExpansionZoom/getClusterLeaves/getClusterChildren methods. Version < 9 methods still supports passing cluster_id as a first argument but a deprecation warning will be shown. ) ([#1499](https://github.com/react-native-mapbox-gl/maps/pull/1499))
 ```
 
+Enable `padding` as a root-level prop on the camera, with `bounds.padding*` as fallbacks ([#TODO](TODO))
+
 ---
 
 ## 8.3.0

--- a/__tests__/components/Camera.test.js
+++ b/__tests__/components/Camera.test.js
@@ -71,6 +71,10 @@ describe('Camera', () => {
           heading: undefined,
           duration: 2000,
           zoom: undefined,
+          paddingBottom: 0,
+          paddingLeft: 0,
+          paddingRight: 0,
+          paddingTop: 0,
         },
         maxZoomLevel: undefined,
         minZoomLevel: undefined,
@@ -495,11 +499,13 @@ describe('Camera', () => {
             animationMode: 'easeTo',
             bounds: {
               ne: [-63.12641, 39.797968],
+              sw: [-74.143727, 40.772177],
+            },
+            padding: {
               paddingBottom: null,
               paddingLeft: null,
               paddingRight: null,
               paddingTop: null,
-              sw: [-74.143727, 40.772177],
             },
           },
           {
@@ -507,11 +513,13 @@ describe('Camera', () => {
             animationMode: 'easeTo',
             bounds: {
               ne: [-63.12641, 39.797968],
+              sw: [-74.143727, 40.772177],
+            },
+            padding: {
               paddingBottom: null,
               paddingLeft: null,
               paddingRight: null,
               paddingTop: null,
-              sw: [-74.143727, 40.772177],
             },
           },
           {
@@ -519,11 +527,13 @@ describe('Camera', () => {
             animationMode: 'easeTo',
             bounds: {
               ne: [-63.12641, 39.797968],
+              sw: [-74.143727, 40.772177],
+            },
+            padding: {
               paddingBottom: 0,
               paddingLeft: 0,
               paddingRight: 0,
               paddingTop: 0,
-              sw: [-74.143727, 40.772177],
             },
           },
         ];
@@ -547,11 +557,13 @@ describe('Camera', () => {
           animationMode: 'easeTo',
           bounds: {
             ne: [-63.12641, 39.797968],
+            sw: [-74.143727, 40.772177],
+          },
+          padding: {
             paddingBottom: 3,
             paddingLeft: 3,
             paddingRight: 3,
             paddingTop: 3,
-            sw: [-74.143727, 40.772177],
           },
         };
 
@@ -565,11 +577,13 @@ describe('Camera', () => {
           animationMode: 'easeTo',
           bounds: {
             ne: [-63.12641, 39.797968],
+            sw: [-74.143727, 40.772177],
+          },
+          padding: {
             paddingBottom: 3,
             paddingLeft: 5,
             paddingRight: 5,
             paddingTop: 3,
-            sw: [-74.143727, 40.772177],
           },
         };
 
@@ -583,11 +597,13 @@ describe('Camera', () => {
           animationMode: 'easeTo',
           bounds: {
             ne: [-63.12641, 39.797968],
+            sw: [-74.143727, 40.772177],
+          },
+          padding: {
             paddingBottom: 8,
             paddingLeft: 10,
             paddingRight: 5,
             paddingTop: 3,
-            sw: [-74.143727, 40.772177],
           },
         };
 
@@ -939,6 +955,10 @@ describe('Camera', () => {
           mode: 'None',
           pitch: undefined,
           zoom: 16,
+          paddingBottom: 0,
+          paddingLeft: 0,
+          paddingRight: 0,
+          paddingTop: 0,
         };
 
         expect(camera.defaultCamera).toStrictEqual(undefined);
@@ -998,6 +1018,10 @@ describe('Camera', () => {
           mode: 'Ease',
           pitch: 45,
           zoom: 9,
+          paddingBottom: 0,
+          paddingLeft: 0,
+          paddingRight: 0,
+          paddingTop: 0,
         });
 
         // with centerCoordinate
@@ -1014,6 +1038,10 @@ describe('Camera', () => {
           mode: 'Ease',
           pitch: 45,
           zoom: 9,
+          paddingBottom: 0,
+          paddingLeft: 0,
+          paddingRight: 0,
+          paddingTop: 0,
         });
       });
 

--- a/__tests__/components/Camera.test.js
+++ b/__tests__/components/Camera.test.js
@@ -781,10 +781,10 @@ describe('Camera', () => {
           stop: {
             bounds:
               '{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-63.12641,39.797968]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-74.143727,40.772177]}}]}',
-            boundsPaddingBottom: 8,
-            boundsPaddingLeft: 10,
-            boundsPaddingRight: 5,
-            boundsPaddingTop: 3,
+            paddingBottom: 8,
+            paddingLeft: 10,
+            paddingRight: 5,
+            paddingTop: 3,
             duration: 500,
             heading: 100,
             mode: 'Ease',
@@ -871,10 +871,10 @@ describe('Camera', () => {
               {
                 bounds:
                   '{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-63.12641,39.797968]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-74.143727,40.772177]}}]}',
-                boundsPaddingBottom: 2,
-                boundsPaddingLeft: 2,
-                boundsPaddingRight: 2,
-                boundsPaddingTop: 2,
+                paddingBottom: 2,
+                paddingLeft: 2,
+                paddingRight: 2,
+                paddingTop: 2,
                 duration: 50,
                 heading: 20,
                 mode: 'Ease',
@@ -884,10 +884,10 @@ describe('Camera', () => {
               {
                 bounds:
                   '{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-63.12641,59.797968]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-71.143727,40.772177]}}]}',
-                boundsPaddingBottom: 8,
-                boundsPaddingLeft: 10,
-                boundsPaddingRight: 5,
-                boundsPaddingTop: 3,
+                paddingBottom: 8,
+                paddingLeft: 10,
+                paddingRight: 5,
+                paddingTop: 3,
                 duration: 3000,
                 heading: 40,
                 mode: 'Flight',
@@ -897,10 +897,10 @@ describe('Camera', () => {
               {
                 bounds:
                   '{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-63.12641,39.797968]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-74.143727,40.772177]}}]}',
-                boundsPaddingBottom: 8,
-                boundsPaddingLeft: 10,
-                boundsPaddingRight: 5,
-                boundsPaddingTop: 3,
+                paddingBottom: 8,
+                paddingLeft: 10,
+                paddingRight: 5,
+                paddingTop: 3,
                 duration: 500,
                 heading: 100,
                 mode: 'Ease',
@@ -1025,10 +1025,10 @@ describe('Camera', () => {
         expect(camera._createStopConfig(configWithBounds, true)).toStrictEqual({
           bounds:
             '{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-63.12641,39.797968]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-74.143727,40.772177]}}]}',
-          boundsPaddingBottom: 8,
-          boundsPaddingLeft: 10,
-          boundsPaddingRight: 5,
-          boundsPaddingTop: 3,
+          paddingBottom: 8,
+          paddingLeft: 10,
+          paddingRight: 5,
+          paddingTop: 3,
           duration: 500,
           heading: 100,
           mode: 'Ease',
@@ -1045,10 +1045,10 @@ describe('Camera', () => {
         ).toStrictEqual({
           bounds:
             '{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-63.12641,39.797968]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-74.143727,40.772177]}}]}',
-          boundsPaddingBottom: 8,
-          boundsPaddingLeft: 10,
-          boundsPaddingRight: 5,
-          boundsPaddingTop: 3,
+          paddingBottom: 8,
+          paddingLeft: 10,
+          paddingRight: 5,
+          paddingTop: 3,
           centerCoordinate:
             '{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-111.8678,40.2866]}}',
           duration: 500,

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/CameraStop.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/CameraStop.java
@@ -29,10 +29,10 @@ public class CameraStop {
     private LatLng mLatLng;
 
     private LatLngBounds mBounds;
-    private int mBoundsPaddingLeft = 0;
-    private int mBoundsPaddingRight = 0;
-    private int mBoundsPaddingBottom = 0;
-    private int mBoundsPaddingTop = 0;
+    private int mPaddingLeft = 0;
+    private int mPaddingRight = 0;
+    private int mPaddingBottom = 0;
+    private int mPaddingTop = 0;
 
     private int mMode = CameraMode.EASE;
     private int mDuration = 2000;
@@ -65,12 +65,15 @@ public class CameraStop {
         mCallback = callback;
     }
 
-    public void setBounds(LatLngBounds bounds, int paddingLeft, int paddingRight, int paddingTop, int paddingBottom) {
+    public void setBounds(LatLngBounds bounds) {
         mBounds = bounds;
-        mBoundsPaddingLeft = paddingLeft;
-        mBoundsPaddingRight = paddingRight;
-        mBoundsPaddingTop = paddingTop;
-        mBoundsPaddingBottom = paddingBottom;
+    }
+
+    public void setPadding(int paddingLeft, int paddingRight, int paddingTop, int paddingBottom) {
+        mPaddingLeft = paddingLeft;
+        mPaddingRight = paddingRight;
+        mPaddingTop = paddingTop;
+        mPaddingBottom = paddingBottom;
     }
 
     public void setMode(@CameraMode.Mode int mode) {
@@ -90,23 +93,32 @@ public class CameraStop {
             builder.tilt(mTilt);
         }
 
+        // Adding map padding to the camera padding which is the same behavior as
+        // mapbox native does on iOS
+        double[] contentInset = mapView.getContentInset();
+
+        int paddingLeft = Double.valueOf(contentInset[0] + mPaddingLeft).intValue();
+        int paddingTop = Double.valueOf(contentInset[1] + mPaddingTop).intValue();
+        int paddingRight = Double.valueOf(contentInset[2] + mPaddingRight).intValue();
+        int paddingBottom = Double.valueOf(contentInset[3] + mPaddingBottom).intValue();
+
+        int[] cameraPadding = {paddingLeft, paddingTop, paddingRight, paddingBottom};
+        int[] cameraPaddingClipped = clippedPadding(cameraPadding, mapView);
+
         if (mLatLng != null) {
             builder.target(mLatLng);
+            builder.padding(
+                cameraPaddingClipped[0],
+                cameraPaddingClipped[1],
+                cameraPaddingClipped[2],
+                cameraPaddingClipped[3]
+            );
+            if (mZoom != null) {
+                builder.zoom(mZoom);
+            }
         } else if (mBounds != null) {
             double tilt = mTilt != null ? mTilt : currentCamera.tilt;
             double bearing = mBearing != null ? mBearing : currentCamera.bearing;
-
-            // Adding map padding to the camera padding which is the same behavior as
-            // mapbox native does on iOS
-            double[] contentInset = mapView.getContentInset();
-
-            int paddingLeft = Double.valueOf(contentInset[0] + mBoundsPaddingLeft).intValue();
-            int paddingTop = Double.valueOf(contentInset[1] + mBoundsPaddingTop).intValue();
-            int paddingRight = Double.valueOf(contentInset[2] + mBoundsPaddingRight).intValue();
-            int paddingBottom = Double.valueOf(contentInset[3] + mBoundsPaddingBottom).intValue();
-
-            int[] cameraPadding = {paddingLeft, paddingTop, paddingRight, paddingBottom};
-            int[] cameraPaddingClipped = clippedPadding(cameraPadding, mapView);
 
             CameraPosition boundsCamera = map.getCameraForLatLngBounds(mBounds, cameraPaddingClipped, bearing, tilt);
             if (boundsCamera != null) {
@@ -115,18 +127,14 @@ public class CameraStop {
                 builder.padding(boundsCamera.padding);
             } else {
                 CameraUpdate update = CameraUpdateFactory.newLatLngBounds(
-                        mBounds,
-                        cameraPaddingClipped[0],
-                        cameraPaddingClipped[1],
-                        cameraPaddingClipped[2],
-                        cameraPaddingClipped[3]
+                    mBounds,
+                    cameraPaddingClipped[0],
+                    cameraPaddingClipped[1],
+                    cameraPaddingClipped[2],
+                    cameraPaddingClipped[3]
                 );
                 return new CameraUpdateItem(map, update, mDuration, mCallback, mMode);
             }
-        }
-
-        if (mZoom != null) {
-            builder.zoom(mZoom);
         }
 
         return new CameraUpdateItem(map, CameraUpdateFactory.newCameraPosition(builder.build()), mDuration, mCallback, mMode);
@@ -143,6 +151,25 @@ public class CameraStop {
             stop.setBearing(readableMap.getDouble("heading"));
         }
 
+        int paddingTop = getPaddingByKey(readableMap, "paddingTop");
+        int paddingRight = getPaddingByKey(readableMap, "paddingRight");
+        int paddingBottom = getPaddingByKey(readableMap, "paddingBottom");
+        int paddingLeft = getPaddingByKey(readableMap, "paddingLeft");
+
+        // scale padding by pixel ratio
+        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+        paddingTop = Float.valueOf(paddingTop * metrics.scaledDensity).intValue();
+        paddingRight = Float.valueOf(paddingRight * metrics.scaledDensity).intValue();
+        paddingBottom = Float.valueOf(paddingBottom * metrics.scaledDensity).intValue();
+        paddingLeft = Float.valueOf(paddingLeft * metrics.scaledDensity).intValue();
+
+        stop.setPadding(
+                paddingLeft,
+                paddingRight,
+                paddingTop,
+                paddingBottom
+        );
+
         if (readableMap.hasKey("centerCoordinate")) {
             Point target = GeoJSONUtils.toPointGeometry(readableMap.getString("centerCoordinate"));
             stop.setLatLng(GeoJSONUtils.toLatLng(target));
@@ -157,21 +184,8 @@ public class CameraStop {
         }
 
         if (readableMap.hasKey("bounds")) {
-            int paddingTop = getBoundsPaddingByKey(readableMap, "boundsPaddingTop");
-            int paddingRight = getBoundsPaddingByKey(readableMap, "boundsPaddingRight");
-            int paddingBottom = getBoundsPaddingByKey(readableMap, "boundsPaddingBottom");
-            int paddingLeft = getBoundsPaddingByKey(readableMap, "boundsPaddingLeft");
-
-            // scale padding by pixel ratio
-            DisplayMetrics metrics = context.getResources().getDisplayMetrics();
-            paddingTop = Float.valueOf(paddingTop * metrics.scaledDensity).intValue();
-            paddingRight = Float.valueOf(paddingRight * metrics.scaledDensity).intValue();
-            paddingBottom = Float.valueOf(paddingBottom * metrics.scaledDensity).intValue();
-            paddingLeft = Float.valueOf(paddingLeft * metrics.scaledDensity).intValue();
-
             FeatureCollection collection = FeatureCollection.fromJson(readableMap.getString("bounds"));
-            stop.setBounds(GeoJSONUtils.toLatLngBounds(collection), paddingLeft, paddingRight,
-                    paddingTop, paddingBottom);
+            stop.setBounds(GeoJSONUtils.toLatLngBounds(collection));
         }
 
         if (readableMap.hasKey("mode")) {
@@ -225,7 +239,7 @@ public class CameraStop {
         return new int[] {resultLeft, resultTop, resultRight, resultBottom};
     }
 
-    private static int getBoundsPaddingByKey(ReadableMap map, String key) {
+    private static int getPaddingByKey(ReadableMap map, String key) {
         return map.hasKey(key) ? map.getInt(key) : 0;
     }
 }

--- a/docs/Camera.md
+++ b/docs/Camera.md
@@ -6,7 +6,7 @@
 | Prop | Type | Default | Required | Description |
 | ---- | :--: | :-----: | :------: | :----------: |
 | animationDuration | `number` | `2000` | `false` | The duration a camera update takes (in ms) |
-| animationMode | `enum` | `'easeTo'` | `false` | The animationstyle when the camara updates. One of; `flyTo`, `easeTo`, `linearTo`, `moveTo` |
+| animationMode | `enum` | `'easeTo'` | `false` | The animationstyle when the camara updates. One of: `flyTo`, `easeTo`, `linearTo`, `moveTo` |
 | defaultSettings | `shape` | `none` | `false` | Default view settings applied on camera |
 | &nbsp;&nbsp;centerCoordinate | `array` | `none` | `false` | Center coordinate on map [lng, lat] |
 | &nbsp;&nbsp;padding | `shape` | `none` | `false` | Padding around edges of map in points |

--- a/docs/Camera.md
+++ b/docs/Camera.md
@@ -9,27 +9,37 @@
 | animationMode | `enum` | `'easeTo'` | `false` | The animationstyle when the camara updates. One of; `flyTo`, `easeTo`, `linearTo`, `moveTo` |
 | defaultSettings | `shape` | `none` | `false` | Default view settings applied on camera |
 | &nbsp;&nbsp;centerCoordinate | `array` | `none` | `false` | Center coordinate on map [lng, lat] |
+| &nbsp;&nbsp;padding | `shape` | `none` | `false` | Padding around edges of map in points |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingLeft | `number` | `none` | `false` | Left padding in points |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingRight | `number` | `none` | `false` | Right padding in points |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingTop | `number` | `none` | `false` | Top padding in points |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingBottom | `number` | `none` | `false` | Bottom padding in points |
 | &nbsp;&nbsp;heading | `number` | `none` | `false` | Heading on map |
 | &nbsp;&nbsp;pitch | `number` | `none` | `false` | Pitch on map |
-| &nbsp;&nbsp;bounds | `shape` | `none` | `false` | Represents a rectangle in geographical coordinates marking the visible area of the map. |
+| &nbsp;&nbsp;bounds | `shape` | `none` | `false` | Represents a rectangle in geographical coordinates marking the visible area of the map.<br/>The `bounds.padding*` properties are deprecated; use root `padding` property instead. |
 | &nbsp;&nbsp;&nbsp;&nbsp;ne | `array` | `none` | `true` | North east coordinate of bound |
 | &nbsp;&nbsp;&nbsp;&nbsp;sw | `array` | `none` | `true` | South west coordinate of bound |
-| &nbsp;&nbsp;&nbsp;&nbsp;paddingLeft | `number` | `none` | `false` | Left camera padding for bounds |
-| &nbsp;&nbsp;&nbsp;&nbsp;paddingRight | `number` | `none` | `false` | Right camera padding for bounds |
-| &nbsp;&nbsp;&nbsp;&nbsp;paddingTop | `number` | `none` | `false` | Top camera padding for bounds |
-| &nbsp;&nbsp;&nbsp;&nbsp;paddingBottom | `number` | `none` | `false` | Bottom camera padding for bounds |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingLeft | `number` | `none` | `false` | Left padding in points (deprecated; use root `padding` property instead) |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingRight | `number` | `none` | `false` | Right padding in points (deprecated; use root `padding` property instead) |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingTop | `number` | `none` | `false` | Top padding in points (deprecated; use root `padding` property instead) |
+| &nbsp;&nbsp;&nbsp;&nbsp;paddingBottom | `number` | `none` | `false` | Bottom padding in points (deprecated; use root `padding` property instead) |
 | &nbsp;&nbsp;onUserTrackingModeChange | `func` | `none` | `false` | Callback that is triggered on user tracking mode changes |
 | &nbsp;&nbsp;zoomLevel | `number` | `none` | `false` | Zoom level of the map |
 | centerCoordinate | `array` | `none` | `false` | Center coordinate on map [lng, lat] |
+| padding | `shape` | `none` | `false` | Padding around edges of map in points |
+| &nbsp;&nbsp;paddingLeft | `number` | `none` | `false` | Left padding in points |
+| &nbsp;&nbsp;paddingRight | `number` | `none` | `false` | Right padding in points |
+| &nbsp;&nbsp;paddingTop | `number` | `none` | `false` | Top padding in points |
+| &nbsp;&nbsp;paddingBottom | `number` | `none` | `false` | Bottom padding in points |
 | heading | `number` | `none` | `false` | Heading on map |
 | pitch | `number` | `none` | `false` | Pitch on map |
-| bounds | `shape` | `none` | `false` | Represents a rectangle in geographical coordinates marking the visible area of the map. |
+| bounds | `shape` | `none` | `false` | Represents a rectangle in geographical coordinates marking the visible area of the map.<br/>The `bounds.padding*` properties are deprecated; use root `padding` property instead. |
 | &nbsp;&nbsp;ne | `array` | `none` | `true` | North east coordinate of bound |
 | &nbsp;&nbsp;sw | `array` | `none` | `true` | South west coordinate of bound |
-| &nbsp;&nbsp;paddingLeft | `number` | `none` | `false` | Left camera padding for bounds |
-| &nbsp;&nbsp;paddingRight | `number` | `none` | `false` | Right camera padding for bounds |
-| &nbsp;&nbsp;paddingTop | `number` | `none` | `false` | Top camera padding for bounds |
-| &nbsp;&nbsp;paddingBottom | `number` | `none` | `false` | Bottom camera padding for bounds |
+| &nbsp;&nbsp;paddingLeft | `number` | `none` | `false` | Left padding in points (deprecated; use root `padding` property instead) |
+| &nbsp;&nbsp;paddingRight | `number` | `none` | `false` | Right padding in points (deprecated; use root `padding` property instead) |
+| &nbsp;&nbsp;paddingTop | `number` | `none` | `false` | Top padding in points (deprecated; use root `padding` property instead) |
+| &nbsp;&nbsp;paddingBottom | `number` | `none` | `false` | Bottom padding in points (deprecated; use root `padding` property instead) |
 | onUserTrackingModeChange | `func` | `none` | `false` | Callback that is triggered on user tracking mode changes |
 | zoomLevel | `number` | `none` | `false` | Zoom level of the map |
 | minZoomLevel | `number` | `none` | `false` | The minimun zoom level of the map |

--- a/docs/OfflineManager.md
+++ b/docs/OfflineManager.md
@@ -177,7 +177,7 @@ await MapboxGL.offlineManager.mergeOfflineRegions(path);
 
 #### setTileCountLimit(limit)
 
-Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.<br/>The Mapbox Terms of Service prohibits changing or bypassing this limit without permission from Mapbox.
+Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.<br/>The Mapbox Terms of Service prohibit changing or bypassing this limit without permission from Mapbox.
 
 ##### arguments
 | Name | Type | Required | Description  |
@@ -193,7 +193,7 @@ MapboxGL.offlineManager.setTileCountLimit(1000);
 
 #### setProgressEventThrottle(throttleValue)
 
-Sets the value at which download status events will be sent over the React Native bridge.<br/>These events happening very very fast default is 500ms.
+Sets the period at which download status events will be sent over the React Native bridge.<br/>The default is 500ms.
 
 ##### arguments
 | Name | Type | Required | Description  |
@@ -203,7 +203,7 @@ Sets the value at which download status events will be sent over the React Nativ
 
 
 ```javascript
-MapboxGL.setProgressEventThrottle(500);
+MapboxGL.offlineManager.setProgressEventThrottle(500);
 ```
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -435,6 +435,45 @@
               "description": "Center coordinate on map [lng, lat]"
             },
             {
+              "name": "padding",
+              "required": false,
+              "type": {
+                "name": "shape",
+                "value": [
+                  {
+                    "name": "paddingLeft",
+                    "required": false,
+                    "type": "number",
+                    "default": "none",
+                    "description": "Left padding in points"
+                  },
+                  {
+                    "name": "paddingRight",
+                    "required": false,
+                    "type": "number",
+                    "default": "none",
+                    "description": "Right padding in points"
+                  },
+                  {
+                    "name": "paddingTop",
+                    "required": false,
+                    "type": "number",
+                    "default": "none",
+                    "description": "Top padding in points"
+                  },
+                  {
+                    "name": "paddingBottom",
+                    "required": false,
+                    "type": "number",
+                    "default": "none",
+                    "description": "Bottom padding in points"
+                  }
+                ]
+              },
+              "default": "none",
+              "description": "Padding around edges of map in points"
+            },
+            {
               "name": "heading",
               "required": false,
               "type": "number",
@@ -483,33 +522,33 @@
                     "required": false,
                     "type": "number",
                     "default": "none",
-                    "description": "Left camera padding for bounds"
+                    "description": "Left padding in points (deprecated; use root `padding` property instead)"
                   },
                   {
                     "name": "paddingRight",
                     "required": false,
                     "type": "number",
                     "default": "none",
-                    "description": "Right camera padding for bounds"
+                    "description": "Right padding in points (deprecated; use root `padding` property instead)"
                   },
                   {
                     "name": "paddingTop",
                     "required": false,
                     "type": "number",
                     "default": "none",
-                    "description": "Top camera padding for bounds"
+                    "description": "Top padding in points (deprecated; use root `padding` property instead)"
                   },
                   {
                     "name": "paddingBottom",
                     "required": false,
                     "type": "number",
                     "default": "none",
-                    "description": "Bottom camera padding for bounds"
+                    "description": "Bottom padding in points (deprecated; use root `padding` property instead)"
                   }
                 ]
               },
               "default": "none",
-              "description": "Represents a rectangle in geographical coordinates marking the visible area of the map."
+              "description": "Represents a rectangle in geographical coordinates marking the visible area of the map.\nThe `bounds.padding*` properties are deprecated; use root `padding` property instead."
             },
             {
               "name": "onUserTrackingModeChange",
@@ -541,6 +580,45 @@
         },
         "default": "none",
         "description": "Center coordinate on map [lng, lat]"
+      },
+      {
+        "name": "padding",
+        "required": false,
+        "type": {
+          "name": "shape",
+          "value": [
+            {
+              "name": "paddingLeft",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Left padding in points"
+            },
+            {
+              "name": "paddingRight",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Right padding in points"
+            },
+            {
+              "name": "paddingTop",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Top padding in points"
+            },
+            {
+              "name": "paddingBottom",
+              "required": false,
+              "type": "number",
+              "default": "none",
+              "description": "Bottom padding in points"
+            }
+          ]
+        },
+        "default": "none",
+        "description": "Padding around edges of map in points"
       },
       {
         "name": "heading",
@@ -591,33 +669,33 @@
               "required": false,
               "type": "number",
               "default": "none",
-              "description": "Left camera padding for bounds"
+              "description": "Left padding in points (deprecated; use root `padding` property instead)"
             },
             {
               "name": "paddingRight",
               "required": false,
               "type": "number",
               "default": "none",
-              "description": "Right camera padding for bounds"
+              "description": "Right padding in points (deprecated; use root `padding` property instead)"
             },
             {
               "name": "paddingTop",
               "required": false,
               "type": "number",
               "default": "none",
-              "description": "Top camera padding for bounds"
+              "description": "Top padding in points (deprecated; use root `padding` property instead)"
             },
             {
               "name": "paddingBottom",
               "required": false,
               "type": "number",
               "default": "none",
-              "description": "Bottom camera padding for bounds"
+              "description": "Bottom padding in points (deprecated; use root `padding` property instead)"
             }
           ]
         },
         "default": "none",
-        "description": "Represents a rectangle in geographical coordinates marking the visible area of the map."
+        "description": "Represents a rectangle in geographical coordinates marking the visible area of the map.\nThe `bounds.padding*` properties are deprecated; use root `padding` property instead."
       },
       {
         "name": "onUserTrackingModeChange",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -414,7 +414,7 @@
         "required": false,
         "type": "enum",
         "default": "'easeTo'",
-        "description": "The animationstyle when the camara updates. One of; `flyTo`, `easeTo`, `linearTo`, `moveTo`"
+        "description": "The animationstyle when the camara updates. One of: `flyTo`, `easeTo`, `linearTo`, `moveTo`"
       },
       {
         "name": "defaultSettings",

--- a/example/src/examples/Camera/FitBounds.js
+++ b/example/src/examples/Camera/FitBounds.js
@@ -9,41 +9,59 @@ import TabBarPage from '../common/TabBarPage';
 class FitBounds extends React.Component {
   static propTypes = {...BaseExamplePropTypes};
 
-  houseBounds = [
-    [-74.135379, 40.795909],
-    [-74.135449, 40.795578],
-  ];
+  houseConfig = {
+    bounds: {
+      ne: [-74.135379, 40.795909],
+      sw: [-74.135449, 40.795578],
+    },
+  };
 
-  townBounds = [
-    [-74.12641, 40.797968],
-    [-74.143727, 40.772177],
-  ];
+  townConfig =  {
+    bounds: {
+      ne: [-74.12641, 40.797968],
+      sw: [-74.143727, 40.772177],
+    },
+  };
+
+  padding = {
+    paddingLeft: 40,
+    paddingRight: 40,
+    paddingTop: 40,
+    paddingBottom: 40,
+  };
 
   constructor(props) {
     super(props);
 
-    this._bounds = [
-      {label: 'Fit House', data: this.houseBounds},
-      {label: 'Fit Town', data: this.townBounds},
+    this.options = [
+      {
+        label: 'House',
+        data: this.houseConfig,
+      },
+      {
+        label: 'Town',
+        data: this.townConfig,
+      },
+      {
+        label: 'House (Padded)',
+        data: { ...this.houseConfig, padding },
+      },
+      {
+        label: 'Town (Padded)',
+        data: { ...this.townConfig, padding },
+      },
     ];
 
-    this.onFitBounds = this.onFitBounds.bind(this);
-
     this.state = {
-      bounds: {
-        ne: this.houseBounds[0],
-        sw: this.houseBounds[1],
-      },
+      ...this.houseConfig,
       animationDuration: 0,
     };
   }
 
-  onFitBounds(i, bounds) {
+  onOptionPress = (i, config) => {
     this.setState({
-      bounds: {
-        ne: bounds[0],
-        sw: bounds[1],
-      },
+      bounds: config.bounds,
+      padding: config.padding,
       animationDuration: 2000,
     });
   }
@@ -52,14 +70,15 @@ class FitBounds extends React.Component {
     return (
       <TabBarPage
         {...this.props}
-        options={this._bounds}
-        onOptionPress={this.onFitBounds}>
+        options={this.options}
+        onOptionPress={this.onOptionPress}>
         <MapboxGL.MapView
           contentInset={10}
           styleURL={MapboxGL.StyleURL.Satellite}
           style={sheet.matchParent}>
           <MapboxGL.Camera
             bounds={this.state.bounds}
+            padding={this.state.padding}
             animationDuration={this.state.animationDuration}
             maxZoomLevel={19}
           />

--- a/index.d.ts
+++ b/index.d.ts
@@ -525,17 +525,20 @@ export interface CameraProps extends CameraSettings, ViewProps {
   ) => void;
 }
 
+interface CameraPadding {
+  paddingLeft?: number;
+  paddingRight?: number;
+  paddingTop?: number;
+  paddingBottom?: number;
+}
+
 export interface CameraSettings {
   centerCoordinate?: GeoJSON.Position;
   heading?: number;
   pitch?: number;
-  bounds?: {
+  bounds?: CameraPadding & {
     ne: GeoJSON.Position;
     sw: GeoJSON.Position;
-    paddingLeft?: number;
-    paddingRight?: number;
-    paddingTop?: number;
-    paddingBottom?: number;
   };
   zoomLevel?: number;
   animationDuration?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -525,7 +525,7 @@ export interface CameraProps extends CameraSettings, ViewProps {
   ) => void;
 }
 
-interface CameraPadding {
+export interface CameraPadding {
   paddingLeft?: number;
   paddingRight?: number;
   paddingTop?: number;
@@ -536,6 +536,7 @@ export interface CameraSettings {
   centerCoordinate?: GeoJSON.Position;
   heading?: number;
   pitch?: number;
+  padding: CameraPadding;
   bounds?: CameraPadding & {
     ne: GeoJSON.Position;
     sw: GeoJSON.Position;

--- a/index.d.ts
+++ b/index.d.ts
@@ -536,7 +536,7 @@ export interface CameraSettings {
   centerCoordinate?: GeoJSON.Position;
   heading?: number;
   pitch?: number;
-  padding: CameraPadding;
+  padding?: CameraPadding;
   bounds?: CameraPadding & {
     ne: GeoJSON.Position;
     sw: GeoJSON.Position;

--- a/ios/RCTMGL/CameraStop.h
+++ b/ios/RCTMGL/CameraStop.h
@@ -19,7 +19,7 @@
 
 @property (nonatomic, assign) CLLocationCoordinate2D coordinate;
 @property (nonatomic, assign) MGLCoordinateBounds bounds;
-@property (nonatomic, assign) UIEdgeInsets boundsPadding;
+@property (nonatomic, assign) UIEdgeInsets padding;
 
 + (CameraStop*)fromDictionary:(NSDictionary*)args;
 

--- a/ios/RCTMGL/CameraStop.m
+++ b/ios/RCTMGL/CameraStop.m
@@ -49,6 +49,15 @@
         stop.heading = args[@"heading"];
     }
     
+    if (args[@"padding"]) {
+        NSDictionary * padding = args[@"padding"];
+        CGFloat paddingTop = padding[@"paddingTop"] ? [padding[@"paddingTop"] floatValue] : 0.0;
+        CGFloat paddingRight = padding[@"paddingRight"] ? [padding[@"paddingRight"] floatValue] : 0.0;
+        CGFloat paddingBottom = padding[@"paddingBottom"] ? [padding[@"paddingBottom"] floatValue] : 0.0;
+        CGFloat paddingLeft = padding[@"paddingLeft"] ? [padding[@"paddingLeft"] floatValue] : 0.0;
+        stop.padding = UIEdgeInsetsMake(paddingTop, paddingLeft, paddingBottom, paddingRight);
+    }
+    
     if (args[@"centerCoordinate"]) {
         stop.coordinate = [RCTMGLUtils fromFeature:args[@"centerCoordinate"]];
     }
@@ -63,13 +72,13 @@
     
     if (args[@"bounds"]) {
         stop.bounds = [RCTMGLUtils fromFeatureCollection:args[@"bounds"]];
-        
-        CGFloat paddingTop = args[@"boundsPaddingTop"] ? [args[@"boundsPaddingTop"] floatValue] : 0.0;
-        CGFloat paddingRight = args[@"boundsPaddingRight"] ? [args[@"boundsPaddingRight"] floatValue] : 0.0;
-        CGFloat paddingBottom = args[@"boundsPaddingBottom"] ? [args[@"boundsPaddingBottom"] floatValue] : 0.0;
-        CGFloat paddingLeft = args[@"boundsPaddingLeft"] ? [args[@"boundsPaddingLeft"] floatValue] : 0.0;
-        stop.boundsPadding = UIEdgeInsetsMake(paddingTop, paddingLeft, paddingBottom, paddingRight);
     }
+    
+    CGFloat paddingTop = args[@"paddingTop"] ? [args[@"paddingTop"] floatValue] : 0.0;
+    CGFloat paddingRight = args[@"paddingRight"] ? [args[@"paddingRight"] floatValue] : 0.0;
+    CGFloat paddingBottom = args[@"paddingBottom"] ? [args[@"paddingBottom"] floatValue] : 0.0;
+    CGFloat paddingLeft = args[@"paddingLeft"] ? [args[@"paddingLeft"] floatValue] : 0.0;
+    stop.padding = UIEdgeInsetsMake(paddingTop, paddingLeft, paddingBottom, paddingRight);
     
     NSTimeInterval duration = 2.0;
     if (args[@"duration"]) {

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -49,7 +49,6 @@ typedef void (^StyleLoadedBlock) (MGLStyle* __nonnull style);
 @property (nonatomic, assign) BOOL reactAttributionEnabled;
 @property (nonatomic, strong) NSDictionary<NSString *, NSNumber *> *reactAttributionPosition;
 @property (nonatomic, assign) BOOL reactLogoEnabled;
-@property (nonatomic, strong) NSDictionary<NSString *, NSNumber *> *reactLogoPosition;
 @property (nonatomic, assign) BOOL reactCompassEnabled;
 @property (nonatomic, assign) BOOL reactZoomEnabled;
 

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -199,61 +199,73 @@ class Camera extends React.Component {
   }
 
   _handleCameraChange(currentCamera, nextCamera) {
-    const hasCameraChanged = this._hasCameraChanged(currentCamera, nextCamera);
+    const c = currentCamera;
+    const n = nextCamera;
+
+    const hasCameraChanged = this._hasCameraChanged(c, n);
     if (!hasCameraChanged) {
       return;
     }
 
-    if (currentCamera.followUserLocation && !nextCamera.followUserLocation) {
+    if (c.followUserLocation && !n.followUserLocation) {
       this.refs.camera.setNativeProps({followUserLocation: false});
       return;
     }
-    if (!currentCamera.followUserLocation && nextCamera.followUserLocation) {
+    if (!c.followUserLocation && n.followUserLocation) {
       this.refs.camera.setNativeProps({followUserLocation: true});
     }
 
-    if (nextCamera.followUserLocation) {
+    if (n.followUserLocation) {
       this.refs.camera.setNativeProps({
-        followUserMode: nextCamera.followUserMode,
-        followPitch: nextCamera.followPitch || nextCamera.pitch,
-        followHeading: nextCamera.followHeading || nextCamera.heading,
-        followZoomLevel: nextCamera.followZoomLevel || nextCamera.zoomLevel,
+        followUserMode: n.followUserMode,
+        followPitch: n.followPitch || n.pitch,
+        followHeading: n.followHeading || n.heading,
+        followZoomLevel: n.followZoomLevel || n.zoomLevel,
       });
       return;
     }
 
-    if (nextCamera.maxBounds) {
+    if (n.maxBounds) {
       this.refs.camera.setNativeProps({
         maxBounds: this._getMaxBounds(),
       });
     }
-    if (nextCamera.minZoomLevel) {
+    if (n.minZoomLevel) {
       this.refs.camera.setNativeProps({
         minZoomLevel: this.props.minZoomLevel,
       });
     }
-    if (nextCamera.maxZoomLevel) {
+    if (n.maxZoomLevel) {
       this.refs.camera.setNativeProps({
         maxZoomLevel: this.props.maxZoomLevel,
       });
     }
 
     const cameraConfig = {
-      animationMode: nextCamera.animationMode,
-      animationDuration: nextCamera.animationDuration,
-      zoomLevel: nextCamera.zoomLevel,
-      pitch: nextCamera.pitch,
-      heading: nextCamera.heading,
-      padding: nextCamera.padding,
+      animationMode: n.animationMode,
+      animationDuration: n.animationDuration,
+      zoomLevel: n.zoomLevel,
+      pitch: n.pitch,
+      heading: n.heading,
+      padding: n.padding,
     };
 
-    if (nextCamera.bounds && this._hasBoundsChanged(currentCamera.bounds, nextCamera.bounds)) {
-      cameraConfig.bounds = nextCamera.bounds;
-    } else {
-      cameraConfig.centerCoordinate = nextCamera.centerCoordinate;
+    const boundsChanged = this._hasBoundsChanged(c.bounds, n.bounds);
+    const centerCoordinateChanged = this._hasCenterCoordinateChanged(c, n);
+    const paddingChanged = this._hasPaddingChanged(c, n);
+    
+    let shouldUpdate = false;
+    if (n.bounds && (boundsChanged || paddingChanged)) {
+      cameraConfig.bounds = n.bounds;
+      shouldUpdate = true;
+    } else if (n.centerCoordinate && (centerCoordinateChanged || paddingChanged)) {
+      cameraConfig.centerCoordinate = n.centerCoordinate;
+      shouldUpdate = true;
     }
 
-    this._setCamera(cameraConfig);
+    if (shouldUpdate) {
+      this._setCamera(cameraConfig);
+    }
   }
 
   _hasCameraChanged(currentCamera, nextCamera) {

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -81,7 +81,7 @@ class Camera extends React.Component {
     animationDuration: PropTypes.number,
 
     /**
-     * The animationstyle when the camara updates. One of; `flyTo`, `easeTo`, `linearTo`, `moveTo`
+     * The animationstyle when the camara updates. One of: `flyTo`, `easeTo`, `linearTo`, `moveTo`
      */
     animationMode: PropTypes.oneOf(['flyTo', 'easeTo', 'linearTo', 'moveTo']),
 

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -19,9 +19,24 @@ const SettingsPropTypes = {
    * Padding around edges of map in points
    */
   padding: PropTypes.shape({
+    /**
+     * Left padding in points
+     */
     paddingLeft: PropTypes.number,
+
+    /**
+     * Right padding in points
+     */
     paddingRight: PropTypes.number,
+
+    /**
+     * Top padding in points
+     */
     paddingTop: PropTypes.number,
+
+    /**
+     * Bottom padding in points
+     */
     paddingBottom: PropTypes.number,
   }),
 
@@ -51,23 +66,23 @@ const SettingsPropTypes = {
     sw: PropTypes.arrayOf(PropTypes.number).isRequired,
 
     /**
-     * Left camera padding for bounds
+     * Left padding in points (deprecated; use root `padding` property instead)
      */
     paddingLeft: PropTypes.number,
 
     /**
-     * Right camera padding for bounds
-     */
+    * Right padding in points (deprecated; use root `padding` property instead)
+    */
     paddingRight: PropTypes.number,
 
     /**
-     * Top camera padding for bounds
-     */
+    * Top padding in points (deprecated; use root `padding` property instead)
+    */
     paddingTop: PropTypes.number,
 
     /**
-     * Bottom camera padding for bounds
-     */
+    * Bottom padding in points (deprecated; use root `padding` property instead)
+    */
     paddingBottom: PropTypes.number,
   }),
 

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -247,7 +247,7 @@ class Camera extends React.Component {
       padding: nextCamera.padding,
     };
 
-    if (nextCamera.bounds) {
+    if (nextCamera.bounds && this._hasBoundsChanged(currentCamera.bounds, nextCamera.bounds)) {
       cameraConfig.bounds = nextCamera.bounds;
     } else {
       cameraConfig.centerCoordinate = nextCamera.centerCoordinate;


### PR DESCRIPTION
## Description

This adds the ability to pass padding directly to the `Camera` component, allowing padding for both `bounds` and `centerCoordinate`. For `centerCoordinate`, this enables offsetting the content of the map with animation, just as was already possible with `bounds`.

To keep the code simple but allow backward compatibility with `bounds.padding`, the fallback from `padding` to `bounds.padding` happens in the JavaScript, so the native code in both platforms only needs to look for a single set of padding values.

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I updated the documentation `yarn generate`
* [X] I mentioned this change in `CHANGELOG.md`
* [X] I updated the typings files (`index.d.ts`)
* [X] I added/ updated a sample  (`/example`)

## Screenshots

The blue box in each image represents padding, e.g.:

```
<MapboxGL.Camera
  centerCoordinate={centerPoint.coordinates}
  padding={{
    paddingTop: 100,
    paddingBottom: 450,
    paddingLeft: 250,
    paddingRight: 50,
  }}
  zoomLevel={9}
/>
```

<span>
<img src="https://user-images.githubusercontent.com/2423291/133326802-ce3c3da1-9e29-442b-9fc4-ad90d6b59487.png" width="200">
<img src="https://user-images.githubusercontent.com/2423291/133326805-60a7615d-2cf6-48cb-a4ac-f6a491b3cb61.png" width="200">
<img src="https://user-images.githubusercontent.com/2423291/133326807-c80e9ce1-8c94-40c0-b9d3-8245fcbc2752.png" width="200">
</span>