### PR TITLE
fix: EventEmitter warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ build(turf): update to version 6.5.0 ([#1638](https://github.com/react-native-ma
 ci: two scripts for linting with and without fix ([#1630](https://github.com/react-native-mapbox-gl/maps/pull/1630))  
 feat(Camera) add an optional `allowUpdates` boolean prop ([#1619](https://github.com/react-native-mapbox-gl/maps/pull/1619))  
 refactor(example): remove unused modules and scripts ([#1618](https://github.com/react-native-mapbox-gl/maps/pull/1618))  
+fix(react-native): update api to get rid of EventEmitter warnings ([#1615](https://github.com/react-native-mapbox-gl/maps/pull/1615))   
 fix(Camera) persist zoom when changing from `bounds` to `centerCoordinate`, fix zero padding not causing map to update, create unified example showcasing bounds/centerCoordinate/zoom/padding ([#1614](https://github.com/react-native-mapbox-gl/maps/pull/1614))  
 Update MapLibre to 5.12.1 on iOS ([#1596](https://github.com/react-native-mapbox-gl/maps/pull/1596))  
 Update ShapeSource methods to make it usable with any cluster ( Use cluster itself instead of cluster_id as first argument for getClusterExpansionZoom/getClusterLeaves/getClusterChildren methods. Version < 9 methods still supports passing cluster_id as a first argument but a deprecation warning will be shown. ) ([#1499](https://github.com/react-native-mapbox-gl/maps/pull/1499))  

--- a/__tests__/__mocks__/react-native.mock.js
+++ b/__tests__/__mocks__/react-native.mock.js
@@ -5,6 +5,5 @@ jest.mock('react-native/Libraries/Image/resolveAssetSource', () => {
 jest.mock('NativeEventEmitter', () => {
   function MockEventEmitter() {}
   MockEventEmitter.prototype.addListener = jest.fn(() => ({remove: jest.fn()}));
-  MockEventEmitter.prototype.removeListener = jest.fn();
   return MockEventEmitter;
 });

--- a/__tests__/modules/location/locationManager.test.js
+++ b/__tests__/modules/location/locationManager.test.js
@@ -198,8 +198,6 @@ describe('LocationManager', () => {
 
         // native location manager has no #stop exposed in tests?
         MapboxGLLocationManager.stop = jest.fn();
-        jest.spyOn(LocationModuleEventEmitter, 'removeListener');
-
         MapboxGL.LocationCallbackName = {Update: 'MapboxUserLocationUpdate'};
 
         expect(locationManager._isListening).toStrictEqual(true);
@@ -207,10 +205,7 @@ describe('LocationManager', () => {
         locationManager.stop();
 
         expect(MapboxGLLocationManager.stop).toHaveBeenCalledTimes(1);
-        expect(LocationModuleEventEmitter.removeListener).toHaveBeenCalledWith(
-          MapboxGL.LocationCallbackName.Update,
-          locationManager.onUpdate,
-        );
+        expect(locationManager.subscription.remove).toHaveBeenCalled();
 
         expect(locationManager._isListening).toStrictEqual(false);
       });
@@ -221,8 +216,6 @@ describe('LocationManager', () => {
 
         // native location manager has no #stop exposed in tests?
         MapboxGLLocationManager.stop = jest.fn();
-        jest.spyOn(LocationModuleEventEmitter, 'removeListener');
-
         MapboxGL.LocationCallbackName = {Update: 'MapboxUserLocationUpdate'};
 
         expect(locationManager._isListening).toStrictEqual(false);
@@ -230,9 +223,7 @@ describe('LocationManager', () => {
         locationManager.stop();
 
         expect(MapboxGLLocationManager.stop).toHaveBeenCalledTimes(1);
-        expect(
-          LocationModuleEventEmitter.removeListener,
-        ).not.toHaveBeenCalled();
+        expect(locationManager.subscription.remove).not.toHaveBeenCalled();
       });
     });
 

--- a/__tests__/modules/offline/offlineManager.test.js
+++ b/__tests__/modules/offline/offlineManager.test.js
@@ -94,7 +94,7 @@ describe('offlineManager', () => {
       const noop = () => {};
       await MapboxGL.offlineManager.createPack(packOptions, noop, noop);
       expect(spy).toHaveBeenCalledTimes(2);
-      spy.mockRestore();
+      spy.mockClear();
     });
 
     it('should call progress listener', async () => {
@@ -133,12 +133,17 @@ describe('offlineManager', () => {
     });
 
     it('should unsubscribe from native events', async () => {
-      const spy = jest.spyOn(OfflineModuleEventEmitter, 'removeListener');
       const noop = () => {};
+
       await MapboxGL.offlineManager.createPack(packOptions, noop, noop);
       MapboxGL.offlineManager.unsubscribe(packOptions.name);
-      expect(spy).toHaveBeenCalledTimes(2);
-      spy.mockRestore();
+
+      expect(
+        MapboxGL.offlineManager.subscriptionProgress.remove,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        MapboxGL.offlineManager.subscriptionError.remove,
+      ).toHaveBeenCalledTimes(1);
     });
 
     it('should unsubscribe event listeners once a pack download has completed', async () => {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLocationModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLocationModule.java
@@ -122,6 +122,16 @@ public class RCTMGLLocationModule extends ReactContextBaseJavaModule {
         );
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Set up any upstream listeners or background tasks as necessary
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Remove upstream listeners, stop unnecessary background tasks
+    }
+
     private void startLocationManager() {
         locationManager.addLocationListener(onUserLocationChangeCallback);
         locationManager.setMinDisplacement(mMinDisplacement);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLogging.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLLogging.java
@@ -116,6 +116,16 @@ public class RCTMGLLogging extends ReactContextBaseJavaModule {
         Logger.setVerbosity(logLevel);
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Set up any upstream listeners or background tasks as necessary
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Remove upstream listeners, stop unnecessary background tasks
+    }
+
     public void onLog(String level, String tag, String msg, Throwable tr) {
         WritableMap event = Arguments.createMap();
         event.putString("message", msg);

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.java
@@ -72,6 +72,16 @@ public class RCTMGLOfflineModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void addListener(String eventName) {
+        // Set up any upstream listeners or background tasks as necessary
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Remove upstream listeners, stop unnecessary background tasks
+    }
+
+    @ReactMethod
     public void createPack(ReadableMap options, final Promise promise) {
         final String name = ConvertUtils.getString("name", options, "");
         final OfflineManager offlineManager = OfflineManager.getInstance(mReactContext);

--- a/javascript/modules/location/locationManager.js
+++ b/javascript/modules/location/locationManager.js
@@ -13,6 +13,7 @@ class LocationManager {
     this._lastKnownLocation = null;
     this._isListening = false;
     this.onUpdate = this.onUpdate.bind(this);
+    this.subscription = null;
   }
 
   async getLastKnownLocation() {
@@ -67,7 +68,7 @@ class LocationManager {
     if (!this._isListening) {
       MapboxGLLocationManager.start(displacement);
 
-      LocationModuleEventEmitter.addListener(
+      this.subscription = LocationModuleEventEmitter.addListener(
         MapboxGL.LocationCallbackName.Update,
         this.onUpdate,
       );
@@ -80,10 +81,7 @@ class LocationManager {
     MapboxGLLocationManager.stop();
 
     if (this._isListening) {
-      LocationModuleEventEmitter.removeListener(
-        MapboxGL.LocationCallbackName.Update,
-        this.onUpdate,
-      );
+      this.subscription.remove();
     }
 
     this._isListening = false;

--- a/javascript/modules/offline/offlineManager.js
+++ b/javascript/modules/offline/offlineManager.js
@@ -26,6 +26,9 @@ class OfflineManager {
 
     this._onProgress = this._onProgress.bind(this);
     this._onError = this._onError.bind(this);
+
+    this.subscriptionProgress = null;
+    this.subscriptionError = null;
   }
 
   /**
@@ -261,7 +264,7 @@ class OfflineManager {
     const totalProgressListeners = Object.keys(this._progressListeners).length;
     if (isFunction(progressListener)) {
       if (totalProgressListeners === 0) {
-        OfflineModuleEventEmitter.addListener(
+        this.subscriptionProgress = OfflineModuleEventEmitter.addListener(
           MapboxGL.OfflineCallbackName.Progress,
           this._onProgress,
         );
@@ -272,7 +275,7 @@ class OfflineManager {
     const totalErrorListeners = Object.keys(this._errorListeners).length;
     if (isFunction(errorListener)) {
       if (totalErrorListeners === 0) {
-        OfflineModuleEventEmitter.addListener(
+        this.subscriptionError = OfflineModuleEventEmitter.addListener(
           MapboxGL.OfflineCallbackName.Error,
           this._onError,
         );
@@ -306,18 +309,18 @@ class OfflineManager {
     delete this._progressListeners[packName];
     delete this._errorListeners[packName];
 
-    if (Object.keys(this._progressListeners).length === 0) {
-      OfflineModuleEventEmitter.removeListener(
-        MapboxGL.OfflineCallbackName.Progress,
-        this._onProgress,
-      );
+    if (
+      Object.keys(this._progressListeners).length === 0 &&
+      this.subscriptionProgress
+    ) {
+      this.subscriptionProgress.remove();
     }
 
-    if (Object.keys(this._errorListeners).length === 0) {
-      OfflineModuleEventEmitter.removeListener(
-        MapboxGL.OfflineCallbackName.Error,
-        this._onError,
-      );
+    if (
+      Object.keys(this._errorListeners).length === 0 &&
+      this.subscriptionError
+    ) {
+      this.subscriptionError.remove();
     }
   }
 


### PR DESCRIPTION
## Description
Native `EventEmitters` api seems to have slightly changed. 
They expect a `addListener` `removeListener` method on the native modules. 

Would be showing warning messages like these:
`'new NativeEventEmitter() was called with a non-null argument without the required addListener method.'`

See: https://github.com/facebook/react-native/commit/114be1d2170bae2d29da749c07b45acf931e51e2

<br>

Additionally, `EventEmitter.js` itself does change `removeListener` => just `remove`, which is called on the return value of `addListener`. 
I've changed the code accordingly.

Would be showing warning messages like these:
`EventEmitter.removeListener(): Method has been deprecated. Please instead use remove() on the subscription returned by EventEmitter.addListener.`



What I didn't do where extensive test on those components/ files. 
I've did some simple playing around within the `example` app - would appreciate some full fledged tests with this PR though 

Fixes #1594
## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I formatted JS and TS files with `yarn lint`
- [x] I mentioned this change in `CHANGELOG.md`