### PR TITLE
feat(shapesource): add getClusterLeaves functionality to example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -36,7 +36,7 @@
     "prop-types": "^15.7.2",
     "react": "17.0.1",
     "react-native": "0.64.2",
-    "react-native-elements": "^3.2.0",
+    "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-safe-area-context": "^3.1.9",
     "react-native-screens": "^3.0.0",

--- a/example/src/examples/SymbolCircleLayer/EarthQuakes.js
+++ b/example/src/examples/SymbolCircleLayer/EarthQuakes.js
@@ -1,5 +1,8 @@
 import React from 'react';
+import {FlatList} from 'react-native';
+import {Overlay, ListItem, FAB, Icon} from 'react-native-elements';
 import MapboxGL from '@react-native-mapbox-gl/maps';
+import moment from 'moment';
 
 import sheet from '../../styles/sheet';
 import {SF_OFFICE_COORDINATE} from '../../utils';
@@ -44,49 +47,114 @@ const layerStyles = {
   },
 };
 
+const styles = {
+  fab: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    elevation: 9999,
+    zIndex: 9999,
+  },
+};
+
 class EarthQuakes extends React.Component {
   static propTypes = {
     ...BaseExamplePropTypes,
   };
 
+  state = {
+    selectedCluster: null,
+  };
+
   render() {
     return (
-      <Page {...this.props}>
-        <MapboxGL.MapView
-          style={sheet.matchParent}
-          styleURL={MapboxGL.StyleURL.Dark}>
-          <MapboxGL.Camera
-            zoomLevel={6}
-            pitch={45}
-            centerCoordinate={SF_OFFICE_COORDINATE}
+      <>
+        <Overlay isVisible={!!this.state.selectedCluster} fullScreen>
+          <FAB
+            onPress={() => {
+              this.setState({selectedCluster: null});
+            }}
+            icon={<Icon name="close" />}
+            size="large"
+            style={styles.fab}
           />
+          {this.state.selectedCluster && (
+            <FlatList
+              keyExtractor={({properties: earthquakeInfo}) => {
+                return earthquakeInfo.code;
+              }}
+              data={this.state.selectedCluster.features}
+              renderItem={({item: {properties: earthquakeInfo}}) => {
+                const magnitude = `Magnitude: ${earthquakeInfo.mag}`;
+                const place = `Place: ${earthquakeInfo.place}`;
+                const code = `Code: ${earthquakeInfo.code}`;
+                const time = `Time: ${moment(earthquakeInfo.time).format(
+                  'MMMM Do YYYY, h:mm:ss a',
+                )}`;
 
-          <MapboxGL.ShapeSource
-            id="earthquakes"
-            cluster
-            clusterRadius={50}
-            clusterMaxZoom={14}
-            url="https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson">
-            <MapboxGL.SymbolLayer
-              id="pointCount"
-              style={layerStyles.clusterCount}
+                return (
+                  <ListItem bottomDivider>
+                    <ListItem.Content>
+                      <ListItem.Title>{earthquakeInfo.title}</ListItem.Title>
+                      <ListItem.Subtitle>{magnitude}</ListItem.Subtitle>
+                      <ListItem.Subtitle>{place}</ListItem.Subtitle>
+                      <ListItem.Subtitle>{code}</ListItem.Subtitle>
+                      <ListItem.Subtitle>{time}</ListItem.Subtitle>
+                    </ListItem.Content>
+                  </ListItem>
+                );
+              }}
+            />
+          )}
+        </Overlay>
+        <Page {...this.props}>
+          <MapboxGL.MapView
+            style={sheet.matchParent}
+            styleURL={MapboxGL.StyleURL.Dark}>
+            <MapboxGL.Camera
+              zoomLevel={6}
+              pitch={45}
+              centerCoordinate={SF_OFFICE_COORDINATE}
             />
 
-            <MapboxGL.CircleLayer
-              id="clusteredPoints"
-              belowLayerID="pointCount"
-              filter={['has', 'point_count']}
-              style={layerStyles.clusteredPoints}
-            />
+            <MapboxGL.ShapeSource
+              id="earthquakes"
+              onPress={async shape => {
+                const cluster = shape.features[0];
+                const collection = await this.shape.getClusterLeaves(
+                  cluster,
+                  999,
+                  0,
+                );
 
-            <MapboxGL.CircleLayer
-              id="singlePoint"
-              filter={['!', ['has', 'point_count']]}
-              style={layerStyles.singlePoint}
-            />
-          </MapboxGL.ShapeSource>
-        </MapboxGL.MapView>
-      </Page>
+                this.setState({selectedCluster: collection});
+              }}
+              ref={shape => (this.shape = shape)}
+              cluster
+              clusterRadius={50}
+              clusterMaxZoom={14}
+              url="https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson">
+              <MapboxGL.SymbolLayer
+                id="pointCount"
+                style={layerStyles.clusterCount}
+              />
+
+              <MapboxGL.CircleLayer
+                id="clusteredPoints"
+                belowLayerID="pointCount"
+                filter={['has', 'point_count']}
+                style={layerStyles.clusteredPoints}
+              />
+
+              <MapboxGL.CircleLayer
+                id="singlePoint"
+                filter={['!', ['has', 'point_count']]}
+                style={layerStyles.singlePoint}
+              />
+            </MapboxGL.ShapeSource>
+          </MapboxGL.MapView>
+        </Page>
+      </>
     );
   }
 }


### PR DESCRIPTION
## Description
Adds `getCluserLeaves` functionality to our `Clustering Earthquakes` example.  
Questions about using this feature came up quite often, so there you go, now we have a usecase to point to.

* open example app
* select `Symbol/CirleLayer`
* select `Clustering Earthquakes`
* press on any earthquake cuslter
* observer the rendered Overlay with a list of useful informations about the individual earthquakes within the cluster