### PR TITLE
Expo android permissions

### DIFF
--- a/plugin/install.md
+++ b/plugin/install.md
@@ -18,6 +18,19 @@ After installing this npm package, add the [config plugin](https://docs.expo.io/
 }
 ```
 
+Then, in your `app.json` change your android permissions to include `READ_PHONE_STATE`:
+```
+{
+    expo:{
+    ...
+     "android": {
+      "permissions": ["READ_PHONE_STATE"],
+      ...
+      },
+    }
+}
+```
+
 Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
 
 ## API


### PR DESCRIPTION
Does not run on android without adding READ_PHONE_STATE to android permissions. See here: https://github.com/react-native-mapbox-gl/maps/issues/1286#

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description
Update expo install readme to include adding READ_PHONE_STATE in `app.json`
Fixes #1286

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I formatted JS and TS files with `yarn lint`
- [ ] I updated the documentation `yarn generate`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)
