### PR TITLE
fix: add TypeScript type for MapViews's preferredFramesPerSecond prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
 
+fix: add TypeScript type for MapViews's preferredFramesPerSecond prop ([#1717](https://github.com/react-native-mapbox-gl/maps/pull/1717))
 fix(example): update `/example` project (iOS only) to work with ARM-based Macs ([#1703](https://github.com/react-native-mapbox-gl/maps/pull/1703))
 
 ---

--- a/index.d.ts
+++ b/index.d.ts
@@ -458,6 +458,7 @@ export interface MapViewProps extends ViewProps {
   style?: StyleProp<ViewStyle>;
   styleURL?: string;
   styleJSON?: string;
+  preferredFramesPerSecond?: number;
   localizeLabels?: boolean;
   zoomEnabled?: boolean;
   scrollEnabled?: boolean;


### PR DESCRIPTION
## Description

Hey,

I noticed there is no TypeScript typing for MapViews's preferredFramesPerSecond prop. TypeScript is giving me errors. This PR fixes the problem.

Cheers!

## Checklist

<!-- Check completed item: [X] -->

- [x] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typings files (`index.d.ts`)
