### PR TITLE
fix: correct transition style value

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleValue.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/styles/RCTMGLStyleValue.java
@@ -204,7 +204,7 @@ public class RCTMGLStyleValue {
             duration = config.getMap("duration").getInt("value");
         }
         if (config.hasKey("delay") && ReadableType.Map.equals(config.getType("delay"))) {
-            duration = config.getMap("delay").getInt("value");
+            delay = config.getMap("delay").getInt("value");
         }
 
         return new TransitionOptions(duration, delay, enablePlacementTransitions);

--- a/example/src/examples/BugReportExample.js
+++ b/example/src/examples/BugReportExample.js
@@ -11,7 +11,7 @@ import {
 const styles = {
   mapView: {flex: 1},
   circleLayer: {
-    circleRadiusTransition: {duration: 5000},
+    circleRadiusTransition: {duration: 5000, delay: 0},
     circleColor: '#ff0000',
   },
 };


### PR DESCRIPTION
## Description
Fixes a bug when setting transition-related style. (`duration` is always overwritten by `delay` value)

You can reproduce this using bug-report example.

## Checklist
* [x]  I have run local test cases via `yarn run unittest` (sneaky edit)
* [x]  I have tested this on a device/simulator for each compatible OS
* [x]  I formatted JS and TS files with running `yarn lint:fix` in the root folder
* [x]  I updated the documentation with running `yarn generate` in the root folder
* [ ]  I mentioned this change in `CHANGELOG.md`
* [ ]  (n/a) I updated the typings files (`index.d.ts`)
* [x]  I added/ updated a sample (`/example`)
 
## Video

Android (no animation)

https://user-images.githubusercontent.com/42024893/143579516-5531d406-f8a5-4ea3-a9d8-98176301260a.mp4

iOS (with animation)

https://user-images.githubusercontent.com/42024893/143580769-d3865954-5641-4fef-8ccc-7d37b6ab68e8.mp4



