### PR TITLE
build(deps-dev): bump eslint-plugin-import from 2.23.4 to 2.25.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint": "^7.32.0 ",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-fp": "^2.3.0",
-    "eslint-plugin-import": "2.23.4",
+    "eslint-plugin-import": "2.25.2",
     "expo-module-scripts": "^2.0.0",
     "husky": "4.3.8",
     "jest": "25.5.4",


### PR DESCRIPTION
##  ⚠️  BLOCKED
=> this PR has to be merged first https://github.com/react-native-mapbox-gl/maps/pull/1638

----

Bumps [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import) from 2.23.4 to 2.25.2.
- [Release notes](https://github.com/import-js/eslint-plugin-import/releases)
- [Changelog](https://github.com/import-js/eslint-plugin-import/blob/main/CHANGELOG.md)
- [Commits](https://github.com/import-js/eslint-plugin-import/compare/v2.23.4...v2.25.2)

---
updated-dependencies:
- dependency-name: eslint-plugin-import
  dependency-type: direct:development
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

