### PR TITLE
fix(build):allow running example on M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
 
-docs(example): I am an example CHANGELOG, replace me!
+fix(example): update `/example` project (iOS only) to work with ARM-based Macs ([#1703](https://github.com/react-native-mapbox-gl/maps/pull/1703))
 
 ---
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -60,6 +60,11 @@ target 'RNMapboxGLExample' do
     # local configuration
     use_flipper!()
     post_install do |installer|
+      installer.pods_project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings["ONLY_ACTIVE_ARCH"] = "NO"
+        end
+      end
       react_native_post_install(installer)
       __apply_Xcode_12_5_M1_post_install_workaround(installer)
       $RNMBGL.post_install(installer)

--- a/example/ios/RNMapboxGLExample/AppDelegate.m
+++ b/example/ios/RNMapboxGLExample/AppDelegate.m
@@ -59,7 +59,7 @@ static void InitializeFlipper(UIApplication *application) {
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
-#ifdef FB_SONARKIT_ENABLED
+#ifdef DEBUG
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];


### PR DESCRIPTION
## Description

Changes build configurations to allow the `example` project to build on M1 Macs.

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [ ] (n/a) I updated the documentation with running `yarn generate` in the root folder
- [x] I mentioned this change in `CHANGELOG.md`
- [ ] (n/a) I updated the typings files (`index.d.ts`)
- [ ] (n/a) I added/ updated a sample (`/example`)