### PR TITLE
build(android): add telemetry dependency to default build setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ PR Title ([#123](link to my pr))
 Update ShapeSource methods to make it usable with any cluster ( Use cluster itself instead of cluster_id as first argument for getClusterExpansionZoom/getClusterLeaves/getClusterChildren methods. Version < 9 methods still supports passing cluster_id as a first argument but a deprecation warning will be shown. ) ([#1499](https://github.com/react-native-mapbox-gl/maps/pull/1499))
 ```
 
+build(android): add telemetry dependency to default build setup ([#1550](https://github.com/react-native-mapbox-gl/maps/pull/1550))  
 fix: revert pinned mapLibre version to `5.11.0` ([8a2b00e67ba6398f3f6e6f52e98b0f0cea437e4d](https://github.com/react-native-mapbox-gl/maps/commit/8a2b00e67ba6398f3f6e6f52e98b0f0cea437e4d))
 
 ---

--- a/android/install.md
+++ b/android/install.md
@@ -1,22 +1,8 @@
 # Android Installation
 
-## React-Native > `0.60.0` 
+## React-Native > `0.60.0`
+
 If you are using autolinking feature introduced in React-Native `0.60.0` you do not need any additional steps.
-
-Notice, that if you're using the default Mapbox Android SDK (which is packed in with this lib)  
-and are on newer Android OS version (API 30+),  
-you'll encounter [`Fatal Exception: java.lang.SecurityException: getDataNetworkTypeForSubscriber`](https://github.com/react-native-mapbox-gl/maps/issues/1286).
-
-Either update the Mapbox Android SDK as described below in the [`Mapbox Maps SDK`](https://github.com/react-native-mapbox-gl/maps/blob/master/android/install.md#mapbox-maps-sdk) section,   
-_OR_ add the following line to your `android/app/build.gradle` to pull in the missing dependency.
-
-```
-dependencies {
-    // ...
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-telemetry:6.1.0'
-    // ...
-}
-```
 
 <br>
 
@@ -24,10 +10,10 @@ dependencies {
 
 It is possible to set a custom version of the Mapbox SDK
 
-
-Add the following to your  `android/build.gradle`:
+Add the following to your `android/build.gradle`:
 
 under section `allprojects/repositories`
+
 ```groovy
         maven {
             url 'https://api.mapbox.com/downloads/v2/releases/maven'
@@ -36,7 +22,7 @@ under section `allprojects/repositories`
             }
             credentials {
                 // Do not change the username below.
-                // This should always be `mapbox` (not your username). 
+                // This should always be `mapbox` (not your username).
                 username = 'mapbox'
                 // Use the secret token you stored in gradle.properties as the password
                 password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ""
@@ -48,7 +34,7 @@ Overwrite mapbox dependencies within your `android/app/build.gradle`:
 
 ```groovy
 dependencies {
-    // ... 
+    // ...
     implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.1'
     implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:5.6.0'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0'
@@ -56,7 +42,6 @@ dependencies {
 ```
 
 Check the current version of the SDK [here](https://docs.mapbox.com/android/maps/guides/).
-
 
 If you are using newer versions of the SDK, you will need to authorize your download of the Maps SDK via a secret access token with the `DOWNLOADS:READ` scope.  
 This [guide](https://docs.mapbox.com/android/maps/guides/install/#configure-credentials) explains how to configure the secret token under section `Configure your secret token`.

--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     customizableDependencies('rnmbglMapboxLibs') {
         implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:5.1.0'
         implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.1.0'
+        implementation 'com.mapbox.mapboxsdk:mapbox-android-telemetry:6.1.0'
         implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
     }
 


### PR DESCRIPTION
## Description
As mentioned in
https://github.com/react-native-mapbox-gl/maps/pull/1376
https://github.com/react-native-mapbox-gl/maps/issues/1286
the missing dependency is leading to more and more headaches,  
especially for Expo user who can not change them manually.

Therefore - adding it to the default setup

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I mentioned this change in `CHANGELOG.md`
